### PR TITLE
[KO-158] 토큰이 필요한 api 로직 수정, api 응답 성공 여부로 ui 분기 및 alert 처리

### DIFF
--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import CommentInput from '@/components/features/detail/comment/comment-input';
 import CommentItem from '@/components/features/detail/comment/comment-item';
 import { postCommentKick } from '@/services/apis/detail/comment';
+import { getAuthToken } from '@/lib/utils/getAccessToken';
 
 const CommentSection = ({ type, comments, isOurTeamPost, contentsId, totalreplies }) => {
 	const [likedComments, setLikedComments] = useState<{ [key: string]: boolean }>({});
@@ -19,11 +20,22 @@ const CommentSection = ({ type, comments, isOurTeamPost, contentsId, totalreplie
 	}, []);
 
 	const toggleCommentLike = async (commentId: number) => {
+		if (!getAuthToken()) {
+			alert('로그인이 필요합니다.');
+			return;
+		}
+
 		const result = await postCommentKick(commentId, isNews);
-		console.log('결과', result);
-		const updatedLikes = { ...likedComments, [commentId]: !likedComments[commentId] };
-		setLikedComments(updatedLikes);
-		localStorage.setItem('likedComments', JSON.stringify(updatedLikes));
+		if (result) {
+			setLikedComments((prev) => ({
+				...prev,
+				[commentId]: !prev[commentId],
+			}));
+			localStorage.setItem(
+				'likedComments',
+				JSON.stringify({ ...likedComments, [commentId]: !likedComments[commentId] }),
+			);
+		}
 	};
 
 	const toggleReplyInputVisibility = (commentId: string) => {

--- a/src/components/features/detail/content/DetailContent.tsx
+++ b/src/components/features/detail/content/DetailContent.tsx
@@ -57,7 +57,7 @@ const DetailContent = ({ data, type, isOurTeamPost }) => {
 			{/* 헤더 */}
 			{isNews && (
 				<div className="flex gap-2 mb-2.5 items-center">
-					{isOurTeamPost && <Image src="/team-logo/liverpool.svg" alt="팀 로고" width={24} height={24} />}
+					{isOurTeamPost && <Image src={data.team.logoUrl} alt="팀 로고" width={24} height={24} />}
 					<span className="px-2.5 py-1 bg-black-900 text-black-000 caption1-medium rounded-[1.25rem]">
 						{categoryLabel}
 					</span>

--- a/src/components/features/detail/content/DetailContent.tsx
+++ b/src/components/features/detail/content/DetailContent.tsx
@@ -6,6 +6,7 @@ import { postContentLike } from '@/services/apis/detail/kick';
 import DOMPurify from 'dompurify';
 import { getRelativeTime } from '@/lib/utils/getRelativeTime';
 import { categories } from '@/lib/constants/options';
+import { getAuthToken } from '@/lib/utils/getAccessToken';
 
 const DetailContent = ({ data, type, isOurTeamPost }) => {
 	const isNews = type === 'news';
@@ -27,17 +28,24 @@ const DetailContent = ({ data, type, isOurTeamPost }) => {
 	}, [data.content]);
 
 	const handleLikeButtonClick = async () => {
-		// UI 즉시 업데이트 (API 응답을 기다리지 않고 반영)
-		setIsLiked((prev) => !prev);
-		setLikes((prev) => (isLiked ? prev - 1 : prev + 1));
+		// 비회원인 경우 클릭 차단 & 알림 표시
+		if (!getAuthToken()) {
+			alert('로그인이 필요합니다.');
+			return;
+		}
 
-		// 좋아요 요청 API 호출
-		const success = await postContentLike(data.pk, isNews);
-
-		// API 요청 실패 시 원래 상태로 롤백
-		if (!success) {
-			setIsLiked((prev) => !prev);
-			setLikes((prev) => (isLiked ? prev + 1 : prev - 1));
+		try {
+			const success = await postContentLike(data.pk, isNews);
+			if (success) {
+				// API 응답이 성공하면 UI 업데이트
+				setIsLiked((prev) => !prev);
+				setLikes((prev) => (isLiked ? prev - 1 : prev + 1));
+			} else {
+				alert('좋아요 요청에 실패했습니다. 다시 시도해주세요.');
+			}
+		} catch (error) {
+			console.error('좋아요 요청 중 오류 발생:', error);
+			alert('네트워크 오류가 발생했습니다. 다시 시도해주세요.');
 		}
 	};
 

--- a/src/services/apis/detail/comment/index.ts
+++ b/src/services/apis/detail/comment/index.ts
@@ -1,9 +1,7 @@
 import { SERVER_URL } from '@/services/config/constants';
 import { createNewReplyRequest, GetCommentsResponse, PostCommentKickRequest } from './dto';
 import { EmptySuccessResponse, SuccessResponse } from '@/services/config/dto';
-import { getAuthToken } from '@/lib/utils/getAccessToken';
-
-const JWT = getAuthToken();
+import axiosInstance from '@/services/config/axiosInstance';
 
 export const getCommentList = async (
 	id: number,
@@ -31,46 +29,31 @@ export const getCommentList = async (
 };
 
 export const postCommentKick = async (id: number, isNews: boolean = false): Promise<SuccessResponse<null>> => {
-	const endpoint = isNews ? 'news-reply-kick' : 'board-reply-kick';
+	try {
+		const endpoint = isNews ? 'news-reply-kick' : 'board-reply-kick';
 
-	const body: PostCommentKickRequest = { reply: id };
-	const response = await fetch(`${SERVER_URL}/api/${endpoint}`, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${JWT}`,
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify(body),
-	});
+		const body: PostCommentKickRequest = { reply: id };
+		const response = await axiosInstance.post<SuccessResponse<null>>(`/api/${endpoint}`, body);
 
-	if (!response.ok) {
-		throw new Error(`Failed to kick comment: ${response.statusText}`);
+		return response;
+	} catch (error) {
+		console.error('댓글 킥 생성 실패:', error);
+		throw error;
 	}
-
-	return response.json();
 };
 
 export const postCreateReply = async (
 	type: 'news' | 'board',
 	requestBody: createNewReplyRequest,
 ): Promise<EmptySuccessResponse> => {
-	const endpoint = type === 'news' ? '/api/news-reply' : '/api/board-reply';
+	try {
+		const endpoint = type === 'news' ? '/api/news-reply' : '/api/board-reply';
 
-	const response = await fetch(`${SERVER_URL}${endpoint}`, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${JWT}`,
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify(requestBody),
-	});
+		const response = await axiosInstance.post<EmptySuccessResponse>(endpoint, requestBody);
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		console.error('댓글 작성 실패 - 응답 상태:', response.status, response.statusText);
-		console.error('응답 본문:', errorText);
-		throw new Error('댓글 작성 실패');
+		return response;
+	} catch (error) {
+		console.error('댓글 작성 실패:', error);
+		throw error;
 	}
-
-	return response.json(); // 성공하면 응답 데이터 반환
 };

--- a/src/services/apis/detail/index.ts
+++ b/src/services/apis/detail/index.ts
@@ -1,24 +1,18 @@
-import { SERVER_URL } from '@/services/config/constants';
+import axiosInstance from '@/services/config/axiosInstance';
 import { GetDetailResponse } from './dto';
-import { getAuthToken } from '@/lib/utils/getAccessToken';
 
 export const getDetailContent = async (type: 'news' | 'board', id: number): Promise<GetDetailResponse | null> => {
-	const JWT = getAuthToken();
+	try {
+		const response = await axiosInstance.get<GetDetailResponse>(`/api/${type}/${id}`);
 
-	// 헤더 동적 설정
-	const headers: HeadersInit = JWT ? { Authorization: `Bearer ${JWT}` } : {};
+		if (!response) {
+			console.error('상세페이지 조회 실패 - 응답 없음');
+			throw new Error('상세페이지 조회 실패');
+		}
 
-	const response = await fetch(`${SERVER_URL}/api/${type}/${id}`, {
-		method: 'GET',
-		headers,
-	});
-
-	if (!response.ok) {
-		const errorText = await response.text();
-		console.error('상세페이지 조회 실패 - 응답 상태:', response.status, response.statusText);
-		console.error('서버 응답 본문:', errorText);
-		throw new Error('상세페이지 조회 실패');
+		return response;
+	} catch (error) {
+		console.error('상세페이지 조회 실패:', error);
+		throw error;
 	}
-
-	return response.json();
 };

--- a/src/services/apis/detail/kick/index.ts
+++ b/src/services/apis/detail/kick/index.ts
@@ -1,29 +1,18 @@
-import { SERVER_URL } from '@/services/config/constants';
+import axiosInstance from '@/services/config/axiosInstance';
 import { EmptySuccessResponse } from '@/services/config/dto';
-import { getAuthToken } from '@/lib/utils/getAccessToken';
-
-const JWT = getAuthToken();
 
 export const postContentLike = async (id: number, isNews: boolean = false): Promise<EmptySuccessResponse> => {
-	const body = JSON.stringify({ [isNews ? 'news' : 'board']: id });
+	try {
+		const body = { [isNews ? 'news' : 'board']: id };
+		const endpoint = isNews ? '/api/news-kick' : '/api/board-kick';
 
-	const endpoint = isNews ? 'news-kick' : 'board-kick';
-	console.log(body);
-	const response = await fetch(`${SERVER_URL}/api/${endpoint}`, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${JWT}`,
-			'Content-Type': 'application/json',
-		},
-		body,
-	});
+		console.log(body);
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		console.error('상세페이지 킥 요청 실패 - 응답 상태:', response.status, response.statusText);
-		console.error('서버 응답 본문:', errorText);
-		throw new Error('상세페이지 킥 요청 실패');
+		const response = await axiosInstance.post<EmptySuccessResponse>(endpoint, body);
+
+		return response;
+	} catch (error) {
+		console.error('상세페이지 킥 생성 실패:', error);
+		throw error;
 	}
-
-	return response.json();
 };

--- a/src/services/apis/detail/report/index.ts
+++ b/src/services/apis/detail/report/index.ts
@@ -1,31 +1,19 @@
-import { SERVER_URL } from '@/services/config/constants';
+import axiosInstance from '@/services/config/axiosInstance';
 import { PostReportDetailRequest } from './dto';
 import { EmptySuccessResponse } from '@/services/config/dto';
-import { getAuthToken } from '@/lib/utils/getAccessToken';
-
-const JWT = getAuthToken();
 
 export const postReportDetail = async (
 	data: PostReportDetailRequest,
 	isNews: boolean = false,
 ): Promise<EmptySuccessResponse> => {
-	const endpoint = isNews ? '/api/report-news' : '/api/report-board';
+	try {
+		const endpoint = isNews ? '/api/report-news' : '/api/report-board';
 
-	const response = await fetch(`${SERVER_URL}${endpoint}`, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${JWT}`,
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify(data),
-	});
+		const response = await axiosInstance.post<EmptySuccessResponse>(endpoint, data);
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		console.error('상세페이지 신고 실패 - 응답 상태:', response.status, response.statusText);
-		console.error('서버 응답 본문:', errorText);
-		throw new Error('상세페이지 신고 실패');
+		return response;
+	} catch (error) {
+		console.error('상세페이지 신고 실패:', error);
+		throw error;
 	}
-
-	return response.json();
 };

--- a/src/services/apis/detail/view/index.ts
+++ b/src/services/apis/detail/view/index.ts
@@ -1,6 +1,6 @@
-import { SERVER_URL } from '@/services/config/constants';
 import { EmptySuccessResponse } from '@/services/config/dto';
 import { PostContentViewRequest } from './dto';
+import axiosInstance from '@/services/config/axiosInstance';
 
 interface PostContentViewProps {
 	requestBody: PostContentViewRequest;
@@ -11,23 +11,14 @@ export const PostContentView = async ({
 	requestBody,
 	isNews = false,
 }: PostContentViewProps): Promise<EmptySuccessResponse> => {
-	const endpoint = isNews ? 'news-view-history' : 'board-view-history';
-	console.log(requestBody);
+	try {
+		const endpoint = isNews ? '/api/news-view-history' : '/api/board-view-history';
 
-	const response = await fetch(`${SERVER_URL}/api/${endpoint}`, {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify(requestBody),
-	});
+		const response = await axiosInstance.post<EmptySuccessResponse>(endpoint, requestBody);
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		console.error('뷰 생성 실패 - 응답 상태:', response.status, response.statusText);
-		console.error('서버 응답 본문:', errorText);
-		throw new Error('뷰 생성 실패');
+		return response;
+	} catch (error) {
+		console.error('뷰 생성 실패:', error);
+		throw error;
 	}
-
-	return response.json();
 };

--- a/src/services/apis/news/getRecommendedNews.ts
+++ b/src/services/apis/news/getRecommendedNews.ts
@@ -1,25 +1,16 @@
-import { SERVER_URL } from '@/services/config/constants';
+import axiosInstance from '@/services/config/axiosInstance';
 import { GetRecommendedNewsRequest, GetRecommendedNewsResponse } from './dto';
-import { getAuthToken } from '@/lib/utils/getAccessToken';
 
 export const getRecommendedNews = async ({
 	type,
 }: GetRecommendedNewsRequest): Promise<GetRecommendedNewsResponse | null> => {
-	const params = new URLSearchParams();
-	const JWT = getAuthToken();
-
-	// 헤더 동적 설정
-	const headers: HeadersInit = JWT ? { Authorization: `Bearer ${JWT}` } : {};
-
-	if (type !== undefined) params.append('type', type);
-	const response = await fetch(`${SERVER_URL}/api/news/home?${params.toString()}`, {
-		method: 'GET',
-		headers,
-	});
-
-	if (!response.ok) {
-		console.error(await response.json());
+	try {
+		const response = await axiosInstance.get<GetRecommendedNewsResponse>('/api/news/home', {
+			params: type ? { type } : {},
+		});
+		return response;
+	} catch (error) {
+		console.error('추천 뉴스 조회 실패:', error);
 		return null;
 	}
-	return response.json();
 };

--- a/src/services/apis/post/index.ts
+++ b/src/services/apis/post/index.ts
@@ -1,28 +1,17 @@
-import { SERVER_URL } from '@/services/config/constants';
+import axiosInstance from '@/services/config/axiosInstance';
 import { PostNewsContentsRequest } from './dto';
-import { getAuthToken } from '@/lib/utils/getAccessToken';
-
-const JWT = getAuthToken();
 
 export async function postNewContents(data: PostNewsContentsRequest, isNews: boolean = false) {
-	const endpoint = isNews ? '/api/news' : '/api/board';
-	console.log(data); // 디버깅
+	try {
+		const endpoint = isNews ? '/api/news' : '/api/board';
 
-	const response = await fetch(`${SERVER_URL}${endpoint}`, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${JWT}`,
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify(data),
-	});
+		console.log(data);
 
-	if (!response.ok) {
-		const errorText = await response.text();
-		console.error('API 요청 실패 - 응답 상태:', response.status, response.statusText);
-		console.error('서버 응답 본문:', errorText);
-		throw new Error('API 요청 실패');
+		const response = await axiosInstance.post(endpoint, data);
+
+		return response;
+	} catch (error) {
+		console.error('API 요청 실패:', error);
+		throw error;
 	}
-
-	return response;
 }


### PR DESCRIPTION
## 작업 내용
- 토큰을 가져다 쓰는 api 모두 axios로 변경했습니다! 추천 뉴스를 가지고 오는 api 함수도 함께 변경하였습니다.
- 제안해 주신 fetch로 refresh를 이용한 새 토큰 발급 로직을 구현해 보고 싶긴 합니다! 하지만 우선 빠른 배포가 먼저니, 다음 스프린트 때 구현해 보고자 합니다...! 
- 뉴스 및 커뮤니티 상세 조회 시 킥 생성과 댓글 킥 생성 시 클릭이 아닌 api 응답 성공 여부로 ui 분기 처리 했으며 fetch와 함께 쓰이던 getAuthToken 유틸 함수를 이용해 로컬 스토리지의 토큰 유무를 보고 로그인을 유도하는 alert를 추가했고 로그인 모달이 띄워지게 했습니다.

## 부수적인 작업 내용
- 내 팀 뉴스 상세의 로고가 리버풀로 고정 되어 있던 걸 지금 발견해서 바로 수정했습니다.