### PR TITLE
[KO-189] 뉴스 리스트 페이지 선택 리그가 초기화되지 않도록 수정

### DIFF
--- a/src/components/common/category-tab/category-tab.tsx
+++ b/src/components/common/category-tab/category-tab.tsx
@@ -46,7 +46,7 @@ export default async function CategoryTab({
 
 	return (
 		<div className="flex flex-col w-full">
-			<TabBar mode={mode} q={q} />
+			<TabBar mode={mode} q={q} type={type} />
 			{!isNews && <CommunityDivisionBar />}
 			{!response ? (
 				<FetchingFailedCard height="770px" marginTop="9.5rem" />

--- a/src/components/common/category-tab/select-box.tsx
+++ b/src/components/common/category-tab/select-box.tsx
@@ -8,7 +8,15 @@ import { useRouter } from 'next/navigation';
 import { LeagueDto } from '@/services/apis/league/dto';
 import { getLeague } from '@/services/apis/league';
 
-export default function SelectBox({ q, isClickedOtherTab = false }: { q: string; isClickedOtherTab: boolean }) {
+export default function SelectBox({
+	q,
+	type,
+	isClickedOtherTab = false,
+}: {
+	q: string;
+	type: string;
+	isClickedOtherTab: boolean;
+}) {
 	const [isVisibleOptions, setIsVisibleOptions] = useState(false);
 	const [options, setOptions] = useState<LeagueDto[] | null>(null);
 	const [league, setLeague] = useState<LeagueDto | null>(null);
@@ -44,7 +52,7 @@ export default function SelectBox({ q, isClickedOtherTab = false }: { q: string;
 	}, []);
 
 	useEffect(() => {
-		if (q) {
+		if (type === 'league' && q) {
 			setLeague({
 				nameKr: q,
 				nameEn: q,
@@ -52,7 +60,7 @@ export default function SelectBox({ q, isClickedOtherTab = false }: { q: string;
 				logoUrl: '',
 			});
 		}
-	}, [q]);
+	}, [type, q]);
 
 	useEffect(() => {
 		// isVisibleOptions가 true일 때만 리스너 등록

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import SelectBox from './select-box';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 
-export default function TabBar({ mode, q }: { mode: 'news' | 'board'; q: string }) {
+export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: string; type: string }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
 	const tabs = ['전체', '인기', currentUserInfo ? currentUserInfo.teamName : null];
@@ -34,7 +34,7 @@ export default function TabBar({ mode, q }: { mode: 'news' | 'board'; q: string 
 						tabs.includes(q) ? 'border-transparent' : 'border-primary-900 text-primary-900 header-semibold',
 					)}
 				>
-					<SelectBox q={q} isClickedOtherTab={tabs.includes(q)} />
+					<SelectBox q={q} type={type} isClickedOtherTab={tabs.includes(q)} />
 				</div>
 			)}
 		</div>


### PR DESCRIPTION
## 작업 내용
- 게시글 작성 페이지에서 뒤로가기를 했는데 프리미어리그를 선택했던 게 리그 선택으로 초기화되는 버그 발견했습니다!! 뒤로가기 시에도 초기화되지 않도록 경로에서 선택 탭을 받아오는 방식으로 수정했습니다.
- 처음에는 q를 받아서 초기화하도록 했는데, 전체/인기/팀 등도 모두 q를 사용하기 때문에 type이 league인지 검사하는 로직을 추가해 리그만 받도록 수정했습니다!