### PR TITLE
[KO-299] 동일한 이미지 업로드 불가 이슈 file input 초기화로 해결

### DIFF
--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -169,7 +169,12 @@ export default function Page() {
 
 	const handleRemoveImage = () => {
 		setSelectedImage(null);
-	};
+	  
+		// file input의 값을 초기화해서 동일한 파일 다시 선택 가능하게 함
+		if (fileInputRef.current) {
+		  fileInputRef.current.value = '';
+		}
+	  };	  
 
 	// 대표 이미지 클릭 시 파일 업로드 창 열기
 	const handleImageClick = () => {

--- a/src/components/features/post/post-editor.tsx.tsx
+++ b/src/components/features/post/post-editor.tsx.tsx
@@ -123,7 +123,9 @@ const PostEditor = ({
 
 			// 업로드된 이미지 URL을 에디터에 추가
 			editor.chain().focus().setImage({ src: s3Url }).run();
-			console.log('이미지 추가됨:', s3Url);
+    
+			// 이미지 삽입 후 빈 단락 추가하여 커서 위치시키기
+			editor.chain().focus().createParagraphNear().run();
 
 			// 에디터 내용 업데이트 (비동기 반영 확인)
 			setTimeout(() => {

--- a/src/components/features/post/tool-bar.tsx
+++ b/src/components/features/post/tool-bar.tsx
@@ -204,7 +204,7 @@ export default function Toolbar({
 							className="cursor-pointer p-[7px] border border-[#D9D9D9] rounded-sm"
 						>
 							{btn.icon}
-							<input type="file" accept={btn.accept} className="hidden" onChange={btn.onChange} />
+							<input type="file" accept={btn.accept} className="hidden" onClick={(e) => (e.target as HTMLInputElement).value = ''} onChange={btn.onChange} />
 						</label>
 					) : (
 						<button


### PR DESCRIPTION
## 작업 내용
- 뉴스 및 커뮤니티 글 작성 페이지에서 대표 이미지 선택과 에디터에 이미지 삽입 시 동일한 이미지는 presigned url이 발급 요청 조차 이루어지지 않는 버그가 있었습니다.
- 동일한 이미지를 다시 업로드할 때 네트워크 요청이 발생하지 않는 이유를 아래 두 가지 정도로 파악했습니다.

1. `<input type="file">`의 value가 **동일한 파일**일 경우 change 이벤트가 발생하지 않음
`<input type="file">` 요소에서 사용자가 이전에 선택한 파일을 다시 선택하더라도, 브라우저는 파일이 이미 선택되었기 때문에 change 이벤트를 트리거하지 않음. 이는 브라우저의 기본 동작으로, 사용자가 동일한 파일을 선택했을 때 불필요한 이벤트를 방지하려는 목적!!
즉, 브라우저가 '이미 전에 선택된 적 있는 파일이다. 다시 업로드 할 필요 없음.'이라고 판단해서 내부적으로 아무 일도 안 일어나는 것.

2. 그래서 s3 presigned url 업로드 요청이 발생하지 x
`<input type="file">`에서 change 이벤트가 발생하지 않으면, 그에 따라 파일 업로드 처리가 트리거되지 않아서 presigned URL 요청도 발생하지 않게 됨. 결과적으로 s3에 파일을 업로드하려는 요청이 생기지 않죠.

- 그래서 대표 사진 업로드에서는 이미지 삭제 핸들러가 있기 때문에 핸들러에서 파일 input 초기화했습니다. 에디터는 삭제 버튼이 따로 있는 것이 아니기에 handleAddImage 함수 안에서 onClick 핸들러에서 동일한 이미지 다시 선택 가능하도록 강제 초기화했습니다.
- 또한 에디터에서 이미지를 추가하면 탭을 한 번 눌러야 아래 줄으로 커서가 이동했는데, 이를 `insertContent({ type: 'paragraph' })`를 사용하여 이미지를 추가하면 자동으로 새 단락이 추가 되어 입력 커서가 아래로 이동하게 했습니다.
