### PR TITLE
[KO-399] 게시글 리스트 페이지 v1.2 ui 적용

### DIFF
--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -28,13 +28,11 @@ export default function Page() {
 	const teams = useMemo(() => {
 		return [
 			{ label: '전체', value: '전체' },
-			...(currentUserInfo?.favoriteTeams
-				? currentUserInfo.favoriteTeams.map((team) => ({
-						label: team.nameKr || team.nameEn || '내 팀',
-						value: String(team.pk),
-						logo: team.logoUrl,
-					}))
-				: []),
+			...currentUserInfo.favoriteTeams.map((team) => ({
+				label: team.nameKr || team.nameEn || '내 팀',
+				value: String(team.pk),
+				logo: team.logoUrl,
+			})),
 		];
 	}, [currentUserInfo]);
 

--- a/src/app/(without-side)/profile-setting/page.tsx
+++ b/src/app/(without-side)/profile-setting/page.tsx
@@ -104,9 +104,9 @@ export default function Page() {
 				setProfileImageUrl(response.data.profileImageUrl);
 				setNickname(response.data.nickname);
 				setTeams(
-					response.data.favoriteTeams ?? [
-						{ nameEn: 'no cheering team', nameKr: '응원팀이 없어요.', pk: -1, logoUrl: '/ban.svg' },
-					],
+					response.data.favoriteTeams.length > 0
+						? response.data.favoriteTeams
+						: [{ nameEn: 'no cheering team', nameKr: '응원팀이 없어요.', pk: -1, logoUrl: '/ban.svg' }],
 				);
 			}
 		};

