### PR TITLE
[KO-184] 상세페이지 content 표시 버그 해결 및 자잘한 버그 수정

### DIFF
--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -7,39 +7,35 @@ import PostEditor from '@/components/features/post/post-editor.tsx';
 import { PostNewsContentsRequest } from '@/services/apis/post/dto';
 import { postNewContents } from '@/services/apis/post';
 import { useRouter } from 'next/navigation';
-import { getTeam } from '@/services/apis/team';
+import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 
 export default function Page() {
 	const navigate = useRouter();
-	const [teams, setTeams] = useState<{ label: string; value: string; logo?: string }[]>([]);
-	const [selectedOption, setSelectedOption] = useState<{
-		label: string;
-		value: string;
-		logo?: string;
-	}>({
-		label: '탭 선택하기',
-		value: '',
-	});
+	const { currentUserInfo } = useCurrentUserInfoStore();
+
+	const userTeams = currentUserInfo?.teamPk
+		? [
+				{
+					label: currentUserInfo.teamName ?? '내 팀',
+					value: String(currentUserInfo.teamPk),
+					logo: currentUserInfo.teamLogoUrl,
+				},
+			]
+		: [];
+
+	const [teams] = useState<{ label: string; value: string; logo?: string }[]>([
+		{ label: '전체', value: '' },
+		...userTeams,
+	]);
+
+	const [selectedOption, setSelectedOption] = useState<{ label: string; value: string; logo?: string }>(teams[0]);
 
 	const [title, setTitle] = useState('');
 	const [body, setBody] = useState('');
-	const isFormValid = !!(selectedOption.value && title.trim() && body.trim());
+	const isFormValid = !!(selectedOption.value !== undefined && title.trim() && body.trim());
 
 	const [isVisibleDropdown, setIsVisibleDropdown] = useState(false);
 	const dropdownRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		const getTeamList = async () => {
-			const response = await getTeam(12);
-			const teamData = response.data.map((team) => ({
-				label: team.nameEn,
-				value: String(team.pk),
-				logo: team.logoUrl,
-			}));
-			setTeams(teamData); // 상태 업데이트
-		};
-		getTeamList();
-	}, []);
 
 	const handleDropdownToggle = () => {
 		setIsVisibleDropdown((prev) => !prev);
@@ -68,16 +64,16 @@ export default function Page() {
 		if (!isFormValid) return;
 
 		const requestBody: PostNewsContentsRequest = {
-			team: Number(selectedOption.value),
+			team: selectedOption.value ? Number(selectedOption.value) : null,
 			title: title.trim(),
 			contents: body.trim(),
 			hasImage: hasImage,
 		};
 
+		console.log(requestBody);
 		try {
 			const response = await postNewContents(requestBody);
 			console.log(response);
-
 			navigate.back();
 		} catch (error) {
 			console.error('게시글 작성 실패:', error);
@@ -95,7 +91,7 @@ export default function Page() {
 					)}
 				>
 					{selectedOption.logo && <Image src={selectedOption.logo} alt={selectedOption.label} width={16} height={16} />}
-					<div className={clsx('body5-regular', selectedOption.value ? 'text-black-900' : 'text-black-600')}>
+					<div className={clsx('button4-medium', selectedOption.value !== '' ? 'text-black-900' : 'text-black-900')}>
 						{selectedOption.label}
 					</div>
 					<Image width={16} height={16} src="/chevron/down.svg" alt="옵션 선택" />
@@ -103,7 +99,6 @@ export default function Page() {
 
 				{isVisibleDropdown && (
 					<div className="z-50 absolute top-10 w-[9.125rem] bg-black-000 border border-black-300 button4-medium rounded-lg shadow-lg overflow-hidden">
-						<div className="px-4 py-2.5">전체</div>
 						{teams.map((option, index) => (
 							<div
 								key={option.value}

--- a/src/app/(without-side)/profile-setting/page.tsx
+++ b/src/app/(without-side)/profile-setting/page.tsx
@@ -15,18 +15,21 @@ import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 export default function Page() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
+	console.log(currentUserInfo);
+
 	const [nickname, setNickname] = useState(currentUserInfo?.nickname);
 	const [league, setLeague] = useState<LeagueDto>({
-		pk: NO_CHEERING_TEAM_PK,
-		nameKr: '응원팀이 없어요.',
+		pk: currentUserInfo?.leaguePk ?? NO_CHEERING_TEAM_PK,
+		nameKr: currentUserInfo?.leagueName ?? '응원팀이 없어요.',
 		nameEn: 'no cheering team',
-		logoUrl: '/ban.svg',
+		logoUrl: currentUserInfo?.leagueLogoUrl ?? '/ban.svg',
 	});
+
 	const [team, setTeam] = useState<TeamDto>({
-		pk: NO_CHEERING_TEAM_PK,
-		nameKr: '응원팀이 없어요.',
+		pk: currentUserInfo?.teamPk ?? NO_CHEERING_TEAM_PK,
+		nameKr: currentUserInfo?.teamName ?? '응원팀이 없어요.',
 		nameEn: 'no cheering team',
-		logoUrl: '/ban.svg',
+		logoUrl: currentUserInfo?.teamLogoUrl ?? '/ban.svg',
 	});
 
 	const route = useRouter();
@@ -82,9 +85,9 @@ export default function Page() {
 
 	return (
 		<div className="m-auto w-[21.5rem] flex flex-col">
-			<div className="relative mb-7">
+			<div className="relative mb-7 w-[68px] h-[68px] rounded-full overflow-hidden">
 				<Image
-					className="rounded-full"
+					className="w-full h-full object-cover"
 					width={68}
 					height={68}
 					src={currentUserInfo?.profileImageUrl || '/default-profile.svg'}

--- a/src/components/common/category-tab/news-item.tsx
+++ b/src/components/common/category-tab/news-item.tsx
@@ -19,7 +19,7 @@ export default function NewsItem({
 	isMyTeam = false,
 }: NewsItemDto & { isMyTeam?: boolean }) {
 	return (
-		<Link href={`news/${pk}`}>
+		<Link href={`/news/${pk}`}>
 			<article className="flex flex-col py-6 px-4 cursor-pointer">
 				<header className="flex gap-2 mb-2.5 items-center">
 					{!isMyTeam && (

--- a/src/components/common/sanitized-content.tsx
+++ b/src/components/common/sanitized-content.tsx
@@ -9,15 +9,23 @@ export default function SanitizedContent({ content }: { content: string }) {
 	const [sanitizedContent, setSanitizedContent] = useState('');
 
 	useEffect(() => {
-		setSanitizedContent(DOMPurify.sanitize(content, { FORBID_TAGS: ['img', 'strong', 'p'] }));
+		let cleanText = DOMPurify.sanitize(content, { ALLOWED_TAGS: ['p'] })
+			.replace(/<\/p>\s*<p>/g, '<br />') // 단락 사이 줄 바꿈 유지
+			.replace(/^<p>|<\/p>$/g, ''); // 맨 앞뒤 <p> 제거
+
+		// 2줄까지만 표시 (대략 120자 기준, <br> 포함)
+		if (cleanText.length > 120) {
+			cleanText = cleanText.substring(0, 117) + '...';
+		}
+
+		setSanitizedContent(cleanText);
 	}, [content]);
 
 	return (
 		<div
-			className="mb-[1.125rem] subtitle2-regular font-normal"
-			dangerouslySetInnerHTML={{
-				__html: sanitizedContent.length > 120 ? `${sanitizedContent.substring(0, 117)}...` : sanitizedContent,
-			}}
+			className="mb-[1.125rem] subtitle2-regular font-normal line-clamp-2"
+			style={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', overflow: 'hidden' }}
+			dangerouslySetInnerHTML={{ __html: sanitizedContent }}
 		/>
 	);
 }

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -101,6 +101,12 @@ const CommentInput = ({
 		if (inputRef.current) inputRef.current.innerHTML = '';
 		setIsSubmitting(false);
 	};
+	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+		if (e.key === 'Enter' && !e.shiftKey) {
+			e.preventDefault();
+			handleSubmit();
+		}
+	};
 
 	return (
 		<div className={type === 'reply' ? 'mt-3.5' : 'bg-black-200 rounded-[0.625rem] p-4 mb-10 flex flex-col gap-4'}>
@@ -110,6 +116,7 @@ const CommentInput = ({
 					<div
 						ref={inputRef}
 						contentEditable
+						onKeyDown={handleKeyDown}
 						onInput={handleInput}
 						className={`w-full h-full p-4 pb-3 rounded-l-[0.625rem] resize-none focus:outline-none overflow-y-scroll no-scrollbar body6-regular
               ${type === 'reply' ? 'bg-black-100' : 'bg-black-000 h-full'} text-left`}

--- a/src/components/features/detail/content/DetailContent.tsx
+++ b/src/components/features/detail/content/DetailContent.tsx
@@ -18,12 +18,11 @@ const DetailContent = ({ data, type, isOurTeamPost }) => {
 
 	useEffect(() => {
 		if (typeof window !== 'undefined') {
-			setSanitizedContent(
-				DOMPurify.sanitize(data.content, {
-					ADD_TAGS: ['iframe'],
-					ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling'],
-				}),
-			);
+			const sanitized = DOMPurify.sanitize(data.content, {
+				ADD_TAGS: ['iframe'],
+				ADD_ATTR: ['allow', 'allowfullscreen', 'frameborder', 'scrolling'],
+			});
+			setSanitizedContent(sanitized);
 		}
 	}, [data.content]);
 
@@ -95,7 +94,7 @@ const DetailContent = ({ data, type, isOurTeamPost }) => {
 
 			{/* 본문 */}
 			<hr className="mt-6 mb-7.5 -mx-4 text-black-300" />
-			<div className="mb-40 whitespace-pre-line body3-regular" dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
+			<div className="mb-40 body3-regular" dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
 
 			{/* 좋아요 버튼 */}
 			<button

--- a/src/components/features/detail/content/DetailContent.tsx
+++ b/src/components/features/detail/content/DetailContent.tsx
@@ -104,7 +104,7 @@ const DetailContent = ({ data, type, isOurTeamPost }) => {
 	${isLiked ? 'bg-[#D91920] text-white' : 'bg-black-100 text-black-900'} transition
 	hover:shadow-[0rem_0.125rem_0.625rem_0rem_rgba(217,25,32,0.2)]`}
 			>
-				<Image src={isLiked ? '/kick/red.svg' : '/kick/black.svg'} alt="축구공" width={18} height={18} />
+				<Image src={'/kick/black.svg'} alt="축구공" width={18} height={18} />
 				<span className="mr-0.5">킥</span>
 				<span className={`${isLiked ? 'text-white' : 'group-hover:text-[#D91920]'}`}>{likes}</span>
 			</button>

--- a/src/components/features/post/tool-bar.tsx
+++ b/src/components/features/post/tool-bar.tsx
@@ -115,7 +115,7 @@ export default function Toolbar({
 				{textFormatButtons.map((btn) => (
 					<button
 						key={btn.key}
-						className={clsx('w-rounded-sm', editor?.isActive(btn.key) && 'bg-gray-300')}
+						className={clsx('w-5 rounded-xs', editor?.isActive(btn.key) && 'bg-black-300')}
 						onClick={() => handleTextFormatToggle(btn.key)}
 					>
 						{btn.icon}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -79,6 +79,11 @@ p {
 hr {
 	border: none;
 	border-top: 1px solid #d9d9d9;
+}
+
+.tiptap hr {
+	border: none;
+	border-top: 1px solid #d9d9d9;
 	margin: 16px 0;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -61,46 +61,38 @@ button {
 .banner-swiper .swiper-pagination-bullet-active {
 	width: 3.125rem;
 }
-.tiptap h1 {
+h1 {
 	font-size: 20px;
 	font-weight: 700;
 }
 
-.tiptap h2 {
+h2 {
 	font-size: 18px;
 	font-weight: 600;
 }
 
-.tiptap p {
+p {
 	font-size: 16px;
 	font-weight: 400;
 }
 
-.tiptap hr {
+hr {
 	border: none;
 	border-top: 1px solid #d9d9d9;
 	margin: 16px 0;
 }
 
-.tiptap ul {
+ul {
 	list-style: disc;
 	padding-left: 1.5rem;
 }
 
-.tiptap blockquote {
+blockquote {
 	border-left: 4px solid var(--color-black-800);
 	padding-left: 1rem;
 	margin: 1rem 0;
 }
-
-.tiptap boxquote {
-	border: 2px solid var(--color-black-300);
-	border-radius: 6px;
-	padding: 1rem;
-	margin: 1rem 0;
-}
-
-.tiptap ol {
+ol {
 	list-style-type: decimal;
 	padding-left: 1.5rem;
 }


### PR DESCRIPTION
## 작업 내용
- 상세페이지 조회 시 인용구, 목록화 등의 스타일링이 콘솔에도 정제된 html 잘 찍히고, 정제도 잘 되는데 렌더링만 안 되는 버그가 있었는데 이는 global.css에서 blockquote, ol 등에 스타일을 주지 않았기 때문에 보이지 않았던 것이었습니다. 
- .tiptap blockquote 하면 스타일이 안 먹혔습니다...... (인용이랑 점 목록만 적용이 안 됐다)
- 더불어 뉴스 아이템의 미리보기 컨텐츠 또한 태그 스타일이 적용되지 않게 수정했습니다.

- 상세 페이지에서 함께 보면 좋을~ 뉴스를 누르면 경로가 /news/news/12 이런 식으로 되어 404가 떴는데 NewsItem 컴포넌트로 가니 Link 태그의 경로가 상대경로로 되어 있어 현재 news/33에서 해당 뉴스 아이템을 누르면 news/news 가 되었던 것... 이를 절대경로로 수정했습니다.

- 커뮤니티 글 작성 시 탭 선택하기 부분에서 오해하고 있던 부분을 수정했습니다. 전체를 클릭하면 team의 값이 null이 되고 내 팀을 선택하면 팀 pk가 request body에 담아 보냅니닷

- 프로필 설정 페이지의 응원 팀과 리그 선택하는 부분의 초깃값이 응원 팀이 없어요 등으로 처리 돼 있던 걸 currentUserInfo에서 내 정보를 꺼내 초깃값으로 넣었습니다. 더불어 프로필 사진을 정원형으로 만들었습니다.


## 추가 내용
- 댓글 입력 후 엔터를 치면 바로 댓글 리스트에 나타나도록 하고자 했는데 컴포넌트 계층이나 props 전달이 너무 복잡해 우선 추후에 수정하고자 합니닷...
- 저의 리팩토링 과제는 DetailPage를 서버 컴포넌트화 하기, 컴포넌트 계층 정리하기 등을 주로 시행하면서... 그 과정에서 댓글 엔터 시 바로 렌더링 등의 문제를 해결하고자 합니다...

