### PR TITLE
[KO-451] 기기에 따라 UI가 깨지는 문제 해결

### DIFF
--- a/src/app/(with-side)/board/page.tsx
+++ b/src/app/(with-side)/board/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({
 	const page = params.page;
 
 	return (
-		<ComponentFrame className="@mobile:mb-[80px]" isMain={true}>
+		<ComponentFrame className="mb-5" isMain={true}>
 			<Suspense fallback={<EmptyState isNews={false} />}>
 				<CategoryTab mode="board" q={q} type={type} id={id} page={page} />
 			</Suspense>

--- a/src/app/(with-side)/news/page.tsx
+++ b/src/app/(with-side)/news/page.tsx
@@ -15,7 +15,7 @@ export default async function Page({
 	const page = params.page;
 
 	return (
-		<ComponentFrame className="@mobile:mb-[80px]" isMain={true}>
+		<ComponentFrame className="mb-5" isMain={true}>
 			<Suspense fallback={<EmptyState isNews={true} />}>
 				<CategoryTab mode="news" q={q} type={type} id={id} page={page} />
 			</Suspense>

--- a/src/components/common/login-modal/login-modal.tsx
+++ b/src/components/common/login-modal/login-modal.tsx
@@ -37,12 +37,15 @@ export default function LoginModal({ onClose }) {
 	}, [onClose]);
 
 	return (
-		<div className="fixed z-50 @mobile:z-60 flex justify-center items-center top-0 left-0 w-full h-full bg-black/40">
+		<div
+			className="fixed z-50 @mobile:z-60 flex justify-center items-center top-0 left-0
+				w-full h-full bg-black/40 @mobile:w-dvw @mobile:h-dvh"
+		>
 			<div
 				ref={modalRef}
 				className="flex flex-col items-center p-6 shadow-predict-button
 					w-[39.5rem] h-[39.75rem] bg-black-000 rounded-[0.625rem] display-semibold
-					@mobile:w-dvw @mobile:h-dvh @mobile:rounded-none @mobile:bg-black-100
+					@mobile:w-full @mobile:h-full @mobile:rounded-none @mobile:bg-black-100
 					@mobile:text-20 @mobile:font-semibold @mobile:leading-8"
 			>
 				<button onClick={handleXButtonClick} className="ml-auto mb-[4.6875rem] @mobile:mt-2 @mobile:mb-0">

--- a/src/components/layouts/with-side/floating-writing-button.tsx
+++ b/src/components/layouts/with-side/floating-writing-button.tsx
@@ -26,7 +26,7 @@ const FloatingWritingButton = () => {
 	return (
 		<div
 			className="desktop:w-[20.125rem] w-fit h-fit z-30 flex items-center sticky transition-all
-				bottom-15 ml-auto -mb-[20.125rem] desktop:-mr-[21.625rem] -mr-[5.125rem] min-[1094px]:max-[1200px]:mr-4 max-[848px]:mr-4"
+				bottom-15 ml-auto desktop:-mr-[21.625rem] -mr-[5.125rem] min-[1094px]:max-[1200px]:mr-4 max-[848px]:mr-4"
 		>
 			<button
 				onClick={handleEditButtonClick}


### PR DESCRIPTION
## 작업 내용
- 기기에 따라 하단 UI가 잘리는 문제가 있었는데, 플로팅 버튼이 있는 화면에서만 그러더라고요.
- 플로팅 버튼의 하단 음수 마진이 문제인가 싶어 제거해봤습니다! 테스트 위해 바로 머지하겠습니다.