### PR TITLE
[KO-451] 모바일 기기 UI 깨짐 문제 해결

### DIFF
--- a/src/components/common/category-tab/select-box.tsx
+++ b/src/components/common/category-tab/select-box.tsx
@@ -93,7 +93,7 @@ export default function Selectbox({
 			<button
 				onClick={handleSelectBoxClick}
 				className={clsx(
-					`flex items-center justify-center gap-2 h-full min-w-[5.625rem] @mobile:w-full
+					`flex items-center justify-center gap-2 h-full min-w-25 @mobile:w-full
 					pl-4 @mobile:pl-3 pr-1.5 rounded-t-[0.625rem]`,
 					isClickedOtherTab
 						? 'hover:text-black-900 text-black-700'

--- a/src/components/common/login-modal/login-modal.tsx
+++ b/src/components/common/login-modal/login-modal.tsx
@@ -42,7 +42,7 @@ export default function LoginModal({ onClose }) {
 				ref={modalRef}
 				className="flex flex-col items-center p-6 shadow-predict-button
 					w-[39.5rem] h-[39.75rem] bg-black-000 rounded-[0.625rem] display-semibold
-					@mobile:w-full @mobile:h-full @mobile:rounded-none @mobile:bg-black-100
+					@mobile:w-dvw @mobile:h-dvh @mobile:rounded-none @mobile:bg-black-100
 					@mobile:text-20 @mobile:font-semibold @mobile:leading-8"
 			>
 				<button onClick={handleXButtonClick} className="ml-auto mb-[4.6875rem] @mobile:mt-2 @mobile:mb-0">

--- a/src/components/common/login-modal/login-modal.tsx
+++ b/src/components/common/login-modal/login-modal.tsx
@@ -45,7 +45,7 @@ export default function LoginModal({ onClose }) {
 					@mobile:w-full @mobile:h-full @mobile:rounded-none @mobile:bg-black-100
 					@mobile:text-20 @mobile:font-semibold @mobile:leading-8"
 			>
-				<button onClick={handleXButtonClick} className="ml-auto mb-[4.6875rem] @mobile:mt-2 @mobile:-mb-8">
+				<button onClick={handleXButtonClick} className="ml-auto mb-[4.6875rem] @mobile:mt-2 @mobile:mb-0">
 					<Image width={24} height={24} src="/x.svg" alt="닫기" />
 				</button>
 

--- a/src/components/common/recommended-content.tsx
+++ b/src/components/common/recommended-content.tsx
@@ -70,17 +70,15 @@ const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 					'flex px-4 justify-between pb-1.5',
 					isNews ? '@mobile:pt-6 pt-7.5' : 'pt-7.5',
 					!isNews && 'border-b pb-7.5',
-					!isNews && (pathname === '/' ? 'border-black-900' : 'border-black-300'),
+					!isNews && (pathname === '/' ? 'border-black-700 @mobile:border-black-200' : 'border-black-200'),
 				)}
 			>
-				<h3 className={clsx('@mobile:ml-4', 'title4-semibold', isNews ? '@mobile:text-16' : '@mobile:text-18')}>
-					{displayTitle}
-				</h3>
+				<h3 className={clsx('title4-semibold', isNews ? '@mobile:text-16' : '@mobile:text-18')}>{displayTitle}</h3>
 
 				<Link
 					href={!isNews ? '/board?q=전체' : isMyTeam ? `/news?q=${teamName}` : `/news?q=전체`}
 					aria-label="더 보기"
-					className="@mobile:mr-4 @mobile:text-[12px] flex gap-2 items-center text-black-700 body5-regular"
+					className="@mobile:text-[12px] flex gap-2 items-center text-black-700 body5-regular"
 				>
 					<span>더 보기</span>
 					<Image

--- a/src/components/features/home/predict-card/team-button/index.tsx
+++ b/src/components/features/home/predict-card/team-button/index.tsx
@@ -158,7 +158,7 @@ export default function TeamButton({
 	return (
 		<div
 			className={clsx(
-				`relative w-full h-full min-h-[4.625rem] @mobile:min-h-[4.8125rem] grid grid-cols-3 items-center
+				`relative grid grid-cols-3 items-center
 				border transition-colors`,
 				isClicked || isFinished ? clickedFont('team') : defaultFont,
 				!isDesktop ? 'rounded-md' : 'rounded-lg',
@@ -170,10 +170,14 @@ export default function TeamButton({
 			)}
 		>
 			{sidesArr.map((side) => (
-				<div key={side} id={side} className={clsx('relative', isClicked && !isDesktop ? 'h-29' : 'h-full')}>
+				<div
+					key={side}
+					id={side}
+					className={clsx('relative', isClicked && !isDesktop ? 'h-29' : isMobile ? 'h-[4.815rem]' : 'h-[4.625rem]')}
+				>
 					<div
 						onClick={onClick}
-						className={clsx('relative h-full flex gap-2 items-center @mobile:min-h-[4.8125rem]', {
+						className={clsx('relative h-full flex gap-2 items-center', {
 							// 데스크톱 태블릿 모바일 공통 스타일
 							'text-left': side === 'home',
 							'flex-row-reverse text-right': side === 'away',

--- a/src/components/features/home/predict-card/team-button/index.tsx
+++ b/src/components/features/home/predict-card/team-button/index.tsx
@@ -149,10 +149,10 @@ export default function TeamButton({
 	};
 
 	const logoSize = (() => {
-		if (isMobile) return 'w-4 h-4 min-w-4 min-h-4';
 		if (isTablet)
 			return isClicked ? 'w-6 h-6 min-w-6 min-h-6' : 'w-[1.375rem] h-[1.375rem] min-w-[1.375rem] min-h-[1.375rem]';
 		if (isDesktop) return 'w-[1.375rem] h-[1.375rem] min-w-[1.375rem] min-h-[1.375rem]';
+		return 'w-4 h-4 min-w-4 min-h-4';
 	})();
 
 	return (


### PR DESCRIPTION
## 작업 내용
- 내부 요소들의 height가 너무 크게 늘어나는 문제인 것 같아
- **승부예측 카드 고정 height 적용**
- **로그인 모달 고정 height 적용**
- 으로 해결해보고자 했습니다! 테스트를 위해 바로 머지하겠습니다.
- 추가로 리그 선택 버튼 개행 문제와 함께 볼 만한 게시글 구분선 색상 수정했습니다.