### PR TITLE
[KO-133] 함께 볼 만한 뉴스/게시글 api & TOP5 뉴스 api 연결

### DIFF
--- a/src/app/(with-side)/[type]/[id]/page.tsx
+++ b/src/app/(with-side)/[type]/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { notFound } from 'next/navigation';
 
-import { mockNewsList } from '@/lib/mock';
 import ComponentFrame from '@/components/common/componentFrame';
 import RecommendedContent from '@/components/common/recommendedContent';
 import DetailContent from '@/components/features/detail/content/DetailContent';
@@ -53,7 +52,7 @@ const DetailPage = async ({ params }: { params?: { type?: string; id?: string } 
 				)}
 			</ComponentFrame>
 
-			<RecommendedContent mode="뉴스" data={mockNewsList} teamName="FC 서울" />
+			<RecommendedContent mode="뉴스" teamName="FC 서울" />
 		</div>
 	);
 };

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import RecommendedContent from '@/components/common/recommendedContent';
 import PredictCard from '@/components/features/home/predict-card';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { getUserInfo } from '@/services/auth';
@@ -41,6 +42,8 @@ export default function Home() {
 				<PredictCard status="fail" />
 				<PredictCard status="unparticipated" />
 			</div>
+			<RecommendedContent mode={'뉴스'} />
+			<RecommendedContent mode={'게시글'} />
 		</div>
 	);
 }

--- a/src/components/common/category-tab/community-item.tsx
+++ b/src/components/common/category-tab/community-item.tsx
@@ -1,22 +1,31 @@
+import { formatStringToDate } from '@/lib/utils/formatStringToDate';
+import { BoardItemDto } from '@/services/apis/news/dto';
 import Image from 'next/image';
+import Link from 'next/link';
 
