### PR TITLE
[KO-408] 승부예측 팀 선택 여러개 가능하게 수정

### DIFF
--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import RecommendedContent from '@/components/common/recommended-content';
-import PredictCardList from '@/components/features/home/predict-card-list';
+import PredictLeagueTab from '@/components/features/home/predict-league-tab';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { Suspense, useEffect } from 'react';
 
@@ -19,7 +19,7 @@ export default function Home() {
 	return (
 		<div className="flex flex-col gap-4">
 			{/* 승부 예측 */}
-			<PredictCardList />
+			<PredictLeagueTab />
 
 			{/* 추천 뉴스 및 게시글 */}
 			<Suspense>

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -50,44 +50,49 @@ export default function Home() {
 	}, []);
 
 	return (
-		<div className="flex flex-col gap-8 @mobile:gap-5">
-			{/* 예측 진행 중 경기 */}
-			{/* 예측 진행 중 경기와 예측 종료 경기가 모두 없는 경우 null */}
-			{!(isProceedingGamesEmpty && isFinishedGamesEmpty) && (
-				<div className="flex flex-col gap-4">
-					{!proceedingGames ? (
-						// 데이터 페칭에 실패한 경우 fetching failed card
-						<div className="bg-black-000 rounded-[0.625rem] flex flex-col px-4 py-[1.375rem] ">
-							<FetchingFailedCard
-								onClick={() => getGamesByStatus('proceeding')}
-								isCardVisible={false}
-								height="8.25rem"
-								marginTop="0"
-							/>
-						</div>
-					) : // 예측 진행 중 경기가 없고, 예측 종료 경기는 있는 경우 no game card
-					isProceedingGamesEmpty && !isFinishedGamesEmpty ? (
-						<NoGameCard />
-					) : (
-						// 그 외에 정상적으로 predict card 렌더링
-						proceedingGames.games.map((game) => (
-							<PredictCard
-								key={game.pk}
-								type={'proceeding'}
-								leagueName={proceedingGames.league.nameKr || proceedingGames.league.nameEn}
-								refetchGames={() => getGamesByStatus('proceeding')}
-								game={game}
-							/>
-						))
-					)}
-				</div>
-			)}
+		<div className="flex flex-col gap-4">
+			{/* 승부예측 */}
+			<div className="flex flex-col gap-8">
+				{/* 예측 진행 중 경기 */}
+				{/* 예측 진행 중 경기와 예측 종료 경기가 모두 없는 경우 null */}
+				{!(isProceedingGamesEmpty && isFinishedGamesEmpty) && (
+					<div className="flex flex-col gap-4">
+						{!proceedingGames ? (
+							// 데이터 페칭에 실패한 경우 fetching failed card
+							<div className="bg-black-000 rounded-[0.625rem] flex flex-col px-4 py-[1.375rem] ">
+								<FetchingFailedCard
+									onClick={() => getGamesByStatus('proceeding')}
+									isCardVisible={false}
+									height="8.25rem"
+									marginTop="0"
+								/>
+							</div>
+						) : // 예측 진행 중 경기가 없고, 예측 종료 경기는 있는 경우 no game card
+						isProceedingGamesEmpty && !isFinishedGamesEmpty ? (
+							<NoGameCard />
+						) : (
+							// 그 외에 정상적으로 predict card 렌더링
+							<div>
+								{proceedingGames.games.map((game, i) => (
+									<div key={game.pk}>
+										<PredictCard
+											type={'proceeding'}
+											leagueName={proceedingGames.league.nameKr || proceedingGames.league.nameEn}
+											refetchGames={() => getGamesByStatus('proceeding')}
+											game={game}
+										/>
+										{i !== proceedingGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
+									</div>
+								))}
+							</div>
+						)}
+					</div>
+				)}
 
-			{/* 예측 종료 경기가 정상적으로 렌더링될 때에만 구분선 렌더링 */}
-			{finishedGames && finishedGames.games.length > 0 && <hr className="mx-6 @mobile:mx-4 border-black-600" />}
+				{/* 예측 종료 경기가 정상적으로 렌더링될 때에만 구분선 렌더링 */}
+				{finishedGames && finishedGames.games.length > 0 && <hr className="mx-6 @mobile:mx-4 border-black-300" />}
 
-			{/* 예측 종료 경기 */}
-			<div className="flex flex-col gap-4">
+				{/* 예측 종료 경기 */}
 				{!finishedGames ? (
 					// 데이터 페칭에 실패한 경우 fetching failed card
 					<div className="bg-black-000 rounded-[0.625rem] flex flex-col px-4 py-[1.375rem] ">
@@ -103,28 +108,31 @@ export default function Home() {
 					<NoGameCard />
 				) : (
 					//  그 외 정상적으로 predict card 렌더링
-					finishedGames.games.map((game) => (
-						<PredictCard
-							key={game.pk}
-							type={'finished'}
-							leagueName={finishedGames.league.nameKr || finishedGames.league.nameEn}
-							game={game}
-						/>
-					))
-				)}
 
-				{/* 추천 뉴스 및 게시글 */}
-				<Suspense>
-					<RecommendedContent
-						mode={'news'}
-						teamLogo={currentUserInfo?.favoriteTeams[0]?.logoUrl}
-						teamName={
-							currentUserInfo?.favoriteTeams[0]?.nameKr || currentUserInfo?.favoriteTeams[0]?.nameEn || undefined
-						}
-					/>
-					<RecommendedContent mode={'board'} />
-				</Suspense>
+					<div>
+						{finishedGames.games.map((game, i) => (
+							<div key={game.pk}>
+								<PredictCard
+									type={'finished'}
+									leagueName={finishedGames.league.nameKr || finishedGames.league.nameEn}
+									game={game}
+								/>
+								{i !== finishedGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
+							</div>
+						))}
+					</div>
+				)}
 			</div>
+
+			{/* 추천 뉴스 및 게시글 */}
+			<Suspense>
+				<RecommendedContent
+					mode={'news'}
+					teamLogo={currentUserInfo?.favoriteTeams[0]?.logoUrl}
+					teamName={currentUserInfo?.favoriteTeams[0]?.nameKr || currentUserInfo?.favoriteTeams[0]?.nameEn || undefined}
+				/>
+				<RecommendedContent mode={'board'} />
+			</Suspense>
 		</div>
 	);
 }

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -1,45 +1,12 @@
 'use client';
 
-import FetchingFailedCard from '@/components/common/fetching-failed-card';
 import RecommendedContent from '@/components/common/recommended-content';
-import NoGameCard from '@/components/features/home/no-game-card';
-import PredictCard from '@/components/features/home/predict-card';
+import PredictCardList from '@/components/features/home/predict-card-list';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
-import { getGames } from '@/services/apis/user-game-gamble';
-import { GameTaggedLeagueDto, GetGamesRequest } from '@/services/apis/user-game-gamble/dto';
-import { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useEffect } from 'react';
 
 export default function Home() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
-	const [proceedingGames, setProceedingGames] = useState<GameTaggedLeagueDto | null>(null);
-	const [finishedGames, setFinishedGames] = useState<GameTaggedLeagueDto | null>(null);
-	const isProceedingGamesEmpty = proceedingGames && proceedingGames.games.length === 0;
-	const isFinishedGamesEmpty = finishedGames && finishedGames.games.length === 0;
-
-	const getGamesByStatus = useCallback(
-		async (status: 'proceeding' | 'finished') => {
-			const setter =
-				status === 'proceeding' ? (value) => setProceedingGames(value) : (value) => setFinishedGames(value);
-
-			const request: GetGamesRequest = {
-				league: currentUserInfo?.league?.pk || 1,
-				status: status,
-			};
-			const response = await getGames(request);
-
-			if (!response) {
-				setter(null);
-			} else {
-				setter(response.data);
-			}
-		},
-		[currentUserInfo?.league?.pk],
-	);
-
-	useEffect(() => {
-		getGamesByStatus('proceeding');
-		getGamesByStatus('finished');
-	}, [currentUserInfo, getGamesByStatus]);
 
 	useEffect(() => {
 		document.body.style.backgroundColor = 'var(--color-black-800)';
@@ -51,78 +18,8 @@ export default function Home() {
 
 	return (
 		<div className="flex flex-col gap-4">
-			{/* 승부예측 */}
-			<div className="flex flex-col gap-8">
-				{/* 예측 진행 중 경기 */}
-				{/* 예측 진행 중 경기와 예측 종료 경기가 모두 없는 경우 null */}
-				{!(isProceedingGamesEmpty && isFinishedGamesEmpty) && (
-					<div className="flex flex-col gap-4">
-						{!proceedingGames ? (
-							// 데이터 페칭에 실패한 경우 fetching failed card
-							<div className="bg-black-000 rounded-[0.625rem] flex flex-col px-4 py-[1.375rem] ">
-								<FetchingFailedCard
-									onClick={() => getGamesByStatus('proceeding')}
-									isCardVisible={false}
-									height="8.25rem"
-									marginTop="0"
-								/>
-							</div>
-						) : // 예측 진행 중 경기가 없고, 예측 종료 경기는 있는 경우 no game card
-						isProceedingGamesEmpty && !isFinishedGamesEmpty ? (
-							<NoGameCard />
-						) : (
-							// 그 외에 정상적으로 predict card 렌더링
-							<div>
-								{proceedingGames.games.map((game, i) => (
-									<div key={game.pk}>
-										<PredictCard
-											type={'proceeding'}
-											leagueName={proceedingGames.league.nameKr || proceedingGames.league.nameEn}
-											refetchGames={() => getGamesByStatus('proceeding')}
-											game={game}
-										/>
-										{i !== proceedingGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
-									</div>
-								))}
-							</div>
-						)}
-					</div>
-				)}
-
-				{/* 예측 종료 경기가 정상적으로 렌더링될 때에만 구분선 렌더링 */}
-				{finishedGames && finishedGames.games.length > 0 && <hr className="mx-6 @mobile:mx-4 border-black-300" />}
-
-				{/* 예측 종료 경기 */}
-				{!finishedGames ? (
-					// 데이터 페칭에 실패한 경우 fetching failed card
-					<div className="bg-black-000 rounded-[0.625rem] flex flex-col px-4 py-[1.375rem] ">
-						<FetchingFailedCard
-							onClick={() => getGamesByStatus('finished')}
-							isCardVisible={false}
-							height="8.25rem"
-							marginTop="0"
-						/>
-					</div>
-				) : isProceedingGamesEmpty && isFinishedGamesEmpty ? (
-					// 예측 진행 중 경기와 예측 종료 경기가 모두 없는 경우 no game card
-					<NoGameCard />
-				) : (
-					//  그 외 정상적으로 predict card 렌더링
-
-					<div>
-						{finishedGames.games.map((game, i) => (
-							<div key={game.pk}>
-								<PredictCard
-									type={'finished'}
-									leagueName={finishedGames.league.nameKr || finishedGames.league.nameEn}
-									game={game}
-								/>
-								{i !== finishedGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
-							</div>
-						))}
-					</div>
-				)}
-			</div>
+			{/* 승부 예측 */}
+			<PredictCardList />
 
 			{/* 추천 뉴스 및 게시글 */}
 			<Suspense>

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import RecommendedContent from '@/components/common/recommended-content';
-import PredictLeagueTab from '@/components/features/home/predict-league-tab';
+import PredictCardList from '@/components/features/home/predict-card-list';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { Suspense, useEffect } from 'react';
 
@@ -19,7 +19,9 @@ export default function Home() {
 	return (
 		<div className="flex flex-col gap-4">
 			{/* 승부 예측 */}
-			<PredictLeagueTab />
+			<div className="bg-black-000 rounded-[0.625rem]">
+				<PredictCardList />
+			</div>
 
 			{/* 추천 뉴스 및 게시글 */}
 			<Suspense>

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import RecommendedContent from '@/components/common/recommended-content';
-import PredictCardList from '@/components/features/home/predict-card-list';
+import PredictLeagueTab from '@/components/features/home/predict-league-tab';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { Suspense, useEffect } from 'react';
 
@@ -20,7 +20,7 @@ export default function Home() {
 		<div className="flex flex-col gap-4">
 			{/* 승부 예측 */}
 			<div className="bg-black-000 rounded-[0.625rem]">
-				<PredictCardList />
+				<PredictLeagueTab />
 			</div>
 
 			{/* 추천 뉴스 및 게시글 */}

--- a/src/app/(without-side)/signup/page.tsx
+++ b/src/app/(without-side)/signup/page.tsx
@@ -92,16 +92,16 @@ export default function Page() {
 	};
 
 	// 소셜 로그인을 통한 접근이 아닌 경우 홈으로 리디렉션
-	// useEffect(() => {
-	// 	const fromLogin = getCookie('fromLogin');
+	useEffect(() => {
+		const fromLogin = getCookie('fromLogin');
 
-	// 	if (fromLogin === 'true') {
-	// 		setIsValidAccess(true);
-	// 	} else {
-	// 		alert('잘못된 접근입니다.');
-	// 		router.replace('/');
-	// 	}
-	// }, [router]);
+		if (fromLogin === 'true') {
+			setIsValidAccess(true);
+		} else {
+			alert('잘못된 접근입니다.');
+			router.replace('/');
+		}
+	}, [router]);
 
 	useEffect(() => {
 		return () => {

--- a/src/app/(without-side)/signup/page.tsx
+++ b/src/app/(without-side)/signup/page.tsx
@@ -92,16 +92,16 @@ export default function Page() {
 	};
 
 	// 소셜 로그인을 통한 접근이 아닌 경우 홈으로 리디렉션
-	useEffect(() => {
-		const fromLogin = getCookie('fromLogin');
+	// useEffect(() => {
+	// 	const fromLogin = getCookie('fromLogin');
 
-		if (fromLogin === 'true') {
-			setIsValidAccess(true);
-		} else {
-			alert('잘못된 접근입니다.');
-			router.replace('/');
-		}
-	}, [router]);
+	// 	if (fromLogin === 'true') {
+	// 		setIsValidAccess(true);
+	// 	} else {
+	// 		alert('잘못된 접근입니다.');
+	// 		router.replace('/');
+	// 	}
+	// }, [router]);
 
 	useEffect(() => {
 		return () => {

--- a/src/components/common/account/selectbox.tsx
+++ b/src/components/common/account/selectbox.tsx
@@ -122,7 +122,12 @@ export default function Selectbox({
 				</button>
 
 				{isOptionListVisible && !!options.length && (
-					<div className="z-10 w-full top-[3.25rem] shadow-select-options border border-black-300 rounded-[0.625rem]">
+					<div
+						className={clsx(
+							'z-10 w-full top-[3.25rem] shadow-select-options border border-black-300 rounded-[0.625rem]',
+							{ 'max-h-62.5 overflow-y-scroll team-scrollbar': !isLeagueSelectBox },
+						)}
+					>
 						{options.map((option, index) => (
 							<div
 								key={option.pk}

--- a/src/components/common/account/selectbox.tsx
+++ b/src/components/common/account/selectbox.tsx
@@ -125,7 +125,7 @@ export default function Selectbox({
 					<div
 						className={clsx(
 							'z-10 w-full top-[3.25rem] shadow-select-options border border-black-300 rounded-[0.625rem]',
-							{ 'max-h-62.5 overflow-y-scroll team-scrollbar': !isLeagueSelectBox },
+							{ 'max-h-62.5 overflow-y-scroll team-scrollbar rounded-r-0': !isLeagueSelectBox },
 						)}
 					>
 						{options.map((option, index) => (

--- a/src/components/common/category-tab/category-tab.tsx
+++ b/src/components/common/category-tab/category-tab.tsx
@@ -16,7 +16,7 @@ export const renderItems = (items, ItemComponent) => (
 			<div key={item.pk}>
 				<ItemComponent {...item} />
 				{index !== items.length - 1 && (
-					<hr className={clsx('border-black-300 mx-4', { '@mobile:mx-0': ItemComponent === CommunityItem })} />
+					<hr className={clsx('border-black-200', { 'mx-4': ItemComponent === NewsItem })} />
 				)}
 			</div>
 		))}

--- a/src/components/common/category-tab/community-division-bar.tsx
+++ b/src/components/common/category-tab/community-division-bar.tsx
@@ -3,8 +3,8 @@ import Image from 'next/image';
 export default function CommunityDivisionBar() {
 	return (
 		<div
-			className="@mobile:hidden flex py-[0.9375rem] mx-4 justify-between
-				subtitle2-medium text-center border-b border-black-300"
+			className="@mobile:hidden flex py-[0.9375rem] px-4 justify-between
+				subtitle2-medium text-center border-b border-black-200"
 		>
 			<div className="ml-[5.625rem]">제목</div>
 			<div className="flex gap-4">

--- a/src/components/common/category-tab/community-item.tsx
+++ b/src/components/common/category-tab/community-item.tsx
@@ -12,7 +12,7 @@ export default function CommunityItem({ pk, title, replies, user, createdAt, has
 		>
 			<div className="flex gap-1 items-center pr-2">
 				<h2
-					className="subtitle1-medium max-w-3xs truncate group-hover:underline
+					className="subtitle1-medium max-w-3xs truncate group-hover:underline group-hover:underline-offset-2
 					@mobile:max-w-max @mobile:w-fit @mobile:text-15 @mobile:font-medium @mobile:leading-4"
 				>
 					{title}

--- a/src/components/common/category-tab/news-item.tsx
+++ b/src/components/common/category-tab/news-item.tsx
@@ -38,7 +38,7 @@ export default function NewsItem({
 				<section className={clsx('flex justify-between @mobile:flex-col-reverse @mobile:gap-4')}>
 					<div className={'w-[28rem] @mobile:grow @mobile:w-auto'}>
 						<h2
-							className="title3-semibold mb-2 pr-2 truncate group-hover:underline
+							className="title3-semibold pb-2 pr-2 truncate group-hover:underline group-hover:underline-offset-3
 								@mobile:text-16 @mobile:font-semibold @mobile:leading-4"
 						>
 							{title}

--- a/src/components/common/category-tab/select-box.tsx
+++ b/src/components/common/category-tab/select-box.tsx
@@ -102,7 +102,7 @@ export default function Selectbox({
 			>
 				{isMobile ? (
 					league ? (
-						<Image className="w-8 h-8 object-contain" src={league.logoUrl} alt="로고" width={32} height={32} />
+						<Image className="w-7 h-7 object-contain" src={league.logoUrl} alt="로고" width={28} height={28} />
 					) : (
 						<div>리그 선택</div>
 					)

--- a/src/components/common/category-tab/team-bar.tsx
+++ b/src/components/common/category-tab/team-bar.tsx
@@ -10,6 +10,7 @@ export default function TeamBar() {
 	const pathname = usePathname();
 	const searchParams = useSearchParams();
 	const id = searchParams.get('id');
+	const isNews = pathname.split('/').includes('news');
 
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const teams = currentUserInfo?.favoriteTeams;
@@ -18,7 +19,7 @@ export default function TeamBar() {
 
 	return (
 		<>
-			<div className="mt-5 mb-3 mx-4 @mobile:mx-0 flex items-center subtitle1-medium">
+			<div className="mt-5 mb-3 flex items-center subtitle1-medium">
 				{teams.map((team, i) => (
 					<div
 						key={team.pk}
@@ -44,7 +45,7 @@ export default function TeamBar() {
 					</div>
 				))}
 			</div>
-			<hr className="mx-4 mb-1.5 w-auto border-black-200" />
+			<hr className={clsx('mb-1.5 w-auto border-black-300', { 'mx-4': isNews })} />
 		</>
 	);
 }

--- a/src/components/common/recommended-content.tsx
+++ b/src/components/common/recommended-content.tsx
@@ -32,8 +32,7 @@ const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 				함께 볼 만한
 				{isMyTeam && (
 					<span className="text-primary-900 flex mx-1.5 items-center">
-						MY 팀
-						<Image width={16} height={16} src={teamLogo} alt="팀 로고" className="w-4 h-4 ml-1" />
+						MY 팀{/* <Image width={16} height={16} src={teamLogo} alt="팀 로고" className="w-4 h-4 ml-1" /> */}
 					</span>
 				)}
 				뉴스
@@ -61,7 +60,7 @@ const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 		<ComponentFrame isMain={true}>
 			<header
 				className={clsx('flex px-4 justify-between pb-1.5', isNews ? '@mobile:pt-6 pt-7.5' : 'pt-7.5', {
-					'border-b border-black-200 pb-7.5': !isNews,
+					'border-b border-black-900 pb-7.5': !isNews,
 				})}
 			>
 				<h3 className={clsx('@mobile:ml-4', 'title4-semibold', isNews ? '@mobile:text-16' : '@mobile:text-18')}>

--- a/src/components/common/recommended-content.tsx
+++ b/src/components/common/recommended-content.tsx
@@ -14,12 +14,10 @@ import { getRecommendedBoards } from '@/services/apis/board/getRecommendedBoards
 import FetchingFailedCard from './fetching-failed-card';
 import Link from 'next/link';
 import NewsItem from './category-tab/news-item';
-import useIsMobile from '@/lib/hooks/useIsMobile';
 
 const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 	const pathname = usePathname();
 	const [data, setData] = useState<RecommendedNewsDto[] | RecommendedBoardDto[] | null>(null);
-	const isMobile = useIsMobile();
 
 	const isMyTeam = Boolean(teamName);
 	const isNews = mode === 'news';
@@ -30,25 +28,16 @@ const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 		pathname === '/' && !isNews ? (
 			'클럽 커뮤니티'
 		) : (
-			<>
-				{!isMobile ? (
-					<div>
-						함께 볼 만한 {isMyTeam && <span className="text-primary-900">{teamName} </span>}
-						{isNews ? ' 뉴스' : ' 게시글'}
-					</div>
-				) : (
-					<div className="flex">
-						함께 볼 만한
-						{isMyTeam && (
-							<span className="text-primary-900 flex mx-1 items-center">
-								MY 팀
-								<Image width={16} height={16} src={teamLogo} alt="팀 로고" className="w-4 h-4 ml-1" />
-							</span>
-						)}
-						{isNews ? '뉴스' : '게시글'}
-					</div>
+			<div className="flex">
+				함께 볼 만한
+				{isMyTeam && (
+					<span className="text-primary-900 flex mx-1.5 items-center">
+						MY 팀
+						<Image width={16} height={16} src={teamLogo} alt="팀 로고" className="w-4 h-4 ml-1" />
+					</span>
 				)}
-			</>
+				뉴스
+			</div>
 		);
 
 	const getDatas = useCallback(async () => {
@@ -71,8 +60,8 @@ const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 	return (
 		<ComponentFrame isMain={true}>
 			<header
-				className={clsx('flex mx-4 justify-between pb-1.5', isNews ? '@mobile:pt-6 pt-7.5' : 'pt-7.5', '@mobile:mx-0', {
-					'border-b border-black-300 pb-7.5': !isNews,
+				className={clsx('flex px-4 justify-between pb-1.5', isNews ? '@mobile:pt-6 pt-7.5' : 'pt-7.5', {
+					'border-b border-black-200 pb-7.5': !isNews,
 				})}
 			>
 				<h3 className={clsx('@mobile:ml-4', 'title4-semibold', isNews ? '@mobile:text-16' : '@mobile:text-18')}>
@@ -108,9 +97,7 @@ const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 					data.map((item, index) => (
 						<div key={item.pk}>
 							<Component {...item} isMyTeam={isMyTeam} />
-							{index !== data.length - 1 && (
-								<hr className={clsx('border-black-300 mx-4', { '@mobile:mx-0': Component === CommunityItem })} />
-							)}
+							{index !== data.length - 1 && <hr className={clsx('border-black-200', { 'mx-4': isNews })} />}
 						</div>
 					))
 				)}

--- a/src/components/features/home/predict-card-list.tsx
+++ b/src/components/features/home/predict-card-list.tsx
@@ -8,33 +8,31 @@ import { getGames } from '@/services/apis/user-game-gamble';
 import { GameTaggedLeagueDto, GetGamesRequest } from '@/services/apis/user-game-gamble/dto';
 import { useCallback, useEffect, useState } from 'react';
 
-export default function PredictCardList({ leaguePk }: { leaguePk: number }) {
+export default function PredictCardList() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const [proceedingGames, setProceedingGames] = useState<GameTaggedLeagueDto | null>(null);
 	const [finishedGames, setFinishedGames] = useState<GameTaggedLeagueDto | null>(null);
 	const isProceedingGamesEmpty = proceedingGames && proceedingGames.games.length === 0;
 	const isFinishedGamesEmpty = finishedGames && finishedGames.games.length === 0;
 
-	const getGamesByStatus = useCallback(
-		async (status: 'proceeding' | 'finished') => {
-			const setter =
-				status === 'proceeding' ? (value) => setProceedingGames(value) : (value) => setFinishedGames(value);
+	const getGamesByStatus = useCallback(async (status: 'proceeding' | 'finished') => {
+		const setter = status === 'proceeding' ? (value) => setProceedingGames(value) : (value) => setFinishedGames(value);
 
-			const request: GetGamesRequest = {
-				league: leaguePk,
-				status: status,
-			};
-			const response = await getGames(request);
+		const request: GetGamesRequest = {
+			// 응원팀이 있는 경우 league와 관계없이 응원팀 관련 경기 조회
+			// 응원팀이 없거나 비회원인 경우 league에 설정한 1(프리미어리그) 유효
+			league: 1,
+			status: status,
+		};
+		const response = await getGames(request);
 
-			if (!response) {
-				setter(null);
-			} else {
-				console.log(response.data);
-				setter(response.data);
-			}
-		},
-		[leaguePk],
-	);
+		if (!response) {
+			setter(null);
+		} else {
+			console.log(response.data);
+			setter(response.data);
+		}
+	}, []);
 
 	useEffect(() => {
 		getGamesByStatus('proceeding');

--- a/src/components/features/home/predict-card-list.tsx
+++ b/src/components/features/home/predict-card-list.tsx
@@ -8,31 +8,37 @@ import { getGames } from '@/services/apis/user-game-gamble';
 import { GameTaggedLeagueDto, GetGamesRequest } from '@/services/apis/user-game-gamble/dto';
 import { useCallback, useEffect, useState } from 'react';
 
-export default function PredictCardList() {
+export default function PredictCardList({ teamPk }: { teamPk: undefined | number }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const [proceedingGames, setProceedingGames] = useState<GameTaggedLeagueDto | null>(null);
 	const [finishedGames, setFinishedGames] = useState<GameTaggedLeagueDto | null>(null);
 	const isProceedingGamesEmpty = proceedingGames && proceedingGames.games.length === 0;
 	const isFinishedGamesEmpty = finishedGames && finishedGames.games.length === 0;
 
-	const getGamesByStatus = useCallback(async (status: 'proceeding' | 'finished') => {
-		const setter = status === 'proceeding' ? (value) => setProceedingGames(value) : (value) => setFinishedGames(value);
+	const getGamesByStatus = useCallback(
+		async (status: 'proceeding' | 'finished') => {
+			const setter =
+				status === 'proceeding' ? (value) => setProceedingGames(value) : (value) => setFinishedGames(value);
 
-		const request: GetGamesRequest = {
-			// 응원팀이 있는 경우 league와 관계없이 응원팀 관련 경기 조회
-			// 응원팀이 없거나 비회원인 경우 league에 설정한 1(프리미어리그) 유효
-			league: 1,
-			status: status,
-		};
-		const response = await getGames(request);
+			const request: GetGamesRequest = {
+				// 응원팀이 있는 경우 league와 관계없이 응원팀 관련 경기 조회
+				// 응원팀이 없거나 비회원인 경우 league에 설정한 1(프리미어리그) 유효
+				league: 1,
+				status: status,
+				team: teamPk,
+			};
+			console.log(request);
+			const response = await getGames(request);
 
-		if (!response) {
-			setter(null);
-		} else {
-			console.log(response.data);
-			setter(response.data);
-		}
-	}, []);
+			if (!response) {
+				setter(null);
+			} else {
+				console.log(response.data);
+				setter(response.data);
+			}
+		},
+		[teamPk],
+	);
 
 	useEffect(() => {
 		getGamesByStatus('proceeding');

--- a/src/components/features/home/predict-card-list.tsx
+++ b/src/components/features/home/predict-card-list.tsx
@@ -8,7 +8,7 @@ import { getGames } from '@/services/apis/user-game-gamble';
 import { GameTaggedLeagueDto, GetGamesRequest } from '@/services/apis/user-game-gamble/dto';
 import { useCallback, useEffect, useState } from 'react';
 
-export default function PredictCardList() {
+export default function PredictCardList({ leaguePk }: { leaguePk: number }) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const [proceedingGames, setProceedingGames] = useState<GameTaggedLeagueDto | null>(null);
 	const [finishedGames, setFinishedGames] = useState<GameTaggedLeagueDto | null>(null);
@@ -21,7 +21,7 @@ export default function PredictCardList() {
 				status === 'proceeding' ? (value) => setProceedingGames(value) : (value) => setFinishedGames(value);
 
 			const request: GetGamesRequest = {
-				league: currentUserInfo?.league?.pk || 1,
+				league: leaguePk,
 				status: status,
 			};
 			const response = await getGames(request);
@@ -29,10 +29,11 @@ export default function PredictCardList() {
 			if (!response) {
 				setter(null);
 			} else {
+				console.log(response.data);
 				setter(response.data);
 			}
 		},
-		[currentUserInfo?.league?.pk],
+		[leaguePk],
 	);
 
 	useEffect(() => {

--- a/src/components/features/home/predict-card-list.tsx
+++ b/src/components/features/home/predict-card-list.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import FetchingFailedCard from '@/components/common/fetching-failed-card';
+import NoGameCard from '@/components/features/home/no-game-card';
+import PredictCard from '@/components/features/home/predict-card';
+import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import { getGames } from '@/services/apis/user-game-gamble';
+import { GameTaggedLeagueDto, GetGamesRequest } from '@/services/apis/user-game-gamble/dto';
+import { useCallback, useEffect, useState } from 'react';
+
+export default function PredictCardList() {
+	const { currentUserInfo } = useCurrentUserInfoStore();
+	const [proceedingGames, setProceedingGames] = useState<GameTaggedLeagueDto | null>(null);
+	const [finishedGames, setFinishedGames] = useState<GameTaggedLeagueDto | null>(null);
+	const isProceedingGamesEmpty = proceedingGames && proceedingGames.games.length === 0;
+	const isFinishedGamesEmpty = finishedGames && finishedGames.games.length === 0;
+
+	const getGamesByStatus = useCallback(
+		async (status: 'proceeding' | 'finished') => {
+			const setter =
+				status === 'proceeding' ? (value) => setProceedingGames(value) : (value) => setFinishedGames(value);
+
+			const request: GetGamesRequest = {
+				league: currentUserInfo?.league?.pk || 1,
+				status: status,
+			};
+			const response = await getGames(request);
+
+			if (!response) {
+				setter(null);
+			} else {
+				setter(response.data);
+			}
+		},
+		[currentUserInfo?.league?.pk],
+	);
+
+	useEffect(() => {
+		getGamesByStatus('proceeding');
+		getGamesByStatus('finished');
+	}, [currentUserInfo, getGamesByStatus]);
+	return (
+		<div className="flex flex-col gap-8">
+			{/* 예측 진행 중 경기 */}
+			{/* 예측 진행 중 경기와 예측 종료 경기가 모두 없는 경우 null */}
+			{!(isProceedingGamesEmpty && isFinishedGamesEmpty) && (
+				<div className="flex flex-col gap-4">
+					{!proceedingGames ? (
+						// 데이터 페칭에 실패한 경우 fetching failed card
+						<div className="bg-black-000 rounded-[0.625rem] flex flex-col px-4 py-[1.375rem] ">
+							<FetchingFailedCard
+								onClick={() => getGamesByStatus('proceeding')}
+								isCardVisible={false}
+								height="8.25rem"
+								marginTop="0"
+							/>
+						</div>
+					) : // 예측 진행 중 경기가 없고, 예측 종료 경기는 있는 경우 no game card
+					isProceedingGamesEmpty && !isFinishedGamesEmpty ? (
+						<NoGameCard />
+					) : (
+						// 그 외에 정상적으로 predict card 렌더링
+						<div>
+							{proceedingGames.games.map((game, i) => (
+								<div key={game.pk}>
+									<PredictCard
+										type={'proceeding'}
+										leagueName={proceedingGames.league.nameKr || proceedingGames.league.nameEn}
+										refetchGames={() => getGamesByStatus('proceeding')}
+										game={game}
+									/>
+									{i !== proceedingGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* 예측 종료 경기가 정상적으로 렌더링될 때에만 구분선 렌더링 */}
+			{finishedGames && finishedGames.games.length > 0 && <hr className="mx-6 @mobile:mx-4 border-black-300" />}
+
+			{/* 예측 종료 경기 */}
+			{!finishedGames ? (
+				// 데이터 페칭에 실패한 경우 fetching failed card
+				<div className="bg-black-000 rounded-[0.625rem] flex flex-col px-4 py-[1.375rem] ">
+					<FetchingFailedCard
+						onClick={() => getGamesByStatus('finished')}
+						isCardVisible={false}
+						height="8.25rem"
+						marginTop="0"
+					/>
+				</div>
+			) : isProceedingGamesEmpty && isFinishedGamesEmpty ? (
+				// 예측 진행 중 경기와 예측 종료 경기가 모두 없는 경우 no game card
+				<NoGameCard />
+			) : (
+				//  그 외 정상적으로 predict card 렌더링
+				<div>
+					{finishedGames.games.map((game, i) => (
+						<div key={game.pk}>
+							<PredictCard
+								type={'finished'}
+								leagueName={finishedGames.league.nameKr || finishedGames.league.nameEn}
+								game={game}
+							/>
+							{i !== finishedGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
+						</div>
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/features/home/predict-card-list.tsx
+++ b/src/components/features/home/predict-card-list.tsx
@@ -62,12 +62,7 @@ export default function PredictCardList() {
 						<div>
 							{proceedingGames.games.map((game, i) => (
 								<div key={game.pk}>
-									<PredictCard
-										type={'proceeding'}
-										leagueName={proceedingGames.league.nameKr || proceedingGames.league.nameEn}
-										refetchGames={() => getGamesByStatus('proceeding')}
-										game={game}
-									/>
+									<PredictCard type={'proceeding'} refetchGames={() => getGamesByStatus('proceeding')} game={game} />
 									{i !== proceedingGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
 								</div>
 							))}
@@ -98,11 +93,7 @@ export default function PredictCardList() {
 				<div>
 					{finishedGames.games.map((game, i) => (
 						<div key={game.pk}>
-							<PredictCard
-								type={'finished'}
-								leagueName={finishedGames.league.nameKr || finishedGames.league.nameEn}
-								game={game}
-							/>
+							<PredictCard type={'finished'} game={game} />
 							{i !== finishedGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
 						</div>
 					))}

--- a/src/components/features/home/predict-card/index.tsx
+++ b/src/components/features/home/predict-card/index.tsx
@@ -17,15 +17,13 @@ import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 export default function PredictCard({
 	game,
 	type,
-	leagueName,
 	refetchGames,
 }: {
 	game: GameDto;
 	type: 'proceeding' | 'finished';
-	leagueName: string;
 	refetchGames?: () => void;
 }) {
-	const { pk, gambleResult, myGambleResult, homeScore, awayScore, gameStatus, startAt } = game;
+	const { pk, gambleResult, myGambleResult, homeScore, awayScore, gameStatus, startAt, homeTeam } = game;
 
 	const { isMobile, isTablet } = getServerDeviceType();
 
@@ -63,7 +61,7 @@ export default function PredictCard({
 				: 'away';
 
 	const headerProps: HeaderProps = {
-		leagueName,
+		leagueName: homeTeam.leagueNameKr || homeTeam.leagueNameEn,
 		isGambleInProgress,
 		isGameInProgress,
 		isGameCanceled,

--- a/src/components/features/home/predict-card/index.tsx
+++ b/src/components/features/home/predict-card/index.tsx
@@ -23,7 +23,7 @@ export default function PredictCard({
 	type: 'proceeding' | 'finished';
 	refetchGames?: () => void;
 }) {
-	const { pk, gambleResult, myGambleResult, homeScore, awayScore, gameStatus, startAt, homeTeam } = game;
+	const { pk, gambleResult, myGambleResult, homeScore, awayScore, gameStatus, startAt, league } = game;
 
 	const { isMobile, isTablet } = getServerDeviceType();
 
@@ -61,7 +61,7 @@ export default function PredictCard({
 				: 'away';
 
 	const headerProps: HeaderProps = {
-		leagueName: homeTeam.leagueNameKr || homeTeam.leagueNameEn,
+		leagueName: league.nameKr || league.nameEn,
 		isGambleInProgress,
 		isGameInProgress,
 		isGameCanceled,

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -8,7 +8,9 @@ import PredictCardList from './predict-card-list';
 
 export default function PredictLeagueTab() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
-	const [selectedTeamPk, setSelectedTeamPk] = useState<undefined | number>(undefined);
+	const [selectedTeamPk, setSelectedTeamPk] = useState<undefined | number>(
+		currentUserInfo?.favoriteTeams?.length > 0 ? undefined : 1,
+	);
 
 	const teams = currentUserInfo?.favoriteTeams ?? [];
 

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -3,7 +3,7 @@
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import clsx from 'clsx';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import PredictCardList from './predict-card-list';
 
 export default function PredictLeagueTab() {
@@ -27,6 +27,12 @@ export default function PredictLeagueTab() {
 					type: 'League',
 				};
 	const tabs = [firstTab, ...teams];
+
+	useEffect(() => {
+		// currentUserInfo 변경될 때마다 (로그인 상태가 변경될 때마다)
+		// default 활성탭 업데이트
+		setSelectedTeamPk(currentUserInfo?.favoriteTeams?.length > 0 ? undefined : 1);
+	}, [currentUserInfo]);
 
 	return (
 		<div>

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import clsx from 'clsx';
+import Image from 'next/image';
+import { useState } from 'react';
+import PredictCardList from './predict-card-list';
+
+export default function PredictLeagueTab() {
+	const { currentUserInfo } = useCurrentUserInfoStore();
+	const [selectedIndex, setSelectedIndex] = useState(0);
+	// TODO: selectedLeaguePk 만들어서 PredictCardList에 leaguePk 넘겨줘야 함
+
+	const leagues = currentUserInfo?.favoriteTeams ?? [];
+
+	// 응원팀이 하나 이상 있는 경우 전체 탭
+	// 응원팀이 없거나 비회원인 경우 프리미어리그 탭
+	const firstTab =
+		currentUserInfo?.favoriteTeams.length > 0
+			? '전체'
+			: {
+					pk: 1,
+					nameKr: '프리미어리그',
+					nameEn: 'Premier League',
+					logoUrl: 'https://media.api-sports.io/football/leagues/39.png',
+					type: 'League',
+				};
+	const tabs = [firstTab, ...leagues];
+
+	return (
+		<div>
+			{/* 탭 바 */}
+			<div
+				className="relative w-full flex rounded-t-[0.625rem] bg-black-200 header-medium
+          @mobile:grid @mobile:grid-cols-4 before:content-[''] before:absolute
+          before:-top-1 before:-left-1 before:bottom-0 before:-right-1
+          before:inset-shadow-[0px_-2px_4px_0px_rgba(0,0,0,0.10)]
+          after:content-[''] after:absolute after:-bottom-4 after:left-0 after:right-0
+          after:h-4 after:bg-black-000"
+			>
+				{tabs.map((league, i) => (
+					<button
+						key={typeof league === 'string' ? league : league.pk}
+						onClick={() => {
+							setSelectedIndex(i);
+						}}
+						className={clsx(
+							`group relative flex items-center h-[3.3125rem] rounded-t-[0.625rem] transition-opacity
+              w-[5.625rem] @mobile:w-full justify-center before:rounded-t-[0.625rem]
+              before:content-[''] before:absolute before:top-0 before:left-0 before:bottom-0 before:right-0
+              before:bg-black-000 before:shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)]`,
+							i === selectedIndex
+								? 'before:block header-semibold text-primary-900'
+								: 'before:hidden opacity-70 hover:opacity-100',
+						)}
+					>
+						{typeof league === 'string' ? (
+							<div className="relative z-20">{league}</div>
+						) : (
+							<div
+								className={clsx(
+									'relative z-20 transition-all',
+									i === selectedIndex ? 'w-7 h-7' : 'group-hover:w-7 group-hover:h-7 w-6 h-6 @mobile:w-7 @mobile:h-7',
+								)}
+							>
+								<Image src={league.logoUrl} alt="로고 이미지" fill className="w-auto h-auto object-contain" />
+							</div>
+						)}
+					</button>
+				))}
+			</div>
+
+			{/* 승부 예측 리스트 */}
+			<div className="pt-7 bg-black-000 rounded-b-[0.625rem]">
+				<PredictCardList leaguePk={1} />
+			</div>
+		</div>
+	);
+}

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -72,7 +72,7 @@ export default function PredictLeagueTab() {
 
 			{/* 승부 예측 리스트 */}
 			<div className="pt-7 bg-black-000 rounded-b-[0.625rem]">
-				<PredictCardList leaguePk={1} />
+				<PredictCardList />
 			</div>
 		</div>
 	);

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -8,16 +8,15 @@ import PredictCardList from './predict-card-list';
 
 export default function PredictLeagueTab() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
-	const [selectedIndex, setSelectedIndex] = useState(0);
-	// TODO: selectedLeaguePk 만들어서 PredictCardList에 leaguePk 넘겨줘야 함
+	const [selectedTeamPk, setSelectedTeamPk] = useState<undefined | number>(undefined);
 
-	const leagues = currentUserInfo?.favoriteTeams ?? [];
+	const teams = currentUserInfo?.favoriteTeams ?? [];
 
 	// 응원팀이 하나 이상 있는 경우 전체 탭
 	// 응원팀이 없거나 비회원인 경우 프리미어리그 탭
 	const firstTab =
 		currentUserInfo?.favoriteTeams.length > 0
-			? '전체'
+			? { content: '전체', isActive: selectedTeamPk === undefined }
 			: {
 					pk: 1,
 					nameKr: '프리미어리그',
@@ -25,7 +24,7 @@ export default function PredictLeagueTab() {
 					logoUrl: 'https://media.api-sports.io/football/leagues/39.png',
 					type: 'League',
 				};
-	const tabs = [firstTab, ...leagues];
+	const tabs = [firstTab, ...teams];
 
 	return (
 		<div>
@@ -38,11 +37,11 @@ export default function PredictLeagueTab() {
           after:content-[''] after:absolute after:-bottom-4 after:left-0 after:right-0
           after:h-4 after:bg-black-000"
 			>
-				{tabs.map((league, i) => (
+				{tabs.map((team) => (
 					<button
-						key={typeof league === 'string' ? league : league.pk}
+						key={'content' in team ? team.content : team.pk}
 						onClick={() => {
-							setSelectedIndex(i);
+							setSelectedTeamPk('content' in team ? undefined : team.pk);
 						}}
 						className={clsx(
 							`group relative flex items-center justify-center h-[3.3125rem] rounded-t-[0.625rem]
@@ -50,19 +49,23 @@ export default function PredictLeagueTab() {
               before:rounded-t-[0.625rem] before:content-[''] before:absolute
 							before:top-0 before:left-0 before:bottom-0 before:right-0
               before:bg-black-000 before:shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)]`,
-							i === selectedIndex ? 'before:block' : 'before:hidden opacity-70 hover:opacity-100',
+							('content' in team && team.isActive) || team.pk === selectedTeamPk
+								? 'before:block'
+								: 'before:hidden opacity-70 hover:opacity-100',
 						)}
 					>
-						{typeof league === 'string' ? (
-							<div className="relative z-20">{league}</div>
+						{'content' in team ? (
+							<div className="relative z-20">{team.content}</div>
 						) : (
 							<div
 								className={clsx(
 									'relative z-20 transition-all',
-									i === selectedIndex ? 'w-7 h-7' : 'group-hover:w-7 group-hover:h-7 w-6 h-6 @mobile:w-7 @mobile:h-7',
+									team.pk === selectedTeamPk
+										? 'w-7 h-7'
+										: 'group-hover:w-7 group-hover:h-7 w-6 h-6 @mobile:w-7 @mobile:h-7',
 								)}
 							>
-								<Image src={league.logoUrl} alt="로고 이미지" fill className="w-auto h-auto object-contain" />
+								<Image src={team.logoUrl} alt="로고 이미지" fill className="w-auto h-auto object-contain" />
 							</div>
 						)}
 					</button>
@@ -71,7 +74,7 @@ export default function PredictLeagueTab() {
 
 			{/* 승부 예측 리스트 */}
 			<div className="pt-7 bg-black-000 rounded-b-[0.625rem]">
-				<PredictCardList />
+				<PredictCardList teamPk={selectedTeamPk} />
 			</div>
 		</div>
 	);

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -45,13 +45,12 @@ export default function PredictLeagueTab() {
 							setSelectedIndex(i);
 						}}
 						className={clsx(
-							`group relative flex items-center h-[3.3125rem] rounded-t-[0.625rem] transition-opacity
-              w-[5.625rem] @mobile:w-full justify-center before:rounded-t-[0.625rem]
-              before:content-[''] before:absolute before:top-0 before:left-0 before:bottom-0 before:right-0
+							`group relative flex items-center justify-center h-[3.3125rem] rounded-t-[0.625rem]
+							w-[5.625rem] @mobile:w-full transition-opacity text-primary-900 header-semibold
+              before:rounded-t-[0.625rem] before:content-[''] before:absolute
+							before:top-0 before:left-0 before:bottom-0 before:right-0
               before:bg-black-000 before:shadow-[0px_4px_6px_0px_rgba(0,0,0,0.25)]`,
-							i === selectedIndex
-								? 'before:block header-semibold text-primary-900'
-								: 'before:hidden opacity-70 hover:opacity-100',
+							i === selectedIndex ? 'before:block' : 'before:hidden opacity-70 hover:opacity-100',
 						)}
 					>
 						{typeof league === 'string' ? (

--- a/src/components/layouts/root/navbar/profile.tsx
+++ b/src/components/layouts/root/navbar/profile.tsx
@@ -71,15 +71,13 @@ export default function Profile({ onClickButton }: { onClickButton: () => void }
 							{currentUserInfo.nickname}
 							<span className="body2-regular text-black-800 @mobile:text-16">님</span>
 						</div>
-						{currentUserInfo.favoriteTeams.length > 0 && (
-							<Image
-								className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
-								src={currentUserInfo.favoriteTeams[0].logoUrl}
-								alt="팀 로고 이미지"
-								width={16}
-								height={16}
-							/>
-						)}
+						<Image
+							className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
+							src={currentUserInfo.favoriteTeams.length > 0 ? currentUserInfo.favoriteTeams[0].logoUrl : '/ban.svg'}
+							alt="팀 로고 이미지"
+							width={16}
+							height={16}
+						/>
 					</div>
 					<button
 						onClick={handleLogoutButtonClick}

--- a/src/components/layouts/with-side/profile.tsx
+++ b/src/components/layouts/with-side/profile.tsx
@@ -105,15 +105,15 @@ export default function Profile() {
 											<div className="title5-semibold">{currentUserInfo?.nickname}</div>
 											<div className="body3-regular text-black-800">님</div>
 										</div>
-										{currentUserInfo?.favoriteTeams.length > 0 && (
-											<Image
-												className="w-4 h-4 object-contain my-auto"
-												width={16}
-												height={16}
-												src={currentUserInfo.favoriteTeams[0].logoUrl}
-												alt={`${currentUserInfo.favoriteTeams[0].nameKr || currentUserInfo.favoriteTeams[0].nameEn} 로고`}
-											/>
-										)}
+										<Image
+											className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
+											src={
+												currentUserInfo.favoriteTeams.length > 0 ? currentUserInfo.favoriteTeams[0].logoUrl : '/ban.svg'
+											}
+											alt="팀 로고 이미지"
+											width={16}
+											height={16}
+										/>
 									</div>
 									<Link
 										onClick={handleProfileSettingButtonClick}

--- a/src/components/layouts/with-side/profile.tsx
+++ b/src/components/layouts/with-side/profile.tsx
@@ -108,7 +108,9 @@ export default function Profile() {
 										<Image
 											className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
 											src={
-												currentUserInfo.favoriteTeams.length > 0 ? currentUserInfo.favoriteTeams[0].logoUrl : '/ban.svg'
+												currentUserInfo?.favoriteTeams.length > 0
+													? currentUserInfo?.favoriteTeams[0].logoUrl
+													: '/ban.svg'
 											}
 											alt="팀 로고 이미지"
 											width={16}

--- a/src/services/apis/user-game-gamble/dto.ts
+++ b/src/services/apis/user-game-gamble/dto.ts
@@ -31,8 +31,9 @@ export interface GameTaggedLeagueDto {
 }
 
 export interface GameDto {
-	homeTeam: GameTeamDto;
-	awayTeam: GameTeamDto;
+	league: LeagueDto;
+	homeTeam: TeamDto;
+	awayTeam: TeamDto;
 	gambleResult: GambleResultDto;
 	myGambleResult: MyGambleResultDto | null;
 	pk: number;
@@ -43,12 +44,6 @@ export interface GameDto {
 	awayPenaltyScore: number | null;
 	gameStatus: 'PENDING' | 'PROCEEDING' | 'CANCELED' | 'HOME' | 'AWAY' | 'DRAW' | 'POSTPONED';
 	startAt: string;
-}
-
-export interface GameTeamDto extends TeamDto {
-	leagueNameKr: string;
-	leagueNameEn: string;
-	leaguePk: number;
 }
 
 // 예측 현황 비율

--- a/src/services/apis/user-game-gamble/dto.ts
+++ b/src/services/apis/user-game-gamble/dto.ts
@@ -31,8 +31,8 @@ export interface GameTaggedLeagueDto {
 }
 
 export interface GameDto {
-	homeTeam: TeamDto;
-	awayTeam: TeamDto;
+	homeTeam: GameTeamDto;
+	awayTeam: GameTeamDto;
 	gambleResult: GambleResultDto;
 	myGambleResult: MyGambleResultDto | null;
 	pk: number;
@@ -44,6 +44,13 @@ export interface GameDto {
 	gameStatus: 'PENDING' | 'PROCEEDING' | 'CANCELED' | 'HOME' | 'AWAY' | 'DRAW' | 'POSTPONED';
 	startAt: string;
 }
+
+export interface GameTeamDto extends TeamDto {
+	leagueNameKr: string;
+	leagueNameEn: string;
+	leaguePk: number;
+}
+
 // 예측 현황 비율
 export interface GambleResultDto {
 	home: number;

--- a/src/services/apis/user-game-gamble/dto.ts
+++ b/src/services/apis/user-game-gamble/dto.ts
@@ -6,6 +6,7 @@ import { LeagueDto } from '../league/dto';
 export interface GetGamesRequest {
 	league: number;
 	status: 'proceeding' | 'finished';
+	team?: number;
 }
 
 // 승부예측 생성

--- a/src/services/apis/user-game-gamble/index.ts
+++ b/src/services/apis/user-game-gamble/index.ts
@@ -3,11 +3,14 @@ import { GetGamesRequest, GetGamesResponse, PatchGameGambleRequest, PostGameGamb
 import { EmptySuccessResponse, FailResponse } from '@/services/config/dto';
 
 // 매치 리스트 조회
-export const getGames = async ({ league, status }: GetGamesRequest): Promise<GetGamesResponse | null> => {
+export const getGames = async ({ league, status, team }: GetGamesRequest): Promise<GetGamesResponse | null> => {
 	const params = new URLSearchParams();
 
 	params.append('league', String(league));
 	params.append('status', String(status));
+	if (team !== undefined) {
+		params.append('team', String(team));
+	}
 
 	const response = await fetcher<GetGamesResponse | FailResponse>({
 		method: 'GET',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -172,13 +172,34 @@ iframe.responsive-youtube {
 	background: transparent; /*스크롤바 뒷 배경 색상*/
 }
 
-.no-scrollbar::-webkit-scrollbar {
-	display: none;
+.team-scrollbar {
+	overflow-y: scroll;
+}
+
+/* 스크롤바의 폭 너비 */
+.team-scrollbar::-webkit-scrollbar {
+	width: 20px;
+}
+
+.team-scrollbar::-webkit-scrollbar-thumb {
+	width: 10px;
+	border: 5px solid var(--color-black-200);
+	background: var(--color-black-500);
+	border-radius: 10px;
+}
+
+.team-scrollbar::-webkit-scrollbar-track {
+	border-radius: 0 9px 9px 0;
+	background: var(--color-black-200); /*스크롤바 뒷 배경 색상*/
 }
 
 .no-scrollbar {
 	-ms-overflow-style: none; /* IE */
 	scrollbar-width: none; /* Firefox */
+}
+
+.no-scrollbar::-webkit-scrollbar {
+	display: none;
 }
 
 /* placeholder */


### PR DESCRIPTION
## 작업 내용
- 팀 선택 여러개 가능하게 수정되면서 변경된 승부예측 리스트 ui 적용했습니다.
- 뉴스/게시글 리스트에서 사용되는 탭바와 유사한 ui를 사용해 복붙과 약간의 수정으로,,, 수월하게 해결했습니다.

**기타 작업**
- 뉴스/커뮤니티 아이템 호버 시 underline이 글자와 너무 붙어있어 offset 주었습니다.
- 뉴스/커뮤니티 아이템 구분선 관련 수정이 있어 추천 컨텐츠까지 일괄 수정했습니다.
- 회원가입 시 팀 선택 드롭다운에 드디어 스크롤 적용했습니다.
- 메인 화면에서 발생하던 null 참조 문제 해결했습니다!

## 작업 화면
![image](https://github.com/user-attachments/assets/aa188c8c-a123-49e3-bde4-0a8005604532)
![image](https://github.com/user-attachments/assets/edbcbe6d-14ce-4c26-8526-fddaed80282e)

## 리뷰어분들께...
- 탭 바 등 승부예측 리스트가 무거워지면서 별도의 컴포넌트로 분리했습니다.
- 첫 커밋에서 두 번째 커밋으로 갈 때 코드만 옮기고 별도의 수정은 없었으니 승부예측 관련해서는 커밋 별로 리뷰하는 게 편하실 거예요!
