### PR TITLE
[KO-289] 이미지 업로드 시 이미지 파일명에 이미지 업로드 시각 추가

### DIFF
--- a/src/lib/utils/addTimestampToFileName.ts
+++ b/src/lib/utils/addTimestampToFileName.ts
@@ -1,14 +1,28 @@
 export const addTimestampToFileName = (originalName: string) => {
 	const now = new Date();
-	const pad = (n: number) => n.toString().padStart(2, '0'); // 숫자를 항상 두 자리로 패딩 처리 5 -> 05
 
-	const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`; // getMonth는 0부터 시작
+	// Intl.DateTimeFormat을 사용해 날짜와 시간 부분을 각각 숫자로 포맷
+	const formatter = new Intl.DateTimeFormat('ko-KR', {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		hour12: false,
+	});
 
-	const dotIndex = originalName.lastIndexOf('.'); // 확장자 구분
-	const name = dotIndex !== -1 ? originalName.substring(0, dotIndex) : originalName; // 파일명 부분
-	const ext = dotIndex !== -1 ? originalName.substring(dotIndex) : ''; // 확장자 부분
+	const parts = formatter.formatToParts(now);
+	const timestamp = parts
+		.filter(part => part.type !== 'literal') // '.', ' ', ':' 같은 구분자는 제외
+		.map(part => part.value)
+		.join(''); // "20250503145809" 같은 문자열로 변환
 
-	// 특수문자 제거 (한글, 영어, 숫자, 공백 제외 -> 공백은 언더바로 대체)
+	const dotIndex = originalName.lastIndexOf('.');
+	const name = dotIndex !== -1 ? originalName.substring(0, dotIndex) : originalName;
+	const ext = dotIndex !== -1 ? originalName.substring(dotIndex) : '';
+
+	// 특수문자 제거 + 공백은 언더바로 대체
 	const cleanedName = name.replace(/[^\p{L}\p{N}\s]/gu, '').replace(/\s+/g, '_');
 
 	return `${cleanedName}_${timestamp}${ext}`;

--- a/src/services/apis/image-upload/index.ts
+++ b/src/services/apis/image-upload/index.ts
@@ -4,7 +4,6 @@ import { addTimestampToFileName } from '@/lib/utils/addTimestampToFileName';
 
 export async function getPresignedUrl(fileName: string, isNews: boolean): Promise<GetPresignedUrlResponse> {
 	const timestampedFileName = addTimestampToFileName(fileName);
-	console.log('new file name:', timestampedFileName);
 
 	const requestBody: PresignedUrlRequest = {
 		type: isNews ? 'news-images' : 'board-images',


### PR DESCRIPTION
## 작업 내용
- presigned url을 얻기 위해 이미지 파일명을 보내는 과정에서 파일명 뒤에 해당 이미지를 get 요청에 담아 보낸 현재 시각을 추가했습니다.
- addTimestampToFileName 유틸 함수를 만들어 getPresignedUrl 함수에서 requestBody에 파일명을 담아보낼 때 현재 시각을 추가한 새로운 파일명을 담아 보내도록 수정했습니다.

- 현재 민서 님께 특수기호 관련해 문의 드린 게 있어 해당 사항 답변이 오면 처리 후 슬랙에 재언급 드리겠습니다! 코멘트는 지금 달아주셔도 되지만 머지는 특수기호 관련 문의가 처리되면 부탁드립니다!!