### PR TITLE
[KO-412] 이미지 최적화

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,39 @@ const nextConfig: NextConfig = {
 			},
 			{
 				protocol: 'https',
-				hostname: '**',
+				hostname: 'k.kakaocdn.net',
+			},
+			{
+				protocol: 'https',
+				hostname: 'premierskillsenglish.britishcouncil.org',
+			},
+			{
+				protocol: 'https',
+				hostname: 'media.gettyimages.com',
+			},
+			{
+				protocol: 'https',
+				hostname: 'kickon-files-bucket.s3.ap-northeast-2.amazonaws.com',
+			},
+			{
+				protocol: 'https',
+				hostname: 'media.api-sports.io',
+			},
+			{
+				protocol: 'https',
+				hostname: 'i.ytimg.com',
+			},
+			{
+				protocol: 'https',
+				hostname: 'img1.kakaocdn.net',
+			},
+			{
+				protocol: 'https',
+				hostname: 'ssl.pstatic.net',
+			},
+			{
+				protocol: 'https',
+				hostname: 'img.coupangstreaming.com',
 			},
 		],
 		dangerouslyAllowSVG: true, // SVG 허용 (보안 주의)

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,39 +9,10 @@ const nextConfig: NextConfig = {
 			},
 			{
 				protocol: 'https',
-				hostname: 'k.kakaocdn.net',
-			},
-			{
-				protocol: 'https',
-				hostname: 'premierskillsenglish.britishcouncil.org',
-			},
-			{
-				protocol: 'https',
-				hostname: 'media.gettyimages.com',
-			},
-			{
-				protocol: 'https',
-				hostname: 'kickon-files-bucket.s3.ap-northeast-2.amazonaws.com',
-			},
-			{
-				protocol: 'https',
-				hostname: 'media.api-sports.io',
-			},
-			{
-				protocol: 'https',
-				hostname: 'i.ytimg.com',
-			},
-			{
-				protocol: 'https',
-				hostname: 'img1.kakaocdn.net',
-			},
-			{
-				protocol: 'https',
-				hostname: 'ssl.pstatic.net',
+				hostname: '**',
 			},
 		],
 		dangerouslyAllowSVG: true, // SVG 허용 (보안 주의)