-export default function CommunityItem({ title, hasImage, comment, nickname, createdAt, views, kick }) {
+export default function CommunityItem({ pk, title, replies, user, createdAt, views, likes }: BoardItemDto) {
 	return (
-		<div className="p-4 flex justify-between cursor-pointer">
+		<Link href={`/board/${pk}`} className="p-4 flex justify-between cursor-pointer">
 			<div className="flex gap-1 items-center">
 				<h2 className="subtitle1-medium max-w-3xs truncate">{title}</h2>
-				{hasImage && <Image width={14} height={14} src="/image.svg" alt="사진" />}
-				<div className="body5-regular">({comment})</div>
+				{/* {hasImage && <Image width={14} height={14} src="/image.svg" alt="사진" />} */}
+				<div className="body5-regular">{!!replies && `(${replies})`}</div>
 			</div>
 			<div className="flex gap-4 body6-regular text-black-600 items-center">
 				<div className="flex gap-2 text-black-900">
-					<Image width={18} height={18} src="/default-profile.svg" alt="프로필 사진" />
-					<div className="w-[5.625rem]">{nickname}</div>
+					<Image
+						width={18}
+						height={18}
+						className="rounded-full w-[1.125rem] h-[1.125rem] object-cover"
+						src={user.profileImageUrl}
+						alt={`${user.nickname} 프로필 사진`}
+					/>
+					<div className="w-[5.625rem]">{user.nickname}</div>
 				</div>
-				<div className="w-[4.0625rem] text-center">{createdAt}</div>
+				<div className="w-[4.0625rem] text-center">{formatStringToDate(createdAt)}</div>
 				<div className="w-[2.625rem] text-center">{views}</div>
-				<div className="w-[2.6875rem] text-center">{kick}</div>
+				<div className="w-[2.6875rem] text-center">{likes}</div>
 			</div>
-		</div>
+		</Link>
 	);
 }

--- a/src/components/common/category-tab/news-item.tsx
+++ b/src/components/common/category-tab/news-item.tsx
@@ -1,59 +1,76 @@
+import { getTimeAgo } from '@/lib/utils/getTimeAgo';
+import { NewsItemDto } from '@/services/apis/news/dto';
 import Image from 'next/image';
+import Link from 'next/link';
 
 export default function NewsItem({
-	teamLogo,
-	team,
-	tag,
+	pk,
 	title,
 	content,
-	nickname,
-	isCertified,
-	timeAgo,
+	user,
+	category,
+	thumbnailUrl,
+	createdAt,
 	views,
-	kick,
-	comment,
+	likes,
+	replies,
 	isMyTeam = false,
-}) {
+}: NewsItemDto & { isMyTeam?: boolean }) {
+	// TODO: 서버 응답 수정에 따라 팀 로고 src/alt 수정, 인증 뱃지 추가가
 	return (
-		<article className="flex flex-col py-6 px-4 cursor-pointer">
-			<header className="flex gap-2 mb-2.5 items-center">
-				{!isMyTeam && <Image width={24} height={24} src={teamLogo} alt={team} />}
-				<div className="h-5 px-2.5 py-0.5 rounded-full bg-black-200 text-black-800 caption1-medium">{tag}</div>
-			</header>
+		<Link href={`news/${pk}`}>
+			<article className="flex flex-col py-6 px-4 cursor-pointer">
+				<header className="flex gap-2 mb-2.5 items-center">
+					{!isMyTeam && <Image width={24} height={24} src={'/team-logo/arsenal.svg'} alt={'팀 로고'} />}
+					<div className="h-5 px-2.5 py-0.5 rounded-full bg-black-200 text-black-800 caption1-medium">{category}</div>
+				</header>
 
-			<section className="flex justify-between">
-				<div className="w-[28rem]">
-					<h2 className="title3-semibold mb-2">{title.length > 33 ? `${title.substring(0, 33)}...` : title}</h2>
-					<p className="subtitle2-regular mb-[1.125rem] ">
-						{content.length > 120 ? `${content.substring(0, 117)}...` : content}
-					</p>
-				</div>
-				<div className="w-40 h-[6.5rem] rounded-lg bg-black-200 my-auto">기사 사진</div>
-			</section>
+				<section className="flex justify-between">
+					<div className="w-[28rem]">
+						<h2 className="title3-semibold mb-2">{title.length > 33 ? `${title.substring(0, 33)}...` : title}</h2>
+						<p className="subtitle2-regular mb-[1.125rem] ">
+							{content.length > 120 ? `${content.substring(0, 117)}...` : content}
+						</p>
+					</div>
+					<Image
+						width={160}
+						height={104}
+						src={thumbnailUrl}
+						alt="기사 썸네일 사진"
+						className="w-40 h-[6.5rem] rounded-lg my-auto object-cover"
+					/>
+				</section>
 
-			<footer className="flex flex-col w-full text-black-600 body6-regular">
-				<div className="flex items-center gap-2">
-					<Image src="/default-profile.svg" alt="작성자 프로필" width={24} height={24} className="rounded-full" />
-					<span className="flex gap-1.5 text-black-900">
-						{nickname}
-						{isCertified && <Image width={12} height={12} src="/certification-mark.svg" alt="인증" />}
-					</span>
-					<span className="ml-2">{timeAgo}</span>
-					<div>|</div>
-					<span>읽음 {views}</span>
-				</div>
+				<footer className="flex flex-col w-full text-black-600 body6-regular">
+					<div className="flex items-center gap-2">
+						<Image
+							src={user.profileImageUrl}
+							alt={`${user.nickname} 프로필 사진`}
+							width={24}
+							height={24}
+							className="w-6 h-6 rounded-full object-cover"
+						/>
+						<span className="flex gap-1.5 text-black-900">
+							{user.nickname}
+							{/* {isCertified && <Image width={12} height={12} src="/certification-mark.svg" alt="인증" />} */}
+						</span>
+						<span className="ml-2">{getTimeAgo(createdAt)}</span>
+						<div>|</div>
+						<span>읽음 {views}</span>
+					</div>
 
-				<div className="flex justify-end items-center gap-3">
-					<span className="flex items-center gap-1.5">
-						<Image width={18} height={18} src="/kick/gray.svg" alt="킥" />
-						<span>{kick}</span>
-					</span>
-					<span className="flex items-center gap-1.5">
-						<Image width={18} height={18} src="/comment.svg" alt="댓글" />
-						<span>{comment}</span>
-					</span>
-				</div>
-			</footer>
-		</article>
+					<div className="flex justify-end items-center gap-3">
+						<span className="flex items-center gap-1.5">
+							<Image width={18} height={18} src="/kick/gray.svg" alt="킥" />
+							<span>{likes}</span>
+						</span>
+						<span className="flex items-center gap-1.5">
+							<Image width={18} height={18} src="/comment.svg" alt="댓글" />
+							<span>{replies}</span>
+						</span>
+					</div>
+				</footer>
+			</article>
+		</Link>
 	);
 }

