### PR TITLE
[KO-161] axios 공통 401/403 에러 핸들링 (토큰 재발급)

### DIFF
--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -22,7 +22,6 @@ export default function Home() {
 			// TODO: 카테고리탭 리그 선택 연결하기
 			const request: GetGamesRequest = {
 				league: currentUserInfo?.leaguePk,
-				season: new Date().getFullYear(),
 				status: status,
 			};
 			const response = await getGames(request);

--- a/src/components/layouts/with-side-layout/ranking-list/ranking-list.tsx
+++ b/src/components/layouts/with-side-layout/ranking-list/ranking-list.tsx
@@ -12,14 +12,28 @@ import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 
 export default function RankingList({ mode }: { mode: 'season' | 'predict' }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
+
 	const [ranking, setRanking] = useState<GambleRankingDto[] | ActualRankingDto[] | null>();
 	const [league, setLeague] = useState<LeagueDto>({
-		pk: currentUserInfo?.leaguePk || 1,
-		nameKr: currentUserInfo?.leagueName || '프리미어리그',
-		nameEn: currentUserInfo?.leagueName || 'Premier League',
-		logoUrl: currentUserInfo?.leagueLogoUrl || 'https://media.api-sports.io/football/leagues/39.png',
+		pk: 1,
+		nameKr: '프리미어리그',
+		nameEn: 'Premier League',
+		logoUrl: 'https://media.api-sports.io/football/leagues/39.png',
 		leagueType: 'League',
 	});
+
+	// 렌더링 초기 currentUserInfo가 null인 문제 해결
+	useEffect(() => {
+		if (currentUserInfo) {
+			setLeague({
+				pk: currentUserInfo?.leaguePk,
+				nameKr: currentUserInfo?.leagueName,
+				nameEn: currentUserInfo?.leagueName,
+				logoUrl: currentUserInfo?.leagueLogoUrl,
+				leagueType: 'League',
+			});
+		}
+	}, [currentUserInfo]);
 
 	const handleLeagueChange = (selectedLeague: LeagueDto) => {
 		if (league.pk === selectedLeague.pk) return;

--- a/src/services/apis/user-game-gamble/dto.ts
+++ b/src/services/apis/user-game-gamble/dto.ts
@@ -3,7 +3,6 @@ import { SuccessResponse } from '@/services/config/dto';
 // 리그 기반으로 매치 리스트 조회
 export interface GetGamesRequest {
 	league: number;
-	season: number;
 	status: 'proceeding' | 'finished';
 }
 

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -62,7 +62,7 @@ export const postNewToken = async (body: PostNewTokenRequest) => {
 			console.error(response);
 			return response.message;
 		}
-		return response;
+		return response.data;
 	} catch (error) {
 		console.error('토큰 발급 실패: ', error);
 	}

--- a/src/services/config/axiosInstance.ts
+++ b/src/services/config/axiosInstance.ts
@@ -6,6 +6,7 @@ import axios, {
 	InternalAxiosRequestConfig,
 } from 'axios';
 import { SERVER_URL } from './constants';
+import { postNewToken } from '../auth';
 
 interface CustomInstance extends AxiosInstance {
 	interceptors: {
@@ -46,9 +47,38 @@ axiosInstance.interceptors.request.use(
 
 axiosInstance.interceptors.response.use(
 	(response) => response.data,
-	(error) => {
+	async (error) => {
+		const originalRequest = error.config;
+
 		if (error.response) {
-			return error.response.data; // FailResponse
+			// 인증 실패 시
+			if ((error.response.status === 401 || error.response.status === 403) && !originalRequest._retry) {
+				originalRequest._retry = true; // 무한 루프 방지
+
+				const prevRefreshToken = localStorage.getItem('refreshToken');
+
+				// 리프레시 토큰이 있으면 토큰 재발급 후 다시 시도
+				if (prevRefreshToken) {
+					const newTokenResponse = await postNewToken({ refreshToken: prevRefreshToken });
+
+					// 토큰 재발급 성공
+					if (newTokenResponse && typeof newTokenResponse !== 'string') {
+						// 새 토큰 저장
+						localStorage.setItem('refreshToken', newTokenResponse.refreshToken);
+						localStorage.setItem('accessToken', newTokenResponse.accessToken);
+
+						// 요청 재시도
+						originalRequest.headers.Authorization = `Bearer ${newTokenResponse.accessToken}`;
+						return axiosInstance(originalRequest);
+					} else {
+						// 토큰 재발급 실패
+						localStorage.clear();
+					}
+				}
+			}
+
+			// 그 외 서버 응답이 있는 오류 (FailResponse)
+			return error.response.data;
 		}
 		return Promise.reject(error); // 기타 오류
 	},


### PR DESCRIPTION
## 작업 내용
- axios 인터셉터에서 401/403 에러가 발생하는 경우, refreshToken을 조회해 로컬스토리지에 refreshToken이 있는 경우 재시도하도록 설정했습니다.
- 따라서 jwt가 필요한 로직은 fetch 대신 axios를 사용하는 게 편리할 것 같습니다!
 또는 리프레시토큰을 검사하는 별도의 함수를 만들어서 처리하는 방법도 있는데, 비용이 더 적을 것으로 생각되는 걸로 수정하면 될 것 같아요!!
- 추가로 테스트 과정에서 랭킹이 유저 리그 기반으로 설정되어야 하는데, currentUserInfo가 설정되기 전에 default값(프리미어리그)으로 설정되는 오류가 있어 랭킹 컴포넌트에서 useEffect를 사용해 초기화하도록 수정했습니다!
- 매치 리스트 조회 request에서 season 값이 제외돼 이 부분도 수정했습니다!