### PR TITLE
[KO-214] 게시글 작성 페이지 진입 시 alert 띄운 후 이전 페이지로 라우팅 처리

### DIFF
--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -8,13 +8,11 @@ import { PostNewsContentsRequest } from '@/services/apis/post/dto';
 import { postNewContents } from '@/services/apis/post';
 import { useRouter } from 'next/navigation';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
-import LoginModal from '@/components/common/login-modal/login-modal';
 import { getAccessToken, getRefreshToken } from '@/lib/utils/getAccessToken';
 
 export default function Page() {
 	const navigate = useRouter();
 	const { currentUserInfo } = useCurrentUserInfoStore();
-	const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
 
 	const userTeams = currentUserInfo?.teamPk
 		? [
@@ -49,12 +47,19 @@ export default function Page() {
 		setIsVisibleDropdown(false);
 	};
 
+	const hasShownAlert = useRef(false);
+
 	useEffect(() => {
+		if (hasShownAlert.current) return;
+		hasShownAlert.current = true;
+
 		const isLoggedIn = getAccessToken() && getRefreshToken();
 		if (!isLoggedIn) {
-			setIsLoginModalOpen(true);
+			alert('로그인 후 작성 가능합니다.');
+			const previousPage = sessionStorage.getItem('previousPage');
+			navigate.replace(previousPage);
 		}
-	}, []);
+	}, [navigate]);
 
 	useEffect(() => {
 		const handleClickOutside = (event: MouseEvent) => {
@@ -149,7 +154,6 @@ export default function Page() {
 				>
 					작성 완료
 				</button>
-				{isLoginModalOpen && <LoginModal onClose={() => setIsLoginModalOpen(false)} />}
 			</div>
 		</div>
 	);

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -11,11 +11,11 @@ import { getPresignedUrl, uploadToS3 } from '@/services/apis/image-upload';
 import { useRouter } from 'next/navigation';
 import { getTeam } from '@/services/apis/team';
 import { getAccessToken, getRefreshToken } from '@/lib/utils/getAccessToken';
-import LoginModal from '@/components/common/login-modal/login-modal';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 
 export default function Page() {
 	const navigate = useRouter();
+
 	const [searchTerm, setSearchTerm] = useState('');
 	const [selectedTeam, setSelectedTeam] = useState<{ id: number; name: string; logo: string } | null>(null);
 	const [selectedOption, setSelectedOption] = useState<{ label: string; value: string }>({
@@ -27,6 +27,7 @@ export default function Page() {
 	const dropdownRef = useRef<HTMLDivElement>(null);
 	const searchRef = useRef<HTMLDivElement>(null);
 	const fileInputRef = useRef(null);
+	const hasShownAlert = useRef(false);
 
 	const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
@@ -36,16 +37,19 @@ export default function Page() {
 	const [teams, setTeams] = useState<{ id: number; name: string; logo: string }[]>([]);
 	const [filteredResults, setFilteredResults] = useState(teams);
 
-	const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-
 	const { currentUserInfo } = useCurrentUserInfoStore(); // 페이지 새로고침 시 유저 정보 초기화, persist 필요
 
 	useEffect(() => {
+		if (hasShownAlert.current) return;
+		hasShownAlert.current = true;
+
 		const isLoggedIn = getAccessToken() && getRefreshToken();
 		if (!isLoggedIn) {
-			setIsLoginModalOpen(true);
+			alert('로그인 후 작성 가능합니다.');
+			const previousPage = sessionStorage.getItem('previousPage');
+			navigate.replace(previousPage);
 		}
-	}, []);
+	}, [navigate]);
 
 	useEffect(() => {
 		const getTeamList = async () => {
@@ -304,7 +308,6 @@ export default function Page() {
 				>
 					작성 완료
 				</button>
-				{isLoginModalOpen && <LoginModal onClose={() => setIsLoginModalOpen(false)} />}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## 작업 내용
- 제안 주신 두 가지 방식 중에서 게시글 작성 페이지 진입 시 alert를 띄운 뒤 이전 페이지로 이동하게 했습니닷.
- 모달을 띄워서 게시글 작성 페이지 내에서 로그인 처리할 수도 있겠지만, 로그인을 하지 않은 상태에서 게시글 작성 페이지 진입하는 경우는 이전 페이지에 항상 로그인 가능한 섹션이 존재하니 이전 페이지로 가게 하는 게 훨씬 간단하겠다고 판단했습니다!!
- alert가 두 번 뜨길래 리렌더링과 무관하게 변수를 유지하는 고정값인 hasShownAlert.current를 이용해 alert가 단 한 번만 실행되도록 컨트롤 했습니다.

- alert가 두 번 뜨는 이유가 뭘까... 생각해 봤는데 답을 모르겠습니다. . . 예전에 react 사용할 때 strictmode 때문에 두 번 뜬 경우가 있었는데 우리 프로젝트에서도 모드가 설정됐나...? 싶어서 컨피그 파일 보니 false로 되어 있어서... 이유는 찾지 못했습니다. . . 뭘까요?-?

