### PR TITLE
[KO-398] 프로필 설정 페이지 팀 선택 여러개 가능하도록 수정

### DIFF
--- a/public/ban.svg
+++ b/public/ban.svg
@@ -1,6 +1,12 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g id="icon/ban">
-<circle id="Ellipse 85" cx="8" cy="8" r="6.25" stroke="#8F8F8F" stroke-width="1.5"/>
-<path id="Vector 192" d="M4 12L12 4" stroke="#8F8F8F" stroke-width="1.5" stroke-linecap="round"/>
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_4320_43951)">
+<circle cx="9" cy="9" r="9" fill="#F0F0F0"/>
+<circle cx="9" cy="9" r="4.25" stroke="#8F8F8F" stroke-width="1.5"/>
+<path d="M6.5 11.5L11.5 6.5" stroke="#8F8F8F" stroke-width="1.5" stroke-linecap="round"/>
 </g>
+<defs>
+<clipPath id="clip0_4320_43951">
+<rect width="18" height="18" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/src/app/(with-side)/[type]/[id]/page.tsx
+++ b/src/app/(with-side)/[type]/[id]/page.tsx
@@ -35,7 +35,7 @@ const DetailPage = () => {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
 	const isTeamNull = contents?.data?.team == null;
-	const isOurTeam = currentUserInfo?.favoriteTeam?.pk === contents?.data?.team?.pk;
+	const isOurTeam = Boolean(currentUserInfo?.favoriteTeams.find((team) => team?.pk === contents?.data?.team?.pk));
 	const isCommentAllowed = isTeamNull || isOurTeam;
 
 	const [shouldCallApi, setShouldCallApi] = useState(false);
@@ -142,7 +142,7 @@ const DetailPage = () => {
 
 			<RecommendedContent
 				mode={type}
-				teamLogo={currentUserInfo?.favoriteTeam?.logoUrl}
+				teamLogo={currentUserInfo?.favoriteTeams[0]?.logoUrl}
 				teamName={isOurTeam ? contents?.data.team?.nameKr : ''}
 			/>
 		</div>

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -117,8 +117,10 @@ export default function Home() {
 				<Suspense>
 					<RecommendedContent
 						mode={'news'}
-						teamLogo={currentUserInfo?.favoriteTeam?.logoUrl}
-						teamName={currentUserInfo?.favoriteTeam?.nameKr || currentUserInfo?.favoriteTeam?.nameEn || undefined}
+						teamLogo={currentUserInfo?.favoriteTeams[0]?.logoUrl}
+						teamName={
+							currentUserInfo?.favoriteTeams[0]?.nameKr || currentUserInfo?.favoriteTeams[0]?.nameEn || undefined
+						}
 					/>
 					<RecommendedContent mode={'board'} />
 				</Suspense>

--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -28,14 +28,12 @@ export default function Page() {
 	const teams = useMemo(() => {
 		return [
 			{ label: '전체', value: '전체' },
-			...(currentUserInfo?.favoriteTeam?.pk
-				? [
-						{
-							label: currentUserInfo.favoriteTeam.nameKr || currentUserInfo.favoriteTeam.nameEn || '내 팀',
-							value: String(currentUserInfo.favoriteTeam.pk),
-							logo: currentUserInfo.favoriteTeam.logoUrl,
-						},
-					]
+			...(currentUserInfo?.favoriteTeams
+				? currentUserInfo.favoriteTeams.map((team) => ({
+						label: team.nameKr || team.nameEn || '내 팀',
+						value: String(team.pk),
+						logo: team.logoUrl,
+					}))
 				: []),
 		];
 	}, [currentUserInfo]);
@@ -195,7 +193,7 @@ export default function Page() {
 								onClick={() => handleOptionClick(option)}
 							>
 								<div className="flex items-center gap-2">
-									{option.logo && (
+									{'logo' in option && (
 										<Image
 											className="w-4 h-4 object-contain"
 											src={option.logo}

--- a/src/app/(without-side)/profile-setting/page.tsx
+++ b/src/app/(without-side)/profile-setting/page.tsx
@@ -135,13 +135,15 @@ export default function Page() {
 				<input ref={fileInputRef} type="file" onChange={handleFileChange} className="hidden" />
 			</div>
 
-			<div className="w-full flex flex-col gap-[3.125rem] @mobile:gap-10">
+			<div className="w-full flex flex-col gap-10">
 				<Nickname nickname={nickname} isDuplicated={isDuplicated} onChange={handleNicknameChange} />
 				<FavoriteTeamSection isEditable={isEditable} initialTeams={teams} />
 			</div>
 
-			<div className="relative flex flex-col gap-2 mt-[4.25rem]">
-				<div className="flex gap-1.5 items-center subtitle1-medium @mobile:text-13">계정 관리</div>
+			<hr className="w-full my-10 h-[1px] border-black-200 @mobile:border-black-300" />
+
+			<div className="relative flex flex-col gap-2">
+				<div className="flex gap-1.5 items-center subtitle1-semibold">계정 관리</div>
 				<div
 					className="flex gap-2.5 items-center px-4 py-3 w-full @mobile:text-14
 						border border-black-300 rounded-lg bg-black-100 body3-regular"

--- a/src/app/(without-side)/profile-setting/page.tsx
+++ b/src/app/(without-side)/profile-setting/page.tsx
@@ -4,15 +4,13 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import Nickname from '@/components/features/signup/nickname';
 import { useEffect, useRef, useState } from 'react';
-import Selectbox from '@/components/common/account/selectbox';
-import { LeagueDto } from '@/services/apis/league/dto';
 import { TeamDto } from '@/services/apis/team/dto';
 import { UpdateUserInfoRequest } from '@/services/auth/dto';
 import { getUserInfo, updateUserInfo } from '@/services/auth';
-import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { setCookie } from '@/lib/utils/cookie';
 import { getPresignedUrl, uploadToS3 } from '@/services/apis/image-upload';
+import FavoriteTeamSection from '@/components/common/account/favorite-team-section';
 
 export default function Page() {
 	const { currentUserInfo, setCurrentUserInfo } = useCurrentUserInfoStore();
@@ -20,24 +18,12 @@ export default function Page() {
 	const [profileImageUrl, setProfileImageUrl] = useState('');
 	const [isDuplicated, setIsDuplicated] = useState(false);
 	const [nickname, setNickname] = useState<string | null>(null);
-	const [league, setLeague] = useState<LeagueDto>({
-		pk: NO_CHEERING_TEAM_PK,
-		nameKr: '응원팀이 없어요.',
-		nameEn: 'no cheering team',
-		logoUrl: '/ban.svg',
-	});
-	const [team, setTeam] = useState<TeamDto>({
-		pk: NO_CHEERING_TEAM_PK,
-		nameKr: '응원팀이 없어요.',
-		nameEn: 'no cheering team',
-		logoUrl: '/ban.svg',
-	});
+	const [teams, setTeams] = useState<(TeamDto | null)[] | null>(null);
 
 	const router = useRouter();
 
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const isEditable = false;
-	const hasTeam = league.nameKr !== '응원팀이 없어요.';
 	const socialLogoUrl = currentUserInfo?.providerType === 'KAKAO' ? '/sns/kakao-small.svg' : '/sns/naver-small.svg';
 
 	// 이미지 업로드
@@ -75,16 +61,6 @@ export default function Page() {
 		}
 	};
 
-	const handleLeagueChange = (selectedLeague) => {
-		if (selectedLeague === league) return;
-		setLeague(selectedLeague);
-	};
-
-	const handleTeamChange = (selectedTeam) => {
-		if (selectedTeam === team) return;
-		setTeam(selectedTeam);
-	};
-
 	const handleCancelButtonClick = () => {
 		const previousPage = sessionStorage.getItem('previousPage');
 		router.push(previousPage);
@@ -94,7 +70,7 @@ export default function Page() {
 		const body: UpdateUserInfoRequest = {
 			profileImageUrl,
 			nickname,
-			team: team.pk === -1 ? undefined : team.pk, // 응원하는 팀이 없는 경우 team을 undefined로
+			teams: !teams || teams[0].pk === -1 ? undefined : teams.map((team) => team?.pk), // 응원하는 팀이 없는 경우 team을 undefined로
 			// league: league.pk, 현재 서버에서 league를 처리하지 않음
 		};
 
@@ -127,21 +103,12 @@ export default function Page() {
 
 				setProfileImageUrl(response.data.profileImageUrl);
 				setNickname(response.data.nickname);
-				if (response.data.league) {
-					setLeague({
-						pk: response.data.league.pk,
-						nameKr: response.data.league.nameKr,
-						nameEn: response.data.league.nameEn,
-						logoUrl: response.data.league.logoUrl,
-					});
-				}
-				if (response.data.favoriteTeam) {
-					setTeam({
-						pk: response.data.favoriteTeam.pk,
-						nameKr: response.data.favoriteTeam.nameKr,
-						nameEn: response.data.favoriteTeam.nameEn,
-						logoUrl: response.data.favoriteTeam.logoUrl,
-					});
+				if (response.data.favoriteTeams) {
+					setTeams(
+						response.data.favoriteTeams ?? [
+							{ nameEn: 'no cheering team', nameKr: '응원팀이 없어요.', pk: -1, logoUrl: '/ban.svg' },
+						],
+					);
 				}
 			}
 		};
@@ -168,12 +135,9 @@ export default function Page() {
 				<input ref={fileInputRef} type="file" onChange={handleFileChange} className="hidden" />
 			</div>
 
-			<div className="flex flex-col gap-6">
+			<div className="w-full flex flex-col gap-[3.125rem] @mobile:gap-10">
 				<Nickname nickname={nickname} isDuplicated={isDuplicated} onChange={handleNicknameChange} />
-				<Selectbox isEditable={isEditable} category={'리그'} content={league} onChange={handleLeagueChange} />
-				{hasTeam && (
-					<Selectbox isEditable={isEditable} category={'응원팀'} content={team} onChange={handleTeamChange} />
-				)}
+				<FavoriteTeamSection isEditable={isEditable} initialTeams={teams} />
 			</div>
 
 			<div className="relative flex flex-col gap-2 mt-[4.25rem]">

--- a/src/app/(without-side)/signup/page.tsx
+++ b/src/app/(without-side)/signup/page.tsx
@@ -1,20 +1,15 @@
 'use client';
 
 import Checkbox from '@/components/features/signup/checkbox';
-import Selectbox from '@/components/common/account/selectbox';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import Nickname from '@/components/features/signup/nickname';
 import { UpdatePrivacyRequest, UpdateUserInfoRequest } from '@/services/auth/dto';
 import { updatePrivacy, updateUserInfo } from '@/services/auth';
 import { agreementDatas } from '@/lib/constants/agreementDatas';
-import { LeagueDto } from '@/services/apis/league/dto';
-import { TeamDto } from '@/services/apis/team/dto';
-import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { getCookie, setCookie } from '@/lib/utils/cookie';
 import { DOMAIN_URL, SERVER_URL } from '@/services/config/constants';
-import FavoriteTeamList from '@/components/common/account/favorite-team-list';
 import FavoriteTeamSection from '@/components/common/account/favorite-team-section';
 export default function Page() {
 	const router = useRouter();
@@ -27,8 +22,7 @@ export default function Page() {
 
 	const [isDuplicated, setIsDuplicated] = useState(false);
 	const [nickname, setNickname] = useState<string | null>(null);
-	const [league, setLeague] = useState<LeagueDto | null>(null);
-	const [team, setTeam] = useState<TeamDto | null>(null);
+	const [teams, setTeams] = useState<number[] | null>(null);
 	const [agreements, setAgreements] = useState({
 		all: false,
 		age: false,
@@ -39,23 +33,13 @@ export default function Page() {
 
 	const isValidNickname = nickname && !isDuplicated;
 	const isAllRequiredChecked = agreements.age && agreements.term && agreements.privacy;
-	const isButtonDisabled = !(isValidNickname && isAllRequiredChecked && league && (league.pk === -1 || team));
+	const isButtonDisabled = !(isValidNickname && isAllRequiredChecked && teams);
 
 	const handleNicknameChange = (e) => {
 		setNickname(e.target.value);
 		if (isDuplicated) {
 			setIsDuplicated(false);
 		}
-	};
-
-	const handleLeagueChange = (selectedLeague) => {
-		if (selectedLeague === league) return;
-		setLeague(selectedLeague);
-	};
-
-	const handleTeamChange = (selectedTeam) => {
-		if (selectedTeam === team) return;
-		setTeam(selectedTeam);
 	};
 
 	const handleCheckboxChange = (key) => {
@@ -80,7 +64,7 @@ export default function Page() {
 		// 회원가입(정보 수정)
 		const updateUserInfoRequest: UpdateUserInfoRequest = {
 			nickname: nickname,
-			team: !team || team.pk === -1 ? undefined : team.pk,
+			teams: !teams || teams[0] === -1 ? undefined : teams,
 		};
 		const updateUserInfoResponse = await updateUserInfo(updateUserInfoRequest);
 
@@ -108,24 +92,24 @@ export default function Page() {
 	};
 
 	// 소셜 로그인을 통한 접근이 아닌 경우 홈으로 리디렉션
-	// useEffect(() => {
-	// 	const fromLogin = getCookie('fromLogin');
+	useEffect(() => {
+		const fromLogin = getCookie('fromLogin');
 
-	// 	if (fromLogin === 'true') {
-	// 		setIsValidAccess(true);
-	// 	} else {
-	// 		alert('잘못된 접근입니다.');
-	// 		router.replace('/');
-	// 	}
-	// }, [router]);
+		if (fromLogin === 'true') {
+			setIsValidAccess(true);
+		} else {
+			alert('잘못된 접근입니다.');
+			router.replace('/');
+		}
+	}, [router]);
 
-	// useEffect(() => {
-	// 	return () => {
-	// 		if (isValidAccess) {
-	// 			setCookie('fromLogin', '', 0);
-	// 		}
-	// 	};
-	// }, [isValidAccess]);
+	useEffect(() => {
+		return () => {
+			if (isValidAccess) {
+				setCookie('fromLogin', '', 0);
+			}
+		};
+	}, [isValidAccess]);
 
 	return (
 		<div className="w-[21.5rem] m-auto flex flex-col items-center">
@@ -139,13 +123,7 @@ export default function Page() {
 
 			<div className="mt-[4.75rem] @mobile:mt-[3.125rem] mb-[4.5rem] w-full flex flex-col gap-[3.125rem] @mobile:gap-10">
 				<Nickname nickname={nickname} isDuplicated={isDuplicated} onChange={handleNicknameChange} />
-
-				<FavoriteTeamSection />
-
-				{/* <Selectbox category="리그" content={league} onChange={handleLeagueChange} />
-				{league && league.pk !== NO_CHEERING_TEAM_PK && (
-					<Selectbox category="응원팀" league={league.pk} content={team} onChange={handleTeamChange} />
-				)} */}
+				<FavoriteTeamSection setTeams={setTeams} />
 			</div>
 
 			<div className="p-2.5 w-full flex flex-col gap-4">

--- a/src/app/(without-side)/signup/page.tsx
+++ b/src/app/(without-side)/signup/page.tsx
@@ -121,7 +121,7 @@ export default function Page() {
 				<div className="body3-regular @mobile:text-14">계정으로 가입을 진행하고 있어요.</div>
 			</div>
 
-			<div className="mt-[4.75rem] @mobile:mt-[3.125rem] mb-[4.5rem] w-full flex flex-col gap-[3.125rem] @mobile:gap-10">
+			<div className="mt-[4.75rem] @mobile:mt-[3.125rem] mb-[4.5rem] w-full flex flex-col gap-10">
 				<Nickname nickname={nickname} isDuplicated={isDuplicated} onChange={handleNicknameChange} />
 				<FavoriteTeamSection setTeams={setTeams} />
 			</div>

--- a/src/components/common/account/favorite-team-item.tsx
+++ b/src/components/common/account/favorite-team-item.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 
 export default function FavoriteTeamItem({
 	team,
@@ -17,9 +18,9 @@ export default function FavoriteTeamItem({
 	team: TeamDto | null;
 	orderNum: number;
 	isActive: boolean;
-	isDisabled: boolean;
-	onClickItem: () => void;
-	onClickXButton: (e: React.MouseEvent) => void;
+	isDisabled?: boolean;
+	onClickItem?: () => void;
+	onClickXButton?: (e: React.MouseEvent) => void;
 }) {
 	const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
 		id: team?.pk ?? -1,
@@ -71,8 +72,8 @@ export default function FavoriteTeamItem({
 				)}
 			>
 				{/* 팀 선택 취소 x 버튼 */}
-				{!(orderNum === 1 && !team) && (
-					// 1순위 팀 선택 전에는 x 버튼 표시 안 함
+				{/* // 1순위 팀 선택 전에는 x 버튼 표시 안 함 */}
+				{!(orderNum === 1 && !team) && team?.pk !== NO_CHEERING_TEAM_PK && (
 					<button
 						onClick={onClickXButton}
 						className={clsx(

--- a/src/components/common/account/favorite-team-item.tsx
+++ b/src/components/common/account/favorite-team-item.tsx
@@ -12,6 +12,7 @@ export default function FavoriteTeamItem({
 	orderNum,
 	isActive,
 	isDisabled,
+	isEditable = true,
 	onClickItem,
 	onClickXButton,
 }: {
@@ -19,6 +20,7 @@ export default function FavoriteTeamItem({
 	orderNum: number;
 	isActive: boolean;
 	isDisabled?: boolean;
+	isEditable?: boolean;
 	onClickItem?: () => void;
 	onClickXButton?: (e: React.MouseEvent) => void;
 }) {
@@ -66,14 +68,15 @@ export default function FavoriteTeamItem({
 					}
 				}}
 				className={clsx(
-					`relative w-full h-auto aspect-[5/4] cursor-pointer
-          flex flex-col gap-1 justify-center items-center rounded-lg bg-black-000`,
+					`relative w-full h-auto aspect-[5/4] flex flex-col gap-1
+					justify-center items-center rounded-lg bg-black-000`,
+					isEditable ? 'cursor-pointer' : 'cursor-default',
 					isActive ? 'p-[4px] pb-[2px] border-2 border-primary-900' : 'p-[5px] pb-[3px] border border-black-300',
 				)}
 			>
 				{/* 팀 선택 취소 x 버튼 */}
-				{/* // 1순위 팀 선택 전에는 x 버튼 표시 안 함 */}
-				{!(orderNum === 1 && !team) && team?.pk !== NO_CHEERING_TEAM_PK && (
+				{/* 1순위 팀 선택 전에는 x 버튼 표시 안 함 */}
+				{isEditable && !(orderNum === 1 && !team) && team?.pk !== NO_CHEERING_TEAM_PK && (
 					<button
 						onClick={onClickXButton}
 						className={clsx(
@@ -95,7 +98,7 @@ export default function FavoriteTeamItem({
 						>
 							<Image className="w-auto h-auto object-contain" src={team.logoUrl} alt="로고" fill />
 						</div>
-						{!isDisabled && (
+						{isEditable && !isDisabled && (
 							<div className={clsx('flex gap-0.5', { 'brightness-0': isDragging })}>
 								<Image src="/draggable.svg" alt="드래그 아이콘" width={18} height={18} />
 							</div>

--- a/src/components/common/account/favorite-team-list.tsx
+++ b/src/components/common/account/favorite-team-list.tsx
@@ -16,6 +16,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { arrayMove } from '@dnd-kit/sortable';
+import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 
 export default function FavoriteTeamList({
 	favoriteTeamLeagueMap,
@@ -122,7 +123,8 @@ export default function FavoriteTeamList({
 							isDisabled={
 								!favorite?.team ||
 								favoriteTeamLeagueMap.length === 1 ||
-								(favoriteTeamLeagueMap.length === 2 && !favoriteTeamLeagueMap.at(-1))
+								(favoriteTeamLeagueMap.length === 2 && !favoriteTeamLeagueMap.at(-1)) ||
+								favorite?.team?.pk === NO_CHEERING_TEAM_PK
 							}
 							onClickItem={() => handleItemClick(i)}
 							onClickXButton={(e) => handleXButtonClick(e, i)}
@@ -130,18 +132,21 @@ export default function FavoriteTeamList({
 					))}
 				</SortableContext>
 				{
-					// 이전 팀 선택이 완료되고 선택 팀이 3개 미만일 때 추가 버튼 표시
-					favoriteTeamLeagueMap.at(-1) !== null && favoriteTeamLeagueMap.length < 3 && (
-						<button
-							onClick={handleAddButtonClick}
-							className="w-full h-auto aspect-[5/4] flex flex-col gap-1 justify-center items-center 
+					// 이전 팀 선택이 완료되고 (응원팀이 없어요 제외)
+					// 선택 팀이 3개 미만일 때 추가 버튼 표시
+					favoriteTeamLeagueMap.at(-1) !== null &&
+						favoriteTeamLeagueMap[0].team.pk !== NO_CHEERING_TEAM_PK &&
+						favoriteTeamLeagueMap.length < 3 && (
+							<button
+								onClick={handleAddButtonClick}
+								className="w-full h-auto aspect-[5/4] flex flex-col gap-1 justify-center items-center 
 								rounded-lg bg-black-000 p-[5px] border border-black-300"
-						>
-							<div className="relative w-12 h-12 @mobile:w-[2.1875rem] @mobile:h-[2.1875rem]">
-								<Image src={'/plus.svg'} alt="팀 추가 버튼" fill className="w-auto h-auto" />
-							</div>
-						</button>
-					)
+							>
+								<div className="relative w-12 h-12 @mobile:w-[2.1875rem] @mobile:h-[2.1875rem]">
+									<Image src={'/plus.svg'} alt="팀 추가 버튼" fill className="w-auto h-auto" />
+								</div>
+							</button>
+						)
 				}
 			</div>
 		</DndContext>

--- a/src/components/common/account/favorite-team-list.tsx
+++ b/src/components/common/account/favorite-team-list.tsx
@@ -19,12 +19,14 @@ import { arrayMove } from '@dnd-kit/sortable';
 import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 
 export default function FavoriteTeamList({
+	isEditable,
 	favoriteTeamLeagueMap,
 	setFavoriteTeamLeagueMap,
 	selectedTeamIndex,
 	setSelectedTeamIndex,
 	clearSelectbox,
 }: {
+	isEditable: boolean;
 	favoriteTeamLeagueMap: (TeamLeagueMap | null)[];
 	setFavoriteTeamLeagueMap: Dispatch<SetStateAction<TeamLeagueMap[]>>;
 	selectedTeamIndex: number;
@@ -119,8 +121,10 @@ export default function FavoriteTeamList({
 							key={favorite?.team?.pk ?? -1}
 							orderNum={i + 1}
 							team={favorite?.team}
-							isActive={selectedTeamIndex === i}
+							isEditable={isEditable}
+							isActive={isEditable && selectedTeamIndex === i}
 							isDisabled={
+								!isEditable ||
 								!favorite?.team ||
 								favoriteTeamLeagueMap.length === 1 ||
 								(favoriteTeamLeagueMap.length === 2 && !favoriteTeamLeagueMap.at(-1)) ||
@@ -132,9 +136,11 @@ export default function FavoriteTeamList({
 					))}
 				</SortableContext>
 				{
+					// 수정 가능 상태에서
 					// 이전 팀 선택이 완료되고 (응원팀이 없어요 제외)
 					// 선택 팀이 3개 미만일 때 추가 버튼 표시
-					favoriteTeamLeagueMap.at(-1) !== null &&
+					isEditable &&
+						favoriteTeamLeagueMap.at(-1) !== null &&
 						favoriteTeamLeagueMap[0].team.pk !== NO_CHEERING_TEAM_PK &&
 						favoriteTeamLeagueMap.length < 3 && (
 							<button

--- a/src/components/common/account/favorite-team-section.tsx
+++ b/src/components/common/account/favorite-team-section.tsx
@@ -7,13 +7,14 @@ import { TeamDto } from '@/services/apis/team/dto';
 import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 import dynamic from 'next/dynamic';
 import FavoriteTeamItem from './favorite-team-item';
+import clsx from 'clsx';
 
 // dnd-kit 컴포넌트 hydration mismatch 가능성 존재 -> ssr 비활성화
 const FavoriteTeamList = dynamic(() => import('./favorite-team-list'), {
 	ssr: false,
 	loading: () => (
 		<div className="grid grid-cols-3 gap-2.5">
-			<FavoriteTeamItem team={null} orderNum={1} isActive={true} />
+			<FavoriteTeamItem team={null} orderNum={1} isActive={false} />
 			<div />
 			<div />
 		</div>
@@ -25,7 +26,15 @@ export interface TeamLeagueMap {
 	league: LeagueDto;
 }
 
-export default function FavoriteTeamSection({ setTeams }: { setTeams: Dispatch<SetStateAction<number[]>> }) {
+export default function FavoriteTeamSection({
+	isEditable = true,
+	setTeams,
+	initialTeams,
+}: {
+	isEditable?: boolean;
+	setTeams?: Dispatch<SetStateAction<number[]>>;
+	initialTeams?: TeamDto[];
+}) {
 	const [favoriteTeamLeagueMap, setFavoriteTeamLeagueMap] = useState<(TeamLeagueMap | null)[]>([null]);
 	const [selectedTeamIndex, setSelectedTeamIndex] = useState(0);
 	const favoriteTeamCount = favoriteTeamLeagueMap.filter((team) => team).length;
@@ -83,19 +92,36 @@ export default function FavoriteTeamSection({ setTeams }: { setTeams: Dispatch<S
 
 	// favoriteTeamLeagueMap 변경될 때마다 pk 배열을 위로 전달
 	useEffect(() => {
+		// optional인 setTeams가 undefined이면 return
+		if (!setTeams) return;
+
 		const teams = favoriteTeamLeagueMap.map((favorite) => favorite?.team?.pk);
 		setTeams(teams);
 	}, [favoriteTeamLeagueMap, setTeams]);
 
+	useEffect(() => {
+		if (initialTeams) {
+			const initialFavoriteTeamLeagueMap: TeamLeagueMap[] = initialTeams.map((team) => ({
+				league: { nameEn: '', nameKr: '', pk: 0, logoUrl: '' },
+				team,
+			}));
+			setFavoriteTeamLeagueMap(initialFavoriteTeamLeagueMap);
+		}
+	}, [initialTeams]);
+
 	return (
 		<div className="flex flex-col">
 			<div className="subtitle1-semibold mb-2">
-				MY팀 선택 (<span className="text-primary-900">{favoriteTeamCount}</span>/3)
+				MY팀 {isEditable && '선택'} (
+				<span className={clsx({ 'text-primary-900': isEditable })}>{favoriteTeamCount}</span>/3)
 			</div>
-			<div className="caption1-regular mb-6">* 최대 3순위까지 선택할 수 있으며, 프로필에는 1순위만 표기돼요.</div>
+			<div className="caption1-regular mb-6">
+				* {isEditable && '최대 3순위까지 선택할 수 있으며, '}프로필에는 1순위만 표기돼요.
+			</div>
 
 			<div className="mb-[1.125rem]">
 				<FavoriteTeamList
+					isEditable={isEditable}
 					favoriteTeamLeagueMap={favoriteTeamLeagueMap}
 					setFavoriteTeamLeagueMap={setFavoriteTeamLeagueMap}
 					selectedTeamIndex={selectedTeamIndex}
@@ -104,23 +130,25 @@ export default function FavoriteTeamSection({ setTeams }: { setTeams: Dispatch<S
 				/>
 			</div>
 
-			<div className="space-y-6">
-				<Selectbox
-					category="리그"
-					favoriteTeamLength={favoriteTeamLeagueMap.length}
-					content={league}
-					onChange={handleLeagueChange}
-				/>
-				{league && league.pk !== NO_CHEERING_TEAM_PK && (
+			{isEditable && (
+				<div className="space-y-6">
 					<Selectbox
-						category="응원팀"
-						isOpen={isDropdownOpen}
-						content={team}
-						league={league.pk}
-						onChange={handleTeamChange}
+						category="리그"
+						favoriteTeamLength={favoriteTeamLeagueMap.length}
+						content={league}
+						onChange={handleLeagueChange}
 					/>
-				)}
-			</div>
+					{league && league.pk !== NO_CHEERING_TEAM_PK && (
+						<Selectbox
+							category="응원팀"
+							isOpen={isDropdownOpen}
+							content={team}
+							league={league.pk}
+							onChange={handleTeamChange}
+						/>
+					)}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/common/account/favorite-team-section.tsx
+++ b/src/components/common/account/favorite-team-section.tsx
@@ -4,8 +4,21 @@ import { LeagueDto } from '@/services/apis/league/dto';
 import Selectbox from './selectbox';
 import { useEffect, useState } from 'react';
 import { TeamDto } from '@/services/apis/team/dto';
-import FavoriteTeamList from './favorite-team-list';
 import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
+import dynamic from 'next/dynamic';
+import FavoriteTeamItem from './favorite-team-item';
+
+// dnd-kit 컴포넌트 hydration mismatch 가능성 존재 -> ssr 비활성화
+const FavoriteTeamList = dynamic(() => import('./favorite-team-list'), {
+	ssr: false,
+	loading: () => (
+		<div className="grid grid-cols-3 gap-2.5">
+			<FavoriteTeamItem team={null} orderNum={1} isActive={true} />
+			<div />
+			<div />
+		</div>
+	),
+});
 
 export interface TeamLeagueMap {
 	team: TeamDto;
@@ -27,6 +40,23 @@ export default function FavoriteTeamSection() {
 		setTeam(selectedMap?.team ?? null);
 	}, [selectedTeamIndex, favoriteTeamLeagueMap]);
 
+	const handleLeagueChange = (selectedLeague: LeagueDto) => {
+		setLeague(selectedLeague);
+
+		// 응원팀이 없는 상태 -> 다른 리그를 선택한 경우
+		if (league?.pk === NO_CHEERING_TEAM_PK) {
+			setTeam(null);
+		}
+
+		// 응원팀이 없어요를 선택한 경우
+		if (selectedLeague.pk === NO_CHEERING_TEAM_PK) {
+			const newFavoriteTeamLeagueMap = favoriteTeamLeagueMap.map((favorite, i) =>
+				i === selectedTeamIndex ? { team: selectedLeague, league: selectedLeague } : favorite,
+			);
+			setFavoriteTeamLeagueMap(newFavoriteTeamLeagueMap);
+		}
+	};
+
 	const handleTeamChange = (selectedTeam: TeamDto) => {
 		// 이미 선택한 팀이면 alert
 		const favoriteTeamPks = favoriteTeamLeagueMap.map((favorite) => favorite?.team?.pk);
@@ -38,7 +68,6 @@ export default function FavoriteTeamSection() {
 		const newFavoriteTeamLeagueMap = favoriteTeamLeagueMap.map((favorite, i) =>
 			i === selectedTeamIndex ? { league, team: selectedTeam } : favorite,
 		);
-		console.log(newFavoriteTeamLeagueMap);
 		setFavoriteTeamLeagueMap(newFavoriteTeamLeagueMap);
 		setTeam(selectedTeam);
 	};
@@ -66,7 +95,12 @@ export default function FavoriteTeamSection() {
 			</div>
 
 			<div className="space-y-6">
-				<Selectbox category="리그" content={league} onChange={(selectedLeague) => setLeague(selectedLeague)} />
+				<Selectbox
+					category="리그"
+					favoriteTeamLength={favoriteTeamLeagueMap.length}
+					content={league}
+					onChange={handleLeagueChange}
+				/>
 				{league && league.pk !== NO_CHEERING_TEAM_PK && (
 					<Selectbox category="응원팀" content={team} league={league.pk} onChange={handleTeamChange} />
 				)}

--- a/src/components/common/account/favorite-team-section.tsx
+++ b/src/components/common/account/favorite-team-section.tsx
@@ -119,7 +119,7 @@ export default function FavoriteTeamSection({
 				* {isEditable && '최대 3순위까지 선택할 수 있으며, '}프로필에는 1순위만 표기돼요.
 			</div>
 
-			<div className="mb-[1.125rem]">
+			<div>
 				<FavoriteTeamList
 					isEditable={isEditable}
 					favoriteTeamLeagueMap={favoriteTeamLeagueMap}
@@ -131,7 +131,7 @@ export default function FavoriteTeamSection({
 			</div>
 
 			{isEditable && (
-				<div className="space-y-6">
+				<div className="space-y-6 mt-[1.125rem]">
 					<Selectbox
 						category="리그"
 						favoriteTeamLength={favoriteTeamLeagueMap.length}

--- a/src/components/common/account/favorite-team-section.tsx
+++ b/src/components/common/account/favorite-team-section.tsx
@@ -32,6 +32,7 @@ export default function FavoriteTeamSection() {
 
 	const [league, setLeague] = useState<LeagueDto | null>(null);
 	const [team, setTeam] = useState<TeamDto | null>(null);
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
 	// 다른 순위의 팀을 선택했을 때마다 실행 (ex. 1순위 팀 -> 2순위 팀)
 	useEffect(() => {
@@ -41,8 +42,6 @@ export default function FavoriteTeamSection() {
 	}, [selectedTeamIndex, favoriteTeamLeagueMap]);
 
 	const handleLeagueChange = (selectedLeague: LeagueDto) => {
-		setLeague(selectedLeague);
-
 		// 응원팀이 없는 상태 -> 다른 리그를 선택한 경우
 		if (league?.pk === NO_CHEERING_TEAM_PK) {
 			setTeam(null);
@@ -55,6 +54,9 @@ export default function FavoriteTeamSection() {
 			);
 			setFavoriteTeamLeagueMap(newFavoriteTeamLeagueMap);
 		}
+
+		setLeague(selectedLeague);
+		setIsDropdownOpen(true); // 리그 선택 시 팀 선택 드롭다운 자동 오픈
 	};
 
 	const handleTeamChange = (selectedTeam: TeamDto) => {
@@ -68,8 +70,10 @@ export default function FavoriteTeamSection() {
 		const newFavoriteTeamLeagueMap = favoriteTeamLeagueMap.map((favorite, i) =>
 			i === selectedTeamIndex ? { league, team: selectedTeam } : favorite,
 		);
+
 		setFavoriteTeamLeagueMap(newFavoriteTeamLeagueMap);
 		setTeam(selectedTeam);
+		setIsDropdownOpen(false);
 	};
 
 	const clearSelectbox = () => {
@@ -102,7 +106,13 @@ export default function FavoriteTeamSection() {
 					onChange={handleLeagueChange}
 				/>
 				{league && league.pk !== NO_CHEERING_TEAM_PK && (
-					<Selectbox category="응원팀" content={team} league={league.pk} onChange={handleTeamChange} />
+					<Selectbox
+						category="응원팀"
+						isOpen={isDropdownOpen}
+						content={team}
+						league={league.pk}
+						onChange={handleTeamChange}
+					/>
 				)}
 			</div>
 		</div>

--- a/src/components/common/account/favorite-team-section.tsx
+++ b/src/components/common/account/favorite-team-section.tsx
@@ -2,7 +2,7 @@
 
 import { LeagueDto } from '@/services/apis/league/dto';
 import Selectbox from './selectbox';
-import { useEffect, useState } from 'react';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { TeamDto } from '@/services/apis/team/dto';
 import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 import dynamic from 'next/dynamic';
@@ -25,7 +25,7 @@ export interface TeamLeagueMap {
 	league: LeagueDto;
 }
 
-export default function FavoriteTeamSection() {
+export default function FavoriteTeamSection({ setTeams }: { setTeams: Dispatch<SetStateAction<number[]>> }) {
 	const [favoriteTeamLeagueMap, setFavoriteTeamLeagueMap] = useState<(TeamLeagueMap | null)[]>([null]);
 	const [selectedTeamIndex, setSelectedTeamIndex] = useState(0);
 	const favoriteTeamCount = favoriteTeamLeagueMap.filter((team) => team).length;
@@ -80,6 +80,12 @@ export default function FavoriteTeamSection() {
 		setLeague(null);
 		setTeam(null);
 	};
+
+	// favoriteTeamLeagueMap 변경될 때마다 pk 배열을 위로 전달
+	useEffect(() => {
+		const teams = favoriteTeamLeagueMap.map((favorite) => favorite?.team?.pk);
+		setTeams(teams);
+	}, [favoriteTeamLeagueMap, setTeams]);
 
 	return (
 		<div className="flex flex-col">

--- a/src/components/common/account/selectbox.tsx
+++ b/src/components/common/account/selectbox.tsx
@@ -27,13 +27,13 @@ export default function Selectbox({
 	isEditable?: boolean;
 	isOpen?: boolean;
 }) {
-	const [isVisibleOptions, setIsVisibleOptions] = useState(isOpen);
+	const [isOptionListVisible, setIsOptionListVisible] = useState(isOpen);
 	const [options, setOptions] = useState<LeagueDto[] | TeamDto[]>([]);
 	const dropboxRef = useRef<HTMLDivElement | null>(null);
 	const isLeagueSelectBox = category === '리그';
 
 	const handleSelectBoxClick = () => {
-		setIsVisibleOptions(!isVisibleOptions);
+		setIsOptionListVisible(!isOptionListVisible);
 	};
 
 	const handleOptionClick = (selectedPk: number) => {
@@ -60,12 +60,12 @@ export default function Selectbox({
 
 		console.log(selectedOption);
 		onChange(selectedOption);
-		setIsVisibleOptions(false);
+		setIsOptionListVisible(false);
 	};
 
 	useEffect(() => {
-		// props isOpen 값 변경 시마다 isVisibleOptions에 반영
-		setIsVisibleOptions(isOpen);
+		// props isOpen 값 변경 시마다 isOptionListVisible에 반영
+		setIsOptionListVisible(isOpen);
 	}, [isOpen]);
 
 	useEffect(() => {
@@ -80,13 +80,13 @@ export default function Selectbox({
 	}, [isLeagueSelectBox, league]);
 
 	useEffect(() => {
-		// isVisibleOptions가 true일 때만 리스너 등록
-		if (!isVisibleOptions) return;
+		// isOptionListVisible가 true일 때만 리스너 등록
+		if (!isOptionListVisible) return;
 
 		// 드롭박스 외부 클릭 시 닫음
 		const handleOutsideClick = (e: MouseEvent) => {
 			if (!dropboxRef.current.contains(e.target as Node)) {
-				setIsVisibleOptions(false);
+				setIsOptionListVisible(false);
 			}
 		};
 
@@ -94,7 +94,7 @@ export default function Selectbox({
 		return () => {
 			document.removeEventListener('click', handleOutsideClick);
 		};
-	}, [isVisibleOptions]);
+	}, [isOptionListVisible]);
 
 	return (
 		<div className="flex flex-col gap-2">
@@ -121,7 +121,7 @@ export default function Selectbox({
 					)}
 				</button>
 
-				{isVisibleOptions && !!options.length && (
+				{isOptionListVisible && !!options.length && (
 					<div className="z-10 w-full top-[3.25rem] shadow-select-options border border-black-300 rounded-[0.625rem]">
 						{options.map((option, index) => (
 							<div

--- a/src/components/common/account/selectbox.tsx
+++ b/src/components/common/account/selectbox.tsx
@@ -17,6 +17,7 @@ export default function Selectbox({
 	content,
 	onChange,
 	isEditable = true,
+	isOpen = false,
 }: {
 	category: '리그' | '응원팀';
 	favoriteTeamLength?: number;
@@ -24,8 +25,9 @@ export default function Selectbox({
 	content: LeagueDto | TeamDto;
 	onChange: (selectedOption: LeagueDto | TeamDto) => void;
 	isEditable?: boolean;
+	isOpen?: boolean;
 }) {
-	const [isVisibleOptions, setIsVisibleOptions] = useState(!!(isEditable && league));
+	const [isVisibleOptions, setIsVisibleOptions] = useState(isOpen);
 	const [options, setOptions] = useState<LeagueDto[] | TeamDto[]>([]);
 	const dropboxRef = useRef<HTMLDivElement | null>(null);
 	const isLeagueSelectBox = category === '리그';
@@ -60,6 +62,11 @@ export default function Selectbox({
 		onChange(selectedOption);
 		setIsVisibleOptions(false);
 	};
+
+	useEffect(() => {
+		// props isOpen 값 변경 시마다 isVisibleOptions에 반영
+		setIsVisibleOptions(isOpen);
+	}, [isOpen]);
 
 	useEffect(() => {
 		const getOptions = async () => {

--- a/src/components/common/account/selectbox.tsx
+++ b/src/components/common/account/selectbox.tsx
@@ -12,12 +12,14 @@ import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
 
 export default function Selectbox({
 	category,
+	favoriteTeamLength,
 	league,
 	content,
 	onChange,
 	isEditable = true,
 }: {
 	category: '리그' | '응원팀';
+	favoriteTeamLength?: number;
 	league?: number;
 	content: LeagueDto | TeamDto;
 	onChange: (selectedOption: LeagueDto | TeamDto) => void;
@@ -126,7 +128,7 @@ export default function Selectbox({
 								{index < options.length - 1 && <hr className="border-black-300" />}
 							</div>
 						))}
-						{isLeagueSelectBox && (
+						{isLeagueSelectBox && favoriteTeamLength === 1 && (
 							<div
 								className="bg-black-000 hover:bg-black-150 transition-colors
 									rounded-b-[0.5625rem] border-t border-black-300"

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -9,7 +9,7 @@ import Image from 'next/image';
 export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: string; type: string }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
-	const tabs = ['전체', '인기', currentUserInfo?.favoriteTeam ? 'MY 팀' : null];
+	const tabs = ['전체', '인기', currentUserInfo?.favoriteTeams ? 'MY 팀' : null];
 	const isNews = mode === 'news';
 
 	return (
@@ -17,7 +17,7 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 			{tabs.map((tab, i) =>
 				!tab ? null : (
 					<Link
-						href={`/${mode}?q=${tab}` + (i === 2 ? `&type=team&id=${currentUserInfo?.favoriteTeam?.pk}` : '')}
+						href={`/${mode}?q=${tab}` + (i === 2 ? `&type=team&id=${currentUserInfo?.favoriteTeams[0]?.pk}` : '')}
 						key={tab}
 						className={clsx(
 							'flex px-2 @max-[350px]:px-1 py-[0.9375rem] border-b-2',
@@ -27,7 +27,7 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 						{tab}
 						{i === 2 && (
 							<Image
-								src={currentUserInfo?.favoriteTeam?.logoUrl}
+								src={currentUserInfo?.favoriteTeams[0]?.logoUrl}
 								alt="로고 이미지"
 								width={16}
 								height={16}

--- a/src/components/features/signup/nickname.tsx
+++ b/src/components/features/signup/nickname.tsx
@@ -19,7 +19,7 @@ export default function Nickname({
 
 	return (
 		<div className="flex flex-col gap-2">
-			<div className="subtitle1-medium @mobile:text-13">닉네임</div>
+			<div className="subtitle1-semibold">닉네임</div>
 			<div className="relative bg-black-000">
 				<input
 					type="text"

--- a/src/components/layouts/root/navbar/profile.tsx
+++ b/src/components/layouts/root/navbar/profile.tsx
@@ -71,10 +71,10 @@ export default function Profile({ onClickButton }: { onClickButton: () => void }
 							{currentUserInfo.nickname}
 							<span className="body2-regular text-black-800 @mobile:text-16">님</span>
 						</div>
-						{currentUserInfo.favoriteTeam && (
+						{currentUserInfo.favoriteTeams && (
 							<Image
 								className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
-								src={currentUserInfo.favoriteTeam.logoUrl}
+								src={currentUserInfo.favoriteTeams[0].logoUrl}
 								alt="팀 로고 이미지"
 								width={16}
 								height={16}
@@ -94,7 +94,7 @@ export default function Profile({ onClickButton }: { onClickButton: () => void }
 				<div className="flex flex-col gap-3 px-1.5 body4-semibold">
 					<div className="flex justify-between items-center">
 						<span className="body5-regular @mobile:text-12">
-							이번 시즌 {currentUserInfo?.favoriteTeam ? '우리 팀 내' : '전체'} 순위
+							이번 시즌 {currentUserInfo?.favoriteTeams ? '우리 팀 내' : '전체'} 순위
 						</span>
 						{extraUserInfo?.ranking || '- '}위
 					</div>

--- a/src/components/layouts/with-side/profile.tsx
+++ b/src/components/layouts/with-side/profile.tsx
@@ -105,13 +105,13 @@ export default function Profile() {
 											<div className="title5-semibold">{currentUserInfo?.nickname}</div>
 											<div className="body3-regular text-black-800">님</div>
 										</div>
-										{currentUserInfo?.favoriteTeam && (
+										{currentUserInfo?.favoriteTeams && (
 											<Image
 												className="w-4 h-4 object-contain my-auto"
 												width={16}
 												height={16}
-												src={currentUserInfo.favoriteTeam.logoUrl}
-												alt={`${currentUserInfo.favoriteTeam.nameKr || currentUserInfo.favoriteTeam.nameEn} 로고`}
+												src={currentUserInfo.favoriteTeams[0].logoUrl}
+												alt={`${currentUserInfo.favoriteTeams[0].nameKr || currentUserInfo.favoriteTeams[0].nameEn} 로고`}
 											/>
 										)}
 									</div>
@@ -136,7 +136,7 @@ export default function Profile() {
 							<div className="flex border-r border-black-200">
 								<div className="mx-auto my-[0.5625rem] text-center items-center">
 									<div className="caption2-regular h-4">
-										이번 시즌 {currentUserInfo?.favoriteTeam ? '우리 팀 내' : '전체'} 순위
+										이번 시즌 {currentUserInfo?.favoriteTeams ? '우리 팀 내' : '전체'} 순위
 									</div>
 									<div className="body4-semibold">{extraUserInfo?.ranking || '-'}위</div>
 								</div>

--- a/src/services/auth/dto.ts
+++ b/src/services/auth/dto.ts
@@ -12,7 +12,7 @@ export interface UpdatePrivacyRequest {
 export interface UpdateUserInfoRequest {
 	profileImageUrl?: string;
 	nickname: string;
-	team?: number;
+	teams?: number[];
 	league?: number;
 }
 

--- a/src/services/auth/dto.ts
+++ b/src/services/auth/dto.ts
@@ -28,7 +28,7 @@ export interface UserInfoDto {
 	providerType: string;
 	privacyAgreedAt: string;
 	marketingAgreedAt: string;
-	favoriteTeam?: TeamDto;
+	favoriteTeams?: TeamDto[];
 	league?: LeagueDto;
 }
 


### PR DESCRIPTION
## 작업 내용
**회원가입 로직 수정**
- **응원 팀이 없는 경우**에 대해 추가적으로 수정했습니다.
- **리그 선택 후 자동으로 팀 선택 드롭다운이 열리는 기능** 수정했습니다. league가 있으면 team dropdown이 바로 열리도록 해두었더니 순위 이동(1순위 -> 2순위 클릭)에서도 팀 드롭다운이 열리는 문제가 있더라고요. 이벤트 핸들러에 상태 변화 로직을 추가해 해결했습니다.
- 폰트 사이즈 수정, 간격 수정 등 세부적인 ui 조정이 있었습니다.

**프로필 설정 페이지**
- FavoriteTeamSection에 isEditable상태를 추가해 프로필 설정 페이지에서는 **isEdtable이 false이면 pointer events를 받지 않도록** 설정했습니다. 
- 그 외에 x 버튼 및 드래그 아이콘 조건부 렌더링 등 ui 처리도 있었습니다.
- **api 응답 수정**이 금방 처리돼서 해당 부분도 모두 **반영**해 두었습니다. 응원 팀이 없는 경우 favoriteTeams 응답이 빈 배열로 오는 반면, 프론트에는 favoriteTeams가 null일 것으로 예상하고 구현했기 때문에 **응원팀이 없는 계정은 여러 오류가 발생할 수 있습니다.**
- 제가 판단하기로는 응원 팀이 없을 때 favoriteTeams의 length를 매번 검사하기보다는 favoriteTeams의 값을 null로 처리하는 게 더 직관적인 것 같아 백엔드에 **수정을 문의드렸고, 답변에 따라 필요 시 수정하도록 하겠습니다.**