### PR TITLE
[KO-266] 조회수 UX 개선

### DIFF
--- a/src/app/(with-side)/[type]/[id]/page.tsx
+++ b/src/app/(with-side)/[type]/[id]/page.tsx
@@ -69,12 +69,25 @@ const DetailPage = () => {
 			router.replace('/404');
 			return;
 		}
-
 		const getDetailContentData = async () => {
 			try {
 				const contentData = await getDetailContent(type, id);
+
+				// 내 조회가 반영되기 전 서버 조회수
+				const serverViewCount = contentData.data.views;
+
+				// shouldCallApi -> true: 글을 처음 본 상태, 조회수 +1, false: 이미 본 적 있음
+				const clientViewCount = shouldCallApi ? serverViewCount + 1 : serverViewCount;
+
+				setContents({
+					...contentData,
+					data: {
+						...contentData.data,
+						views: clientViewCount, // 수정한 조회수만 덮어씀
+					},
+				});
+
 				setTotalReplies(contentData.data.replies);
-				setContents(contentData);
 				console.log('상세조회', contentData);
 			} catch (error) {
 				console.error('데이터 불러오기 실패:', error);
@@ -84,7 +97,7 @@ const DetailPage = () => {
 		};
 
 		getDetailContentData();
-	}, [type, id, currentPage, router, isNews]);
+	}, [type, id, currentPage, router, isNews, shouldCallApi]);
 
 	const viewSent = useRef(false);
 


### PR DESCRIPTION
## 작업 내용

- 상세페이지 조회 시의 내 조회수가 새로고침을 해야 반영되는 버그가 있었습니다. 아영 님께서 세심히 알려주신 덕분에 빠르게 해결할 수 있었습니당 감사합니다!!!
- 문제는 상세페이지 조회 api -> 조회수 올리는 api 이 순서로 호출되어 새로고침을 해야 새로운 조회수가 반영된 상세페이지 조회 api 응답을 받아올 수 있어 그때 조회수가 리프레시 되는 거였으니 가장 처음으로는... 이 둘의 순서를 바꿔보는 방식으로 해결해 보려 했습니다. 조회수를 바로 올리고 나서 상세페이지를 조회하면 업데이트 된 내용이 바로 오지 않을까? 하고요

   그렇게 해당 방식으로 코드 수정을 진행하던 찰나 두 api 호출 타이밍 문제에 대해 생각해 보았습니다. 서버에서 조회수를 반영하는 것에는 지연이 따를 것 같은데 바로 이어서 상세페이지 조회를 호출하면 조회수 반영이 DB에 되기 전의 상태를 가져올 것으로 예상되어 오히려 UX를 망칠 것 같다 판단했습니다. 
    그래서 순서를 바꾸는 것이 아닌 프론트 단에서 +1 하는 방식으로 변경했습니다.
    
    shouldCallApi를 이용해 내가 글을 처음 본 상태인지 아닌지 판단 후 조회수 api 호출하게 해 불러올 상황이라면 서버 응답 기다릴 필요 없이 프론트에서 +1된 값을 기존 조회수에 덮어써 즉각 반응을 보장했습니다.

- 테스트 결과, 게시글 작성 후 해당 게시글로 이동 시의 조회수도 잘 올라가는 걸로 확인했습니다.