-		unoptimized: true, // 모든 이미지 최적화 비활성화 → 외부 이미지 무제한 허용
 	},
 	webpack(config) {
 		config.module.rules.push({

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tiptap/react": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",
     "axios": "^1.8.4",
+    "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.4",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "browser-image-compression": "^2.0.2",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.4",
+    "html-react-parser": "^5.2.5",
     "lodash": "^4.17.21",
     "next": "15.1.7",
     "react": "^19.0.0",

--- a/src/components/features/detail/content/detail-content.tsx
+++ b/src/components/features/detail/content/detail-content.tsx
@@ -8,6 +8,7 @@ import { getRelativeTime } from '@/lib/utils/getRelativeTime';
 import { categories } from '@/lib/constants/options';
 import LoginModal from '@/components/common/login-modal/login-modal';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import parse, { Element } from 'html-react-parser';
 
 const DetailContent = ({ data, type, isCommentAllowed }) => {
 	const { currentUserInfo } = useCurrentUserInfoStore();
@@ -47,6 +48,24 @@ const DetailContent = ({ data, type, isCommentAllowed }) => {
 		});
 		setSanitizedContent(sanitized);
 	}, [data.content]);
+
+	const parsedContent = parse(sanitizedContent, {
+		replace: (domNode) => {
+			if ('name' in domNode && domNode.name === 'img') {
+				const { src, alt, width, height } = (domNode as Element).attribs;
+				return (
+					<Image
+						src={src}
+						alt={alt || '본문 이미지'}
+						width={width ? parseInt(width) : 640}
+						height={height ? parseInt(height) : 480}
+						sizes="100vw"
+						style={{ width: '100%', height: 'auto' }}
+					/>
+				);
+			}
+		},
+	});
 
 	const handleLikeButtonClick = async () => {
 		// 비회원인 경우 클릭 차단 & 알림 표시
@@ -147,10 +166,7 @@ const DetailContent = ({ data, type, isCommentAllowed }) => {
 
 			{/* 본문 */}
 			<hr className="mt-6 mb-7.5 -mx-4 text-black-300" />
-			<div
-				className="mb-40 body3-regular @mobile:mb-30 responsive-youtube tiptap"
-				dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-			/>
+			<div className="mb-40 body3-regular @mobile:mb-30 responsive-youtube tiptap">{parsedContent}</div>
 
 			{/* 좋아요 버튼 */}
 			<button

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useRef, useState } from 'react';
 import clsx from 'clsx';
 import { getPresignedUrl, uploadToS3 } from '@/services/apis/image-upload';
+import { compressImage } from '@/lib/utils/compressImage';
 
 interface ThumbnailUploaderProps {
 	selectedImage: string | null;
@@ -19,21 +20,25 @@ export default function ThumbnailUploader({ selectedImage, onChange }: Thumbnail
 		if (!file) return;
 
 		try {
+			const compressedFile = await compressImage(file);
+
 			const img = document.createElement('img');
-			img.src = URL.createObjectURL(file);
-			img.onload = async () => {
+			img.src = URL.createObjectURL(compressedFile);
+			img.onload = () => {
 				setIsPortrait(img.height > img.width);
-
-				const presignedResponse = await getPresignedUrl({
-					type: 'news-files',
-					fileName: file.name,
-				});
-
-				const { presignedUrl, s3Url } = presignedResponse.data;
-
-				await uploadToS3(presignedUrl, file);
-				onChange(s3Url);
+				URL.revokeObjectURL(img.src);
 			};
+
+			const presignedResponse = await getPresignedUrl({
+				type: 'news-files',
+				fileName: compressedFile.name || file.name,
+			});
+
+			const { presignedUrl, s3Url } = presignedResponse.data;
+
+			await uploadToS3(presignedUrl, compressedFile);
+
+			onChange(s3Url);
 		} catch (error) {
 			console.error('파일 업로드 실패:', error);
 		}

--- a/src/lib/contexts/editor/provider.tsx
+++ b/src/lib/contexts/editor/provider.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from 'react';
 import { getPresignedUrl, uploadToS3 } from '@/services/apis/image-upload';
 import { EditorContext } from './context';
 import { Video } from '@/lib/extensions/video';
+import { compressImage } from '@/lib/utils/compressImage';
 
 type EditorProviderProps = {
 	children: React.ReactNode;
@@ -165,10 +166,12 @@ export const EditorProvider = ({ children, setBody, isNews, editedBody }: Editor
 		const file = event.target.files[0];
 
 		try {
+			const compressedFile = await compressImage(file);
+
 			// Presigned URL 요청
 			const presignedResponse = await getPresignedUrl({
 				type: isNews ? 'news-files' : 'board-files',
-				fileName: file.name,
+				fileName: compressedFile.name || file.name,
 			});
 
 			const { presignedUrl, s3Url } = presignedResponse.data;
@@ -176,7 +179,7 @@ export const EditorProvider = ({ children, setBody, isNews, editedBody }: Editor
 			console.log('S3 업로드 요청:', presignedResponse);
 
 			// Presigned URL로 S3에 이미지 업로드
-			await uploadToS3(presignedUrl, file);
+			await uploadToS3(presignedUrl, compressedFile);
 			console.log('S3 업로드 완료:', s3Url);
 
 			// 업로드된 이미지 URL을 에디터에 추가

--- a/src/lib/utils/compressImage.ts
+++ b/src/lib/utils/compressImage.ts
@@ -1,0 +1,26 @@
+import imageCompression from 'browser-image-compression';
+
+export const compressImage = async (file: File): Promise<File> => {
+	const MAX_SIZE_MB = 1; // 1MB 기준
+	const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024; // 바이트로 변환
+
+	console.log('압축 전 파일 크기:', (file.size / 1024).toFixed(2), 'KB');
+
+	// 파일이 이미 충분히 작다면 압축하지 않고 반환
+	if (file.size <= MAX_SIZE_BYTES) {
+		return file;
+	}
+
+	const options = {
+		maxSizeMB: MAX_SIZE_MB,
+		maxWidthOrHeight: 1920,
+		useWebWorker: true,
+		initialQuality: 0.8,
+	};
+
+	const compressedFile = await imageCompression(file, options);
+
+	console.log('압축 후 파일 크기:', (compressedFile.size / 1024).toFixed(2), 'KB');
+
+	return compressedFile;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2219,6 +2219,13 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
+browser-image-compression@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.2.tgz#4d5ef8882e9e471d6d923715ceb9034499d14eaa"
+  integrity sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==
+  dependencies:
+    uzip "0.20201231.0"
+
 browserslist@^4.24.0, browserslist@^4.24.4:
   version "4.24.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.5.tgz#aa0f5b8560fe81fde84c6dcb38f759bafba0e11b"
@@ -4998,6 +5005,11 @@ use-sync-external-store@^1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz#55122e2a3edd2a6c106174c27485e0fd59bcfca0"
   integrity sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==
+
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
 
 w3c-keyname@^2.2.0:
   version "2.2.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2563,7 +2563,7 @@ domelementtype@^2.3.0:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
-domhandler@^5.0.2, domhandler@^5.0.3:
+domhandler@5.0.3, domhandler@^5.0.2, domhandler@^5.0.3:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
@@ -2577,7 +2577,7 @@ dompurify@^3.2.4:
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
-domutils@^3.0.1:
+domutils@^3.0.1, domutils@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
@@ -2625,6 +2625,11 @@ entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -3240,12 +3245,40 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+html-dom-parser@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-5.1.1.tgz#9efb2cfa055f6a71de1bb2f07c5b019db5004f9e"
+  integrity sha512-+o4Y4Z0CLuyemeccvGN4bAO20aauB2N9tFEAep5x4OW34kV4PTarBHm6RL02afYt2BMKcr0D2Agep8S3nJPIBg==
+  dependencies:
+    domhandler "5.0.3"
+    htmlparser2 "10.0.0"
+
 html-encoding-sniffer@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
   integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
   dependencies:
     whatwg-encoding "^3.1.1"
+
+html-react-parser@^5.2.5:
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-5.2.5.tgz#4a0d62c129d5d5c63cc49f986c946552d737190c"
+  integrity sha512-bRPdv8KTqG9CEQPMNGksDqmbiRfVQeOidry8pVetdh/1jQ1Edx4KX5m0lWvDD89Pt4CqTYjK1BLz6NoNVxN/Uw==
+  dependencies:
+    domhandler "5.0.3"
+    html-dom-parser "5.1.1"
+    react-property "2.0.2"
+    style-to-js "1.1.16"
+
+htmlparser2@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.0.0.tgz#77ad249037b66bf8cc99c6e286ef73b83aeb621d"
+  integrity sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.1"
+    entities "^6.0.0"
 
 http-proxy-agent@^7.0.2:
   version "7.0.2"
@@ -3287,6 +3320,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inline-style-parser@0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/inline-style-parser/-/inline-style-parser-0.2.4.tgz#f4af5fe72e612839fcd453d989a586566d695f22"
+  integrity sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==
 
 internal-slot@^1.1.0:
   version "1.1.0"
@@ -4322,6 +4360,11 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-property@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.2.tgz#d5ac9e244cef564880a610bc8d868bd6f60fdda6"
+  integrity sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==
+
 react@^19.0.0:
   version "19.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-19.1.0.tgz#926864b6c48da7627f004795d6cce50e90793b75"
@@ -4713,6 +4756,20 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+style-to-js@1.1.16:
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.16.tgz#e6bd6cd29e250bcf8fa5e6591d07ced7575dbe7a"
+  integrity sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==
+  dependencies:
+    style-to-object "1.0.8"
+
+style-to-object@1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-1.0.8.tgz#67a29bca47eaa587db18118d68f9d95955e81292"
+  integrity sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==
+  dependencies:
+    inline-style-parser "0.2.4"
 
 styled-jsx@5.1.6:
   version "5.1.6"


### PR DESCRIPTION
### 작업 내용
- 이미지 최적화 작업 진행했습니다. (이미지 준최적화 라고 하겠습니다...)

- 이미지 업로드 시, 고화질(=고용량) 이미지의 경우 presigned URL을 발급받아 S3로 업로드 되기까지 10초 이상 소요되는 지연이 발생해, S3 URL 발급 전 이미지 압축 과정이 필요했습니다. 압축 라이브러리로는 sharp와 browser-image-compression 중 고민했는데, 처음에는 sharp를 선택하려 했습니다. 공식 Next.js 문서에서도 강력히 추천하고, 서버에서 작동하기 때문에 디바이스 성능에 영향을 받지 않으며 압축 품질도 뛰어나고 다양한 옵션을 제공하는 장점이 있었기 때문입니다.
하지만 sharp는 native 바이너리 기반이라 OS나 아키텍처의 영향을 많이 받는 듯했고, 실제 설치 시 Error: Could not load the "sharp" module using the darwin-arm64 runtime 에러가 발생했습니다.... 캐시 및 node_modules 초기화, 재빌드, 플랫폼에 맞춘 설치 등을 시도했지만 결국 해결하지 못했고, 이는 배포 시에도 잠재적인 문제가 될 수 있다고 생각했습니다.
결국 임시방편으로 browser-image-compression을 사용해 이미지 크기를 줄이기로 했지만, 클라이언트 측에서 동작하다 보니 사용자 디바이스 성능에 따라 압축 가능 용량에 제한이 있다는 한계가... 있습니다. 🥲

- 또, Next.js의 Image 컴포넌트가 제공하는 최적화 이점을 활용하고자 했습니다. 기존에는 외부 이미지를 무제한으로 허용하기 위해 `unoptimized: true` 옵션을 켜둔 상태였고, 이로 인해 Image 컴포넌트의 주요 이점들을 제대로 활용하지 못하고 있었습니다. 해당 옵션을 제거하니 대표 이미지나 로고 이미지 등이 webp로 자동 변환되어 파일 용량이 줄어드는 효과를 확인할 수 있었습니다.
또한 게시글 상세 페이지에서는 서버에서 받아온 HTML을 그대로 렌더링하고 있었기 때문에, 본문 이미지들이 <img> 태그로 출력되어 최적화가 적용되지 않고 있었습니다. 이를 해결하기 위해 html-react-parser를 이용해 HTML을 React 컴포넌트 형태로 변환한 후, <img> 태그를 Next.js의 Image 컴포넌트로 치환하여 렌더링했습니다. 그 결과, 본문 내 이미지들도 webp로 자동 변환되어 용량이 감소하는 것을 확인할 수 있었습니다.
다만 여기에도 한 가지 문제가... 남아 있습니다. 우리 서비스 특성상 사용자들이 이미지를 자주 업로드하고, 그 과정에서 외부 도메인의 이미지 링크를 사용하는 경우가 많은데, next에서는 외부 도메인에 대해 `next.config.js`의 `images.domains` 설정에 허용된 도메인만 최적화를 적용할 수 있습니다. 이 도메인을 하나하나 수동으로 추가하는 것은 유지보수 측면에서 번거롭다고 생각했습니다.
이에 따라 https 프로토콜을 사용하는 외부 도메인에 대해서는 와일드카드를 이용해 전부 허용하고, http 도메인은 보안상의 이유로 일부 도메인만 선택적으로 허용하는 방식으로 설정했습니다. 물론, 모든 외부 이미지를 허용하는 방식은 악성 이미지 삽입 등 보안 리스크가 있지만... 이에 대한 근본적인 해결책은 아직 찾지 못했습니다 🥲

- 다음 스프린트에서 sharp 적용과 외부 도메인 이슈를 좀 더 파헤쳐 보겠습니다...!!!!!!