--- a/src/components/common/category-tab/category-tab.tsx
+++ b/src/components/common/category-tab/category-tab.tsx
@@ -59,7 +59,7 @@ export default async function CategoryTab({
 
 	return (
 		<div className="flex flex-col overflow-hidden">
-			<TabBar mode={mode} q={q} type={type} />
+			<TabBar mode={mode} q={q} type={type} id={id} />
 			{!isNews && <CommunityDivisionBar />}
 			{!response ? (
 				<FetchingFailedCard height="770px" marginTop="9.5rem" />

--- a/src/components/common/category-tab/category-tab.tsx
+++ b/src/components/common/category-tab/category-tab.tsx
@@ -66,7 +66,7 @@ export default async function CategoryTab({
 			) : !response.data.length ? (
 				<EmptyState isNews={isNews} />
 			) : (
-				<div className="flex flex-col w-full pb-10 @mobile:pb-0">
+				<div className="flex flex-col w-full">
 					{renderItems(response.data, isNews ? NewsItem : CommunityItem)}
 					<MoreList {...moreListProps} />
 					<PaginationBar totalPages={response.meta.totalPages} baseUrl={`/${mode}`} />

--- a/src/components/common/category-tab/category-tab.tsx
+++ b/src/components/common/category-tab/category-tab.tsx
@@ -58,7 +58,7 @@ export default async function CategoryTab({
 		: null;
 
 	return (
-		<div className="flex flex-col w-full @mobile:w-[calc(100vw-34px)] overflow-hidden">
+		<div className="flex flex-col overflow-hidden">
 			<TabBar mode={mode} q={q} type={type} />
 			{!isNews && <CommunityDivisionBar />}
 			{!response ? (

--- a/src/components/common/category-tab/category-tab.tsx
+++ b/src/components/common/category-tab/category-tab.tsx
@@ -58,7 +58,7 @@ export default async function CategoryTab({
 		: null;
 
 	return (
-		<div className="flex flex-col w-full @mobile:w-[calc(100vw-34px)]">
+		<div className="flex flex-col w-full @mobile:w-[calc(100vw-34px)] overflow-hidden">
 			<TabBar mode={mode} q={q} type={type} />
 			{!isNews && <CommunityDivisionBar />}
 			{!response ? (

--- a/src/components/common/category-tab/community-item.tsx
+++ b/src/components/common/category-tab/community-item.tsx
@@ -8,11 +8,11 @@ export default function CommunityItem({ pk, title, replies, user, createdAt, has
 		<Link
 			href={`/board/${pk}`}
 			className="p-4 flex justify-between cursor-pointer
-				@mobile:flex-col @mobile:gap-3"
+				@mobile:flex-col @mobile:gap-3 group"
 		>
 			<div className="flex gap-1 items-center pr-2">
 				<h2
-					className="subtitle1-medium max-w-3xs truncate
+					className="subtitle1-medium max-w-3xs truncate group-hover:underline
 					@mobile:max-w-max @mobile:w-fit @mobile:text-15 @mobile:font-medium @mobile:leading-4"
 				>
 					{title}

--- a/src/components/common/category-tab/news-item.tsx
+++ b/src/components/common/category-tab/news-item.tsx
@@ -21,7 +21,7 @@ export default function NewsItem({
 }: NewsItemDto & { isMyTeam?: boolean }) {
 	return (
 		<Link href={`/news/${pk}`}>
-			<article className="flex flex-col py-6 px-4 cursor-pointer">
+			<article className="flex flex-col my-2 py-4 px-4 cursor-pointer">
 				<header className="flex gap-2 mb-2.5 items-center">
 					{team && !isMyTeam && (
 						<Image

--- a/src/components/common/category-tab/news-item.tsx
+++ b/src/components/common/category-tab/news-item.tsx
@@ -20,7 +20,7 @@ export default function NewsItem({
 	isMyTeam = false,
 }: NewsItemDto & { isMyTeam?: boolean }) {
 	return (
-		<Link href={`/news/${pk}`}>
+		<Link href={`/news/${pk}`} className="group">
 			<article className="flex flex-col my-2 py-4 px-4 cursor-pointer">
 				<header className="flex gap-2 mb-2.5 items-center">
 					{team && !isMyTeam && (
@@ -38,7 +38,7 @@ export default function NewsItem({
 				<section className={clsx('flex justify-between @mobile:flex-col-reverse @mobile:gap-4')}>
 					<div className={'w-[28rem] @mobile:grow @mobile:w-auto'}>
 						<h2
-							className="title3-semibold mb-2 pr-2 truncate
+							className="title3-semibold mb-2 pr-2 truncate group-hover:underline
 								@mobile:text-16 @mobile:font-semibold @mobile:leading-4"
 						>
 							{title}

--- a/src/components/common/category-tab/select-box.tsx
+++ b/src/components/common/category-tab/select-box.tsx
@@ -7,6 +7,7 @@ import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
 import { LeagueDto } from '@/services/apis/league/dto';
 import { getLeague } from '@/services/apis/league';
+import useIsMobile from '@/lib/hooks/useIsMobile';
 
 export default function Selectbox({
 	q,
@@ -20,8 +21,11 @@ export default function Selectbox({
 	const [isVisibleOptions, setIsVisibleOptions] = useState(false);
 	const [options, setOptions] = useState<LeagueDto[] | null>(null);
 	const [league, setLeague] = useState<LeagueDto | null>(null);
+
 	const dropboxRef = useRef<HTMLDivElement | null>(null);
-	const route = useRouter();
+	const router = useRouter();
+
+	const isMobile = useIsMobile();
 
 	const handleSelectBoxClick = () => {
 		setIsVisibleOptions(!isVisibleOptions);
@@ -31,10 +35,10 @@ export default function Selectbox({
 		if (league?.pk === selectedPk) return;
 
 		const selectedLeague = options.find((option) => option.pk === selectedPk);
+
+		router.push(`/news?q=${selectedLeague.nameKr}&type=league&id=${selectedLeague.pk}`);
 		setLeague(selectedLeague);
 		setIsVisibleOptions(false);
-
-		route.push(`/news?q=${selectedLeague.nameKr}&type=league&id=${selectedLeague.pk}`);
 	};
 
 	useEffect(() => {
@@ -52,15 +56,11 @@ export default function Selectbox({
 	}, []);
 
 	useEffect(() => {
-		if (type === 'league' && q) {
-			setLeague({
-				nameKr: q,
-				nameEn: q,
-				pk: -1,
-				logoUrl: '',
-			});
+		if (type === 'league' && q && options) {
+			const selectedLeague = options.find((option) => option.nameKr === q);
+			setLeague(selectedLeague);
 		}
-	}, [type, q]);
+	}, [type, q, options]);
 
 	useEffect(() => {
 		// isVisibleOptions가 true일 때만 리스너 등록
@@ -85,23 +85,34 @@ export default function Selectbox({
 		}
 	}, [isClickedOtherTab]);
 
+	if (isMobile === null) return;
+
 	return (
-		<div ref={dropboxRef} className="relative flex justify-center">
+		<div ref={dropboxRef} className="relative grow">
 			<button
 				onClick={handleSelectBoxClick}
 				className={clsx(
-					`flex items-center gap-2 min-w-[5.625rem] pl-4 pr-1.5 pt-[1.0625rem] pb-[0.9375rem] rounded-t-[0.625rem]`,
+					`flex items-center justify-center gap-2 h-full min-w-[5.625rem] @mobile:w-full
+					pl-4 @mobile:pl-3 pr-1.5 rounded-t-[0.625rem]`,
 					isClickedOtherTab
-						? 'hover:text-black-900 text-black-800'
+						? 'hover:text-black-900 text-black-700'
 						: 'bg-black-000 shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)] header-semibold text-primary-900',
 				)}
 			>
-				<div>{!league ? '리그 선택' : league.nameKr || league.nameEn}</div>
+				{isMobile ? (
+					league ? (
+						<Image className="w-8 h-8 object-contain" src={league.logoUrl} alt="로고" width={32} height={32} />
+					) : (
+						<div>리그 선택</div>
+					)
+				) : (
+					<div>{!league ? '리그 선택' : league.nameKr || league.nameEn}</div>
+				)}
 				<Image width={16} height={16} src="/chevron/down.svg" alt="리그 선택" />
 			</button>
 			{isVisibleOptions && (
 				<div
-					className="absolute z-10 w-[12.5rem] top-13 left-0 @mobile:w-max @mobile:right-0
+					className="absolute z-10 w-[12.5rem] top-13 @not-mobile:left-0 @mobile:right-4 @mobile:w-max
 						shadow-select-options border border-black-200 rounded-[0.625rem]"
 				>
 					{!options

--- a/src/components/common/category-tab/select-box.tsx
+++ b/src/components/common/category-tab/select-box.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation';
 import { LeagueDto } from '@/services/apis/league/dto';
 import { getLeague } from '@/services/apis/league';
 
-export default function SelectBox({
+export default function Selectbox({
 	q,
 	type,
 	isClickedOtherTab = false,
@@ -86,21 +86,22 @@ export default function SelectBox({
 	}, [isClickedOtherTab]);
 
 	return (
-		<div ref={dropboxRef} className="relative w-fit">
-			<button onClick={handleSelectBoxClick} className="flex items-center">
-				<div
-					className={clsx(
-						'border-b-2 py-[0.9375rem] px-2 @max-[350px]:px-1',
-						isClickedOtherTab ? 'border-transparent' : 'border-primary-900 text-primary-900 header-semibold',
-					)}
-				>
-					{!league ? '리그 선택' : league.nameKr || league.nameEn}
-				</div>
+		<div ref={dropboxRef} className="relative flex justify-center">
+			<button
+				onClick={handleSelectBoxClick}
+				className={clsx(
+					`flex items-center gap-2 min-w-[5.625rem] pl-4 pr-1.5 pt-[1.0625rem] pb-[0.9375rem] rounded-t-[0.625rem]`,
+					isClickedOtherTab
+						? 'hover:text-black-900 text-black-800'
+						: 'bg-black-000 shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)] header-semibold text-primary-900',
+				)}
+			>
+				<div>{!league ? '리그 선택' : league.nameKr || league.nameEn}</div>
 				<Image width={16} height={16} src="/chevron/down.svg" alt="리그 선택" />
 			</button>
 			{isVisibleOptions && (
 				<div
-					className="absolute z-10 w-[12.5rem] top-[2.5625rem] @mobile:w-max @mobile:right-0
+					className="absolute z-10 w-[12.5rem] top-13 left-0 @mobile:w-max @mobile:right-0
 						shadow-select-options border border-black-200 rounded-[0.625rem]"
 				>
 					{!options

--- a/src/components/common/category-tab/select-box.tsx
+++ b/src/components/common/category-tab/select-box.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import OptionItem from '../option-item';
 import clsx from 'clsx';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { LeagueDto } from '@/services/apis/league/dto';
 import { getLeague } from '@/services/apis/league';
 import useIsMobile from '@/lib/hooks/useIsMobile';
@@ -23,6 +23,7 @@ export default function Selectbox({
 	const [league, setLeague] = useState<LeagueDto | null>(null);
 
 	const dropboxRef = useRef<HTMLDivElement | null>(null);
+	const pathname = usePathname();
 	const router = useRouter();
 
 	const isMobile = useIsMobile();
@@ -36,7 +37,7 @@ export default function Selectbox({
 
 		const selectedLeague = options.find((option) => option.pk === selectedPk);
 
-		router.push(`/news?q=${selectedLeague.nameKr}&type=league&id=${selectedLeague.pk}`);
+		router.push(`${pathname}?q=${selectedLeague.nameKr}&type=league&id=${selectedLeague.pk}`);
 		setLeague(selectedLeague);
 		setIsVisibleOptions(false);
 	};

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -44,7 +44,7 @@ export default function TabBar({ mode, q, type, id }: { mode: 'news' | 'board'; 
 							{i === 2 && (
 								<Image
 									src={
-										id
+										type === 'team'
 											? currentUserInfo?.favoriteTeams.find((team) => id === String(team.pk))?.logoUrl
 											: currentUserInfo?.favoriteTeams[0].logoUrl
 									}

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import clsx from 'clsx';
-import SelectBox from './select-box';
+import Selectbox from './select-box';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import Image from 'next/image';
 
@@ -13,33 +13,46 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 	const isNews = mode === 'news';
 
 	return (
-		<div className="flex gap-3 pt-[0.9375rem] @mobile:pt-2 pl-4 header-medium border-b border-black-300">
+		<div
+			className="relative flex rounded-t-[0.625rem] bg-black-200 header-medium
+				before:content-[''] before:absolute before:-top-1 before:-left-1 before:bottom-0 before:-right-1
+				before:inset-shadow-[0px_-2px_4px_0px_rgba(0,0,0,0.10)]
+				after:content-[''] after:absolute after:-bottom-4 after:left-0 after:right-0
+				after:h-4 after:bg-black-000"
+		>
 			{tabs.map((tab, i) =>
 				!tab ? null : (
 					<Link
 						href={`/${mode}?q=${tab}` + (i === 2 ? `&type=team&id=${currentUserInfo?.favoriteTeams[0]?.pk}` : '')}
 						key={tab}
 						className={clsx(
-							'flex px-2 @max-[350px]:px-1 py-[0.9375rem] border-b-2',
-							q === tab ? 'border-primary-900 text-primary-900 header-semibold' : 'border-transparent',
+							`relative flex pt-[1.0625rem] pb-[0.9375rem] rounded-t-[0.625rem]
+							w-[5.625rem] justify-center @mobile:w-auto before:rounded-t-[0.625rem]
+							before:content-[''] before:absolute before:top-0 before:left-0 before:bottom-0 before:right-0
+							before:bg-black-000 before:shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)]`,
+							q === tab
+								? 'before:block header-semibold text-primary-900'
+								: 'before:hidden text-black-700 hover:text-black-900 ',
 						)}
 					>
-						{tab}
+						<div className="relative z-20">{tab}</div>
 						{i === 2 && (
 							<Image
 								src={currentUserInfo?.favoriteTeams[0]?.logoUrl}
 								alt="로고 이미지"
 								width={16}
 								height={16}
-								className="w-4 h-4 ml-0.5 object-contain"
+								className="w-4 h-4 ml-0.5 object-contain relative z-20"
 							/>
 						)}
 					</Link>
 				),
 			)}
+
+			{/* 리그 선택 */}
 			{isNews && (
 				<div>
-					<SelectBox q={q} type={type} isClickedOtherTab={tabs.includes(q)} />
+					<Selectbox q={q} type={type} isClickedOtherTab={tabs.includes(q)} />
 				</div>
 			)}
 		</div>

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -43,7 +43,11 @@ export default function TabBar({ mode, q, type, id }: { mode: 'news' | 'board'; 
 							<div className="relative z-20">{tab}</div>
 							{i === 2 && (
 								<Image
-									src={currentUserInfo?.favoriteTeams.find((team) => id === String(team.pk))?.logoUrl}
+									src={
+										id
+											? currentUserInfo?.favoriteTeams.find((team) => id === String(team.pk))?.logoUrl
+											: currentUserInfo?.favoriteTeams[0].logoUrl
+									}
 									alt="로고 이미지"
 									width={16}
 									height={16}

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import Selectbox from './select-box';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import Image from 'next/image';
+import { Suspense } from 'react';
 
 export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: string; type: string }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
@@ -14,7 +15,8 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 
 	return (
 		<div
-			className="relative flex rounded-t-[0.625rem] bg-black-200 header-medium
+			className="relative w-full flex rounded-t-[0.625rem] bg-black-200 header-medium
+				@mobile:grid @mobile:grid-cols-[1fr_1fr_1fr_clamp(100px,30vw,150px)]
 				before:content-[''] before:absolute before:-top-1 before:-left-1 before:bottom-0 before:-right-1
 				before:inset-shadow-[0px_-2px_4px_0px_rgba(0,0,0,0.10)]
 				after:content-[''] after:absolute after:-bottom-4 after:left-0 after:right-0
@@ -27,7 +29,7 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 						key={tab}
 						className={clsx(
 							`relative flex pt-[1.0625rem] pb-[0.9375rem] rounded-t-[0.625rem]
-							w-[5.625rem] justify-center @mobile:w-auto before:rounded-t-[0.625rem]
+							w-[5.625rem] @mobile:w-full justify-center before:rounded-t-[0.625rem]
 							before:content-[''] before:absolute before:top-0 before:left-0 before:bottom-0 before:right-0
 							before:bg-black-000 before:shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)]`,
 							q === tab
@@ -51,9 +53,9 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 
 			{/* 리그 선택 */}
 			{isNews && (
-				<div>
+				<Suspense>
 					<Selectbox q={q} type={type} isClickedOtherTab={tabs.includes(q)} />
-				</div>
+				</Suspense>
 			)}
 		</div>
 	);

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -11,7 +11,7 @@ import TeamBar from './team-bar';
 export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: string; type: string }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
-	const tabs = ['전체', '인기', currentUserInfo?.favoriteTeams ? 'MY 팀' : null];
+	const tabs = ['전체', '인기', currentUserInfo?.favoriteTeams.length > 0 ? 'MY 팀' : null];
 	const isNews = mode === 'news';
 
 	return (
@@ -62,7 +62,7 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 				)}
 			</div>
 
-			{/* 팀 선택 바 */}
+			{/* 팀 선택 바 - 응원팀이 2개 이상일 때 */}
 			{type === 'team' && currentUserInfo?.favoriteTeams?.length > 1 && <TeamBar />}
 		</div>
 	);

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -6,6 +6,7 @@ import Selectbox from './select-box';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import Image from 'next/image';
 import { Suspense } from 'react';
+import TeamBar from './team-bar';
 
 export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: string; type: string }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
@@ -14,49 +15,55 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 	const isNews = mode === 'news';
 
 	return (
-		<div
-			className="relative w-full flex rounded-t-[0.625rem] bg-black-200 header-medium
+		<div>
+			{/* 탭 바 */}
+			<div
+				className="relative w-full flex rounded-t-[0.625rem] bg-black-200 header-medium
 				@mobile:grid @mobile:grid-cols-[1fr_1fr_1fr_clamp(100px,30vw,150px)]
 				before:content-[''] before:absolute before:-top-1 before:-left-1 before:bottom-0 before:-right-1
 				before:inset-shadow-[0px_-2px_4px_0px_rgba(0,0,0,0.10)]
 				after:content-[''] after:absolute after:-bottom-4 after:left-0 after:right-0
 				after:h-4 after:bg-black-000"
-		>
-			{tabs.map((tab, i) =>
-				!tab ? null : (
-					<Link
-						href={`/${mode}?q=${tab}` + (i === 2 ? `&type=team&id=${currentUserInfo?.favoriteTeams[0]?.pk}` : '')}
-						key={tab}
-						className={clsx(
-							`relative flex pt-[1.0625rem] pb-[0.9375rem] rounded-t-[0.625rem]
+			>
+				{tabs.map((tab, i) =>
+					!tab ? null : (
+						<Link
+							href={`/${mode}?q=${tab}` + (i === 2 ? `&type=team&id=${currentUserInfo?.favoriteTeams[0]?.pk}` : '')}
+							key={tab}
+							className={clsx(
+								`relative flex pt-[1.0625rem] pb-[0.9375rem] rounded-t-[0.625rem]
 							w-[5.625rem] @mobile:w-full justify-center before:rounded-t-[0.625rem]
 							before:content-[''] before:absolute before:top-0 before:left-0 before:bottom-0 before:right-0
 							before:bg-black-000 before:shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)]`,
-							q === tab
-								? 'before:block header-semibold text-primary-900'
-								: 'before:hidden text-black-700 hover:text-black-900 ',
-						)}
-					>
-						<div className="relative z-20">{tab}</div>
-						{i === 2 && (
-							<Image
-								src={currentUserInfo?.favoriteTeams[0]?.logoUrl}
-								alt="로고 이미지"
-								width={16}
-								height={16}
-								className="w-4 h-4 ml-0.5 object-contain relative z-20"
-							/>
-						)}
-					</Link>
-				),
-			)}
+								q === tab
+									? 'before:block header-semibold text-primary-900'
+									: 'before:hidden text-black-700 hover:text-black-900 ',
+							)}
+						>
+							<div className="relative z-20">{tab}</div>
+							{i === 2 && (
+								<Image
+									src={currentUserInfo?.favoriteTeams[0]?.logoUrl}
+									alt="로고 이미지"
+									width={16}
+									height={16}
+									className="w-4 h-4 ml-0.5 object-contain relative z-20"
+								/>
+							)}
+						</Link>
+					),
+				)}
 
-			{/* 리그 선택 */}
-			{isNews && (
-				<Suspense>
-					<Selectbox q={q} type={type} isClickedOtherTab={tabs.includes(q)} />
-				</Suspense>
-			)}
+				{/* 리그 선택 */}
+				{isNews && (
+					<Suspense>
+						<Selectbox q={q} type={type} isClickedOtherTab={type !== 'league'} />
+					</Suspense>
+				)}
+			</div>
+
+			{/* 팀 선택 바 */}
+			{type === 'team' && currentUserInfo?.favoriteTeams?.length > 1 && <TeamBar />}
 		</div>
 	);
 }

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -8,7 +8,7 @@ import Image from 'next/image';
 import { Suspense } from 'react';
 import TeamBar from './team-bar';
 
-export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: string; type: string }) {
+export default function TabBar({ mode, q, type, id }: { mode: 'news' | 'board'; q: string; type: string; id: string }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
 	const tabs = ['전체', '인기', currentUserInfo?.favoriteTeams.length > 0 ? 'MY 팀' : null];
@@ -43,7 +43,7 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 							<div className="relative z-20">{tab}</div>
 							{i === 2 && (
 								<Image
-									src={currentUserInfo?.favoriteTeams[0]?.logoUrl}
+									src={currentUserInfo?.favoriteTeams.find((team) => id === String(team.pk))?.logoUrl}
 									alt="로고 이미지"
 									width={16}
 									height={16}
@@ -63,7 +63,7 @@ export default function TabBar({ mode, q, type }: { mode: 'news' | 'board'; q: s
 			</div>
 
 			{/* 팀 선택 바 - 응원팀이 2개 이상일 때 */}
-			{type === 'team' && currentUserInfo?.favoriteTeams?.length > 1 && <TeamBar />}
+			<Suspense>{type === 'team' && currentUserInfo?.favoriteTeams?.length > 1 && <TeamBar />}</Suspense>
 		</div>
 	);
 }

--- a/src/components/common/category-tab/team-bar.tsx
+++ b/src/components/common/category-tab/team-bar.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 export default function TeamBar() {
 	const pathname = usePathname();
+	const searchParams = useSearchParams();
+	const id = searchParams.get('id');
 
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const teams = currentUserInfo?.favoriteTeams;
@@ -15,11 +18,16 @@ export default function TeamBar() {
 
 	return (
 		<>
-			<div className="mt-5 mb-3 mx-4 @mobile:mx-0 flex gap-1.5 items-center text-black-400 subtitle1-medium">
+			<div className="mt-5 mb-3 mx-4 @mobile:mx-0 flex items-center subtitle1-medium">
 				{teams.map((team, i) => (
-					<>
+					<div
+						key={team.pk}
+						className={clsx(
+							'flex items-center',
+							id === String(team.pk) ? 'font-semibold text-primary-900' : 'text-black-400',
+						)}
+					>
 						<Link
-							key={team.pk}
 							href={`${pathname}?q=MY 팀&type=team&id=${team.pk}`}
 							className="px-3 py-1.5 flex gap-0.5 items-center"
 						>
@@ -32,8 +40,8 @@ export default function TeamBar() {
 							/>
 							{team.nameKr || team.nameEn}
 						</Link>
-						{i < teams.length - 1 && <div className="h-3 w-[1px] rounded-full bg-black-600" />}
-					</>
+						{i < teams.length - 1 && <div className="h-3 w-[1px] mx-1.5 rounded-full bg-black-600" />}
+					</div>
 				))}
 			</div>
 			<hr className="mx-4 mb-1.5 w-auto border-black-200" />

--- a/src/components/common/category-tab/team-bar.tsx
+++ b/src/components/common/category-tab/team-bar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+export default function TeamBar() {
+	const pathname = usePathname();
+
+	const { currentUserInfo } = useCurrentUserInfoStore();
+	const teams = currentUserInfo?.favoriteTeams;
+
+	if (!teams) return;
+
+	return (
+		<>
+			<div className="mt-5 mb-3 mx-4 @mobile:mx-0 flex gap-1.5 items-center text-black-400 subtitle1-medium">
+				{teams.map((team, i) => (
+					<>
+						<Link
+							key={team.pk}
+							href={`${pathname}?q=MY 팀&type=team&id=${team.pk}`}
+							className="px-3 py-1.5 flex gap-0.5 items-center"
+						>
+							<Image
+								src={team.logoUrl}
+								alt={`${team.nameKr} 로고`}
+								width={20}
+								height={20}
+								className="w-5 h-5 object-contain"
+							/>
+							{team.nameKr || team.nameEn}
+						</Link>
+						{i < teams.length - 1 && <div className="h-3 w-[1px] rounded-full bg-black-600" />}
+					</>
+				))}
+			</div>
+			<hr className="mx-4 mb-1.5 w-auto border-black-200" />
+		</>
+	);
+}

--- a/src/components/common/category-tab/team-bar.tsx
+++ b/src/components/common/category-tab/team-bar.tsx
@@ -11,7 +11,7 @@ export default function TeamBar() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const teams = currentUserInfo?.favoriteTeams;
 
-	if (!teams) return;
+	if (teams.length === 0) return;
 
 	return (
 		<>

--- a/src/components/common/pagination-bar.tsx
+++ b/src/components/common/pagination-bar.tsx
@@ -31,7 +31,7 @@ export default function PaginationBar({ totalPages, baseUrl }: { totalPages: num
 	const isLastGroup = endPage === totalPages;
 
 	return (
-		<div className="flex gap-3 body6-regular items-center mx-auto @mobile:hidden">
+		<div className="flex gap-3 body6-regular items-center mx-auto my-10 @mobile:hidden">
 			{/* 이전 그룹 버튼 */}
 			<button
 				onClick={() => handlePageClick(startPage - 1)}

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -275,7 +275,7 @@ function CommentSection({
 	};
 
 	return (
-		<div className="px-4 mb-4">
+		<div className="px-4">
 			{isCommentAllowed && (
 				<CommentInput
 					contentType={type}
@@ -327,7 +327,7 @@ function CommentSection({
 							</div>
 						)
 					) : (
-						<div className="flex justify-center mt-10">
+						<div className="flex justify-center">
 							<PaginationBar totalPages={totalPages} baseUrl={baseUrl} />
 						</div>
 					)}

--- a/src/components/layouts/root/navbar/profile.tsx
+++ b/src/components/layouts/root/navbar/profile.tsx
@@ -71,7 +71,7 @@ export default function Profile({ onClickButton }: { onClickButton: () => void }
 							{currentUserInfo.nickname}
 							<span className="body2-regular text-black-800 @mobile:text-16">님</span>
 						</div>
-						{currentUserInfo.favoriteTeams && (
+						{currentUserInfo.favoriteTeams.length > 0 && (
 							<Image
 								className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
 								src={currentUserInfo.favoriteTeams[0].logoUrl}

--- a/src/components/layouts/root/navbar/profile.tsx
+++ b/src/components/layouts/root/navbar/profile.tsx
@@ -93,9 +93,7 @@ export default function Profile({ onClickButton }: { onClickButton: () => void }
 
 				<div className="flex flex-col gap-3 px-1.5 body4-semibold">
 					<div className="flex justify-between items-center">
-						<span className="body5-regular @mobile:text-12">
-							이번 시즌 {currentUserInfo?.favoriteTeams ? '우리 팀 내' : '전체'} 순위
-						</span>
+						<span className="body5-regular @mobile:text-12">이번 시즌 전체 순위</span>
 						{extraUserInfo?.ranking || '- '}위
 					</div>
 					<div className="flex justify-between items-center">

--- a/src/components/layouts/with-side/profile.tsx
+++ b/src/components/layouts/with-side/profile.tsx
@@ -135,9 +135,7 @@ export default function Profile() {
 						<div className="grid grid-cols-2">
 							<div className="flex border-r border-black-200">
 								<div className="mx-auto my-[0.5625rem] text-center items-center">
-									<div className="caption2-regular h-4">
-										이번 시즌 {currentUserInfo?.favoriteTeams ? '우리 팀 내' : '전체'} 순위
-									</div>
+									<div className="caption2-regular h-4">이번 시즌 전체 순위</div>
 									<div className="body4-semibold">{extraUserInfo?.ranking || '-'}위</div>
 								</div>
 							</div>

--- a/src/components/layouts/with-side/profile.tsx
+++ b/src/components/layouts/with-side/profile.tsx
@@ -105,7 +105,7 @@ export default function Profile() {
 											<div className="title5-semibold">{currentUserInfo?.nickname}</div>
 											<div className="body3-regular text-black-800">님</div>
 										</div>
-										{currentUserInfo?.favoriteTeams && (
+										{currentUserInfo?.favoriteTeams.length > 0 && (
 											<Image
 												className="w-4 h-4 object-contain my-auto"
 												width={16}


### PR DESCRIPTION
## 작업 내용
- 전체적으로 게시글 리스트 페이지 ui가 변경되어 적용했습니다.
- shadow는 bottom에만 제한적으로 거는 등의 세부 조정이 안 되기 때문에 **before/after 가상 요소를 사용해 필요한 shadow만 렌더링**할 수 있도록 구현했습니다.
- 모바일에서 **리그 로고를 렌더링**해야 했기 때문에 기존 리그 선택 시 logoUrl을 ''로 설정하던 로직을 수정했습니다.
- 모바일에서는 리그 선택 탭 우측에 애매한 **여백이 남지 않도록 clamp 사용해서 반응형 구현**했습니다.
- 유저가 선택한 **응원팀이 2개 이상일 때에 MY 팀 탭 아래에 팀 선택 바**가 나타나도록 구현했습니다.

**기타 수정 사항**
- 페이지네이션바 상/하 여백이 게시글 리스트와 댓글 영역에 유시하게 적용되어 있어서(게시글 - 38/40, 댓글 - 40/42) **페이지네이션바 자체에 `my-10` 적용하고, 개별적으로 적용한 여백 스타일 제거**했습니다.
- 최근에 데스크톱에서 clickable item 사이에 여백을 조금 주는 게 오히려 더 ux를 높인다는 관점에 대해 들은 바가 있어서 뉴스 아이템에 적용된 상하 패딩 일부를 마진으로 변경했습니다.
- hover 시 뉴스/커뮤니티 아이템에 underline 추가됐습니다!