--- a/src/components/common/fetching-failed-card.tsx
+++ b/src/components/common/fetching-failed-card.tsx
@@ -7,7 +7,7 @@ export default function FetchingFailedCard({
 }: {
 	height: string;
 	marginTop: string;
-	onClick: () => void;
+	onClick?: () => void;
 }) {
 	return (
 		<div className="flex flex-col items-center" style={{ height }}>

--- a/src/components/common/recommendedContent.tsx
+++ b/src/components/common/recommendedContent.tsx
@@ -7,15 +7,22 @@ import NewsItem from './category-tab/news-item';
 import ComponentFrame from './componentFrame';
 import clsx from 'clsx';
 import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { RecommendedNewsDto } from '@/services/apis/news/dto';
+import { RecommendedBoardDto } from '@/services/apis/board/dto';
+import { getRecommendedNews } from '@/services/apis/news/getRecommendedNews';
+import { getRecommendedBoards } from '@/services/apis/board/getRecommendedBoards';
+import FetchingFailedCard from './fetching-failed-card';
 
-const RecommendedContent = ({ mode, data, teamName = '' }) => {
+const RecommendedContent = ({ mode, teamName = '' }) => {
 	const pathname = usePathname();
+	const [data, setData] = useState<RecommendedNewsDto[] | RecommendedBoardDto[] | null>(null);
 
 	const isMyTeam = Boolean(teamName);
 	const isNews = mode === '뉴스';
-
-	const itemsToRender = isNews ? data.slice(0, 3) : data.slice(0, 10);
+	const isHome = pathname === '/';
 	const Component = isNews ? NewsItem : CommunityItem;
+
 	const displayTitle =
 		pathname === '/' && mode === '게시글' ? (
 			'클럽 커뮤니티'
@@ -25,6 +32,23 @@ const RecommendedContent = ({ mode, data, teamName = '' }) => {
 				{mode}
 			</>
 		);
+
+	useEffect(() => {
+		const getDatas = async () => {
+			const response = isNews
+				? await getRecommendedNews({ type: isHome ? 'all' : undefined })
+				: await getRecommendedBoards();
+
+			if (!response) {
+				setData(null);
+			} else {
+				setData(response.data);
+				console.log(response.data);
+			}
+		};
+
+		getDatas();
+	}, [isHome, isNews, isMyTeam]);
 
 	return (
 		<ComponentFrame isMain={true}>
@@ -44,12 +68,20 @@ const RecommendedContent = ({ mode, data, teamName = '' }) => {
 			{!isNews && <CommunityDivisionBar />}
 
 			<div className="flex flex-col">
-				{itemsToRender.map((item, index) => (
-					<div key={item.id}>
-						<Component {...item} isMyTeam={isMyTeam} />
-						{index !== itemsToRender.length - 1 && <hr className="border-black-300 mx-4" />}
-					</div>
-				))}
+				{!data ? (
+					<FetchingFailedCard
+						onClick={() => {}}
+						height={isNews ? '45.375rem' : '35.125rem'}
+						marginTop={isNews ? '14.4375rem' : '10.25rem'}
+					/>
+				) : (
+					data.map((item, index) => (
+						<div key={item.id}>
+							<Component {...item} isMyTeam={isMyTeam} />
+							{index !== data.length - 1 && <hr className="border-black-300 mx-4" />}
+						</div>
+					))
+				)}
 			</div>
 		</ComponentFrame>
 	);

--- a/src/components/common/recommendedContent.tsx
+++ b/src/components/common/recommendedContent.tsx
@@ -13,6 +13,7 @@ import { RecommendedBoardDto } from '@/services/apis/board/dto';
 import { getRecommendedNews } from '@/services/apis/news/getRecommendedNews';
 import { getRecommendedBoards } from '@/services/apis/board/getRecommendedBoards';
 import FetchingFailedCard from './fetching-failed-card';
+import Link from 'next/link';
 
 const RecommendedContent = ({ mode, teamName = '' }) => {
 	const pathname = usePathname();
@@ -59,10 +60,14 @@ const RecommendedContent = ({ mode, teamName = '' }) => {
 			>
 				<h3 className="title4-semibold">{displayTitle}</h3>
 
-				<a href="#" aria-label="더 보기" className="flex gap-2 items-center text-black-700 body5-regular">
+				<Link
+					href={!isNews ? '/board?q=전체' : isMyTeam ? `/news?q=${teamName}` : `/news?q=전체`}
+					aria-label="더 보기"
+					className="flex gap-2 items-center text-black-700 body5-regular"
+				>
 					<span>더 보기</span>
 					<Image src="/chevron/right-gray.svg" width={18} height={18} alt="오른쪽 화살표" />
-				</a>
+				</Link>
 			</header>
 
 			{!isNews && <CommunityDivisionBar />}
@@ -70,13 +75,12 @@ const RecommendedContent = ({ mode, teamName = '' }) => {
 			<div className="flex flex-col">
 				{!data ? (
 					<FetchingFailedCard
-						onClick={() => {}}
 						height={isNews ? '45.375rem' : '35.125rem'}
 						marginTop={isNews ? '14.4375rem' : '10.25rem'}
 					/>
 				) : (
 					data.map((item, index) => (
-						<div key={item.id}>
+						<div key={item.pk}>
 							<Component {...item} isMyTeam={isMyTeam} />
 							{index !== data.length - 1 && <hr className="border-black-300 mx-4" />}
 						</div>

--- a/src/components/features/home/predict-card.tsx
+++ b/src/components/features/home/predict-card.tsx
@@ -4,9 +4,9 @@ import Closed from './closed';
 
 export default function PredictCard({ status }: { status: 'inProgress' | 'success' | 'fail' | 'unparticipated' }) {
 	const successBackground =
-		'linear-gradient(262deg, #000 -20.49%, #600606 3.69%, #C00C0B 50.27%, #600606 87.98%, #000 114.36%);';
+		'linear-gradient(262deg, #000 -20.49%, #600606 3.69%, #C00C0B 50.27%, #600606 87.98%, #000 114.36%)';
 	const failBackground =
-		'linear-gradient(84deg, #6D6D6D -12.16%, #888 11.83%, #AFAFAF 49.66%, #888 95.51%, #6D6D6D 113.24%);';
+		'linear-gradient(84deg, #6D6D6D -12.16%, #888 11.83%, #AFAFAF 49.66%, #888 95.51%, #6D6D6D 113.24%)';
 
 	return (
 		<div

--- a/src/components/layouts/with-side-layout/most-read-news-list/most-read-news-item.tsx
+++ b/src/components/layouts/with-side-layout/most-read-news-list/most-read-news-item.tsx
@@ -1,12 +1,14 @@
-export default function MostReadNewsItem() {
+import { HotNewsDto } from '@/services/apis/news/dto';
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function MostReadNewsItem({ pk, title, thumbnailUrl }: HotNewsDto) {
 	return (
-		<button className="grid grid-cols-[auto_1fr] gap-2 border-t border-black-200 p-4">
-			<div className="w-20 h-[3.75rem] bg-black-200 rounded-[0.25rem]"></div>
+		<Link href={`/news/${pk}`} className="grid grid-cols-[auto_1fr] gap-2 border-t border-black-200 p-4">
+			<Image width={80} height={60} src={thumbnailUrl} alt="기사 사진" className="w-20 h-[3.75rem] rounded-[0.25rem]" />
 			<div className="mr-2.5 my-auto body6-regular text-left line-clamp-3">
-				<strong>[K리그 1]</strong> 새 시즌 판도에 영향을 미칠 새로운 팀을 찾아 떠나는 경험 많은 선수들새 시즌 판도에
-				영향을 미칠 새로운 팀을 찾아 떠나는 경험 많은 선수들새 시즌 판도에 영향을 미칠 새로운 팀을 찾아 떠나는 경험 많은
-				선수들
+				<strong>[K리그 1]</strong> {title}
 			</div>
-		</button>
+		</Link>
 	);
 }

--- a/src/components/layouts/with-side-layout/most-read-news-list/most-read-news-list.tsx
+++ b/src/components/layouts/with-side-layout/most-read-news-list/most-read-news-list.tsx
@@ -1,16 +1,20 @@
 import ComponentFrame from '@/components/common/componentFrame';
 import MostReadNewsItem from './most-read-news-item';
+import { getHotNews } from '@/services/apis/news/getHotNews';
+import FetchingFailedCard from '@/components/common/fetching-failed-card';
 
-export default function MostReadNewsList() {
+export default async function MostReadNewsList() {
+	const response = await getHotNews();
+
 	return (
 		<div id="most-read-news-list">
 			<ComponentFrame>
 				<div className="pl-4 py-6 title5-semibold">많이 본 뉴스 TOP5</div>
-				<MostReadNewsItem />
-				<MostReadNewsItem />
-				<MostReadNewsItem />
-				<MostReadNewsItem />
-				<MostReadNewsItem />
+				{!response || !response.data.length ? (
+					<FetchingFailedCard height="28.75rem" marginTop="5.625rem" />
+				) : (
+					response.data.map((data) => <MostReadNewsItem key={data.pk} {...data} />)
+				)}
 			</ComponentFrame>
 		</div>
 	);

--- a/src/components/layouts/with-side-layout/ranking-list/ranking-item.tsx
+++ b/src/components/layouts/with-side-layout/ranking-list/ranking-item.tsx
@@ -1,24 +1,39 @@
+import { ActualRankingDto } from '@/services/apis/ranking/dto';
 import Image from 'next/image';
 
-export default function RankingItem({ mode }: { mode: 'season' | 'predict' }) {
+export default function RankingItem({
+	mode,
+	rankOrder,
+	teamLogoUrl,
+	teamName = '팀 이름',
+	gameNum,
+	points,
+	wonScores,
+}: Partial<ActualRankingDto> & { mode: 'season' | 'predict' }) {
 	return (
 		<div className="flex justify-between h-9 body6-medium items-center">
 			<div className="flex gap-2.5">
-				<div className="flex justify-center items-center w-7">1</div>
-				<Image width={18} height={18} src="/team-logo/ulsan.svg" alt="울산" />
-				<div>울산</div>
+				<div className="flex justify-center items-center w-7">{rankOrder}</div>
+				<Image
+					className="w-[1.125rem] h-[1.125rem] object-contain"
+					width={18}
+					height={18}
+					src={teamLogoUrl}
+					alt={`${teamLogoUrl} 로고`}
+				/>
+				<div>{teamName}</div>
 			</div>
 			<div className="flex gap-2">
 				{mode === 'season' ? (
 					<>
-						<div className="text-center w-7">38</div>
-						<div className="text-center w-7">72</div>
-						<div className="text-center w-7">62</div>
+						<div className="text-center w-7">{gameNum}</div>
+						<div className="text-center w-7">{points}</div>
+						<div className="text-center w-7">{wonScores}</div>
 					</>
 				) : (
 					<>
-						<div className="w-7 text-center">38</div>
-						<div className="w-12 text-center">62.24</div>
+						<div className="w-7 text-center">{gameNum}</div>
+						<div className="w-12 text-center">{points}</div>
 					</>
 				)}
 			</div>

--- a/src/components/layouts/with-side-layout/ranking-list/ranking-list.tsx
+++ b/src/components/layouts/with-side-layout/ranking-list/ranking-list.tsx
@@ -63,7 +63,7 @@ export default function RankingList({ mode }: { mode: 'season' | 'predict' }) {
 				{!ranking || !ranking.length ? (
 					<FetchingFailedCard onClick={getRanking} height="356px" marginTop="50px" />
 				) : (
-					ranking.map(({ rankOrder }) => <RankingItem key={rankOrder} mode={mode} />)
+					ranking.map((item, rankOrder) => <RankingItem key={rankOrder} mode={mode} {...item} />)
 				)}
 			</div>
 		</ComponentFrame>

--- a/src/lib/utils/formatStringToDate.ts
+++ b/src/lib/utils/formatStringToDate.ts
@@ -1,0 +1,12 @@
+export const formatStringToDate = (createdAt: string) => {
+	const date = new Date(createdAt);
+
+	return new Intl.DateTimeFormat('ko-KR', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	})
+		.format(date)
+		.replace(/\s/g, '')
+		.replace(/\.$/, '');
+};

--- a/src/lib/utils/getTimeAgo.ts
+++ b/src/lib/utils/getTimeAgo.ts
@@ -1,0 +1,17 @@
+export const getTimeAgo = (createdAt: string) => {
+	const now = new Date();
+	const date = new Date(createdAt);
+	const diff = Math.floor((now.getTime() - date.getTime()) / 1000); // 초 단위 차이 계산
+
+	if (diff < 60) return `${diff}초 전`;
+	const minutes = Math.floor(diff / 60);
+	if (minutes < 60) return `${minutes}분 전`;
+	const hours = Math.floor(minutes / 60);
+	if (hours < 24) return `${hours}시간 전`;
+	const days = Math.floor(hours / 24);
+	if (days < 30) return `${days}일 전`;
+	const months = Math.floor(days / 30);
+	if (months < 12) return `${months}개월 전`;
+	const years = Math.floor(days / 365);
+	return `${years}년 전`;
+};

--- a/src/services/apis/board/dto.ts
+++ b/src/services/apis/board/dto.ts
@@ -1,0 +1,16 @@
+import { SuccessResponse } from '@/services/config/dto';
+import { UserDto } from '../news/dto';
+import { TeamDto } from '../team/dto';
+
+export type GetRecommendedBoardsResponse = SuccessResponse<RecommendedBoardDto[]>;
+
+export interface RecommendedBoardDto {
+	pk: number;
+	title: string;
+	user: UserDto;
+	team: TeamDto;
+	createdAt: string;
+	views: number;
+	likes: number;
+	replies: number;
+}

--- a/src/services/apis/board/getRecommendedBoards.ts
+++ b/src/services/apis/board/getRecommendedBoards.ts
@@ -1,0 +1,12 @@
+import { SERVER_URL } from '@/services/config/constants';
+import { GetRecommendedBoardsResponse } from './dto';
+
+export const getRecommendedBoards = async (): Promise<GetRecommendedBoardsResponse | null> => {
+	const response = await fetch(`${SERVER_URL}/api/board/home`);
+
+	if (!response.ok) {
+		console.error(await response.json());
+		return null;
+	}
+	return response.json();
+};

--- a/src/services/apis/news/dto.ts
+++ b/src/services/apis/news/dto.ts
@@ -1,4 +1,5 @@
 import { SuccessResponse } from '../../config/dto';
+import { TeamDto } from '../team/dto';
 
 // 뉴스 리스트 조회
 export interface GetNewsListRequest {
@@ -20,6 +21,13 @@ export interface GetBoardListRequest {
 }
 
 export type GetBoardListResponse = SuccessResponse<BoardItemDto[]>;
+
+// 함께 볼 만한 게시글 조회
+export interface GetRecommendedNewsRequest {
+	type?: 'all';
+}
+
+export type GetRecommendedNewsResponse = SuccessResponse<RecommendedNewsDto[]>;
 
 // 내부 DTO
 export interface NewsItemDto {
@@ -49,4 +57,18 @@ export interface UserDto {
 	id: string;
 	nickname: string;
 	profileImageUrl: string;
+}
+
+export interface RecommendedNewsDto {
+	pk: number;
+	title: string;
+	content: string;
+	thumbnailUrl: string;
+	category: string;
+	user: UserDto;
+	team: TeamDto;
+	createdAt: string;
+	views: number;
+	likes: number;
+	replies: number;
 }

--- a/src/services/apis/news/dto.ts
+++ b/src/services/apis/news/dto.ts
@@ -22,12 +22,15 @@ export interface GetBoardListRequest {
 
 export type GetBoardListResponse = SuccessResponse<BoardItemDto[]>;
 
-// 함께 볼 만한 게시글 조회
+// 함께 볼 만한 뉴스 조회
 export interface GetRecommendedNewsRequest {
 	type?: 'all';
 }
 
 export type GetRecommendedNewsResponse = SuccessResponse<RecommendedNewsDto[]>;
+
+// top5 뉴스 조회
+export type GetHotNewsResponse = SuccessResponse<HotNewsDto[]>;
 
 // 내부 DTO
 export interface NewsItemDto {
@@ -71,4 +74,12 @@ export interface RecommendedNewsDto {
 	views: number;
 	likes: number;
 	replies: number;
+}
+
+export interface HotNewsDto {
+	pk: number;
+	title: string;
+	thumbnailUrl: string;
+	category: string;
+	views: number;
 }

--- a/src/services/apis/news/getHotNews.ts
+++ b/src/services/apis/news/getHotNews.ts
@@ -1,0 +1,12 @@
+import { SERVER_URL } from '@/services/config/constants';
+import { GetHotNewsResponse } from './dto';
+
+export const getHotNews = async (): Promise<GetHotNewsResponse | null> => {
+	const response = await fetch(`${SERVER_URL}/api/news/hot`);
+
+	if (!response.ok) {
+		console.error('TOP5 뉴스 조회 실패: ', await response.json());
+		return null;
+	}
+	return response.json();
+};

--- a/src/services/apis/news/getRecommendedNews.ts
+++ b/src/services/apis/news/getRecommendedNews.ts
@@ -6,7 +6,7 @@ export const getRecommendedNews = async ({
 }: GetRecommendedNewsRequest): Promise<GetRecommendedNewsResponse | null> => {
 	const params = new URLSearchParams();
 
-	if (type !== undefined) params.append('team', type);
+	if (type !== undefined) params.append('type', type);
 	const response = await fetch(`${SERVER_URL}/api/news/home?${params.toString()}`);
 
 	if (!response.ok) {

--- a/src/services/apis/news/getRecommendedNews.ts
+++ b/src/services/apis/news/getRecommendedNews.ts
@@ -1,0 +1,17 @@
+import { SERVER_URL } from '@/services/config/constants';
+import { GetRecommendedNewsRequest, GetRecommendedNewsResponse } from './dto';
+
+export const getRecommendedNews = async ({
+	type,
+}: GetRecommendedNewsRequest): Promise<GetRecommendedNewsResponse | null> => {
+	const params = new URLSearchParams();
+
+	if (type !== undefined) params.append('team', type);
+	const response = await fetch(`${SERVER_URL}/api/news/home?${params.toString()}`);
+
+	if (!response.ok) {
+		console.error(await response.json());
+		return null;
+	}
+	return response.json();
+};


### PR DESCRIPTION
## 작업 내용
- 함께 볼 만한 뉴스/게시글 api 연결했습니다.
- 많이 본 뉴스 TOP5 api 연결했습니다.
- 추가로 랭킹 api 응답에 따라 데이터 처리도 해 두었습니다.
- 서버 응답 수정에 따른 추가 조정들이 필요합니다!!
- FetchingFailedCard에서 데이터 리페칭을 어떻게 해야 할지 고민입니다,,, 서버 컴포넌트에서 이벤트 핸들러를 props로 넘겨주는 게 불가하기 때문에 FetchingFailedCard 내부적으로 처리할 수 있는 방안이 가장 좋을 듯한데,,, 우선은 onClick props를 옵셔널로 설정해서 피해가고 있습니다... api 연결이 마무리되면 로직 고안해 보겠습니다