### PR TITLE
[KO-453] 게시글 리스트 팀 로고 추가 & 기타 버그 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -32,6 +32,10 @@ const nextConfig: NextConfig = {
 				hostname: 'i.ytimg.com',
 			},
 			{
+				protocol: 'http',
+				hostname: 'img1.kakaocdn.net',
+			},
+			{
 				protocol: 'https',
 				hostname: 'img1.kakaocdn.net',
 			},

--- a/src/components/common/category-tab/community-item.tsx
+++ b/src/components/common/category-tab/community-item.tsx
@@ -47,7 +47,7 @@ export default function CommunityItem({
 					{title}
 				</h2>
 				{hasImage && <Image width={14} height={14} src="/image.svg" alt="사진" />}
-				<div className="body5-regular">{!!replies && `(${replies})`}</div>
+				<div className="body5-regular text-primary-900">{!!replies && `(${replies})`}</div>
 			</div>
 
 			<div

--- a/src/components/common/category-tab/community-item.tsx
+++ b/src/components/common/category-tab/community-item.tsx
@@ -12,6 +12,7 @@ export default function CommunityItem({
 	title,
 	replies,
 	user,
+	team,
 	createdAt,
 	hasImage,
 	views,
@@ -27,6 +28,15 @@ export default function CommunityItem({
 			)}
 		>
 			<div className="flex gap-1 items-center pr-2">
+				{team && (
+					<Image
+						width={16}
+						height={16}
+						src={team.logoUrl}
+						alt={team.nameKr || team.nameEn}
+						className="object-contain"
+					/>
+				)}{' '}
 				<h2
 					className={clsx(
 						'subtitle1-medium max-w-3xs truncate group-hover:underline',

--- a/src/components/common/category-tab/community-item.tsx
+++ b/src/components/common/category-tab/community-item.tsx
@@ -39,7 +39,7 @@ export default function CommunityItem({
 				)}{' '}
 				<h2
 					className={clsx(
-						'subtitle1-medium max-w-3xs truncate group-hover:underline',
+						'body5-medium max-w-3xs truncate group-hover:underline',
 						'@mobile:max-w-max @mobile:w-fit @mobile:text-15 @mobile:leading-4',
 						isPinned && 'text-primary-900 font-semibold @mobile:font-semibold',
 					)}

--- a/src/components/common/category-tab/tab-bar.tsx
+++ b/src/components/common/category-tab/tab-bar.tsx
@@ -18,12 +18,15 @@ export default function TabBar({ mode, q, type, id }: { mode: 'news' | 'board'; 
 		<div>
 			{/* 탭 바 */}
 			<div
-				className="relative w-full flex rounded-t-[0.625rem] bg-black-200 header-medium
+				className={clsx(
+					`relative w-full flex rounded-t-[0.625rem] bg-black-200 header-medium
 				@mobile:grid @mobile:grid-cols-[1fr_1fr_1fr_clamp(100px,30vw,150px)]
 				before:content-[''] before:absolute before:-top-1 before:-left-1 before:bottom-0 before:-right-1
 				before:inset-shadow-[0px_-2px_4px_0px_rgba(0,0,0,0.10)]
 				after:content-[''] after:absolute after:-bottom-4 after:left-0 after:right-0
-				after:bg-black-000"
+				after:bg-black-000`,
+					isNews && 'after:h-4',
+				)}
 			>
 				{tabs.map((tab, i) =>
 					!tab ? null : (

--- a/src/components/common/recommended-content.tsx
+++ b/src/components/common/recommended-content.tsx
@@ -70,7 +70,7 @@ const RecommendedContent = ({ mode, teamLogo = '', teamName = '' }) => {
 					'flex px-4 justify-between pb-1.5',
 					isNews ? '@mobile:pt-6 pt-7.5' : 'pt-7.5',
 					!isNews && 'border-b pb-7.5',
-					!isNews && (pathname === '/' ? 'border-black-700 @mobile:border-black-200' : 'border-black-200'),
+					!isNews && 'border-black-700 @mobile:border-black-200',
 				)}
 			>
 				<h3 className={clsx('title4-semibold', isNews ? '@mobile:text-16' : '@mobile:text-18')}>{displayTitle}</h3>

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -8,31 +8,44 @@ import PredictCardList from './predict-card-list';
 
 export default function PredictLeagueTab() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
-	const [selectedTeamPk, setSelectedTeamPk] = useState<undefined | number>(
-		currentUserInfo?.favoriteTeams?.length > 0 ? undefined : 1,
-	);
+	const [selectedTeamPk, setSelectedTeamPk] = useState<undefined | number>(undefined);
 
 	const teams = currentUserInfo?.favoriteTeams ?? [];
+	const favoriteTeamLength = currentUserInfo?.favoriteTeams.length;
 
-	// 응원팀이 하나 이상 있는 경우 전체 탭
+	// 응원팀이 하나만 있는 경우 별도의 firstTab 없음
+	// 응원팀이 둘 이상 있는 경우 전체 탭
 	// 응원팀이 없거나 비회원인 경우 프리미어리그 탭
 	const firstTab =
-		currentUserInfo?.favoriteTeams.length > 0
-			? { content: '전체', isActive: selectedTeamPk === undefined }
-			: {
-					pk: 1,
-					nameKr: '프리미어리그',
-					nameEn: 'Premier League',
-					logoUrl: 'https://media.api-sports.io/football/leagues/39.png',
-					type: 'League',
-				};
-	const tabs = [firstTab, ...teams];
+		favoriteTeamLength === 1
+			? null
+			: favoriteTeamLength > 1
+				? { content: '전체', isActive: selectedTeamPk === undefined }
+				: {
+						pk: 1,
+						nameKr: '프리미어리그',
+						nameEn: 'Premier League',
+						logoUrl: 'https://media.api-sports.io/football/leagues/39.png',
+						type: 'League',
+					};
+	const tabs = firstTab ? [firstTab, ...teams] : [...teams];
 
 	useEffect(() => {
 		// currentUserInfo 변경될 때마다 (로그인 상태가 변경될 때마다)
 		// default 활성탭 업데이트
-		setSelectedTeamPk(currentUserInfo?.favoriteTeams?.length > 0 ? undefined : 1);
-	}, [currentUserInfo]);
+
+		let defaultTeamPk: number | undefined;
+
+		if (favoriteTeamLength === 1) {
+			defaultTeamPk = currentUserInfo.favoriteTeams[0].pk;
+		} else if (favoriteTeamLength > 1) {
+			defaultTeamPk = undefined;
+		} else {
+			defaultTeamPk = 1;
+		}
+
+		setSelectedTeamPk(defaultTeamPk);
+	}, [currentUserInfo, favoriteTeamLength]);
 
 	return (
 		<div>

--- a/src/components/layouts/root/navbar/profile.tsx
+++ b/src/components/layouts/root/navbar/profile.tsx
@@ -72,7 +72,7 @@ export default function Profile({ onClickButton }: { onClickButton: () => void }
 							<span className="body2-regular text-black-800 @mobile:text-16">님</span>
 						</div>
 						<Image
-							className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
+							className="w-4 h-4 object-contain"
 							src={currentUserInfo.favoriteTeams.length > 0 ? currentUserInfo.favoriteTeams[0].logoUrl : '/ban.svg'}
 							alt="팀 로고 이미지"
 							width={16}

--- a/src/components/layouts/with-side/profile.tsx
+++ b/src/components/layouts/with-side/profile.tsx
@@ -106,7 +106,7 @@ export default function Profile() {
 											<div className="body3-regular text-black-800">님</div>
 										</div>
 										<Image
-											className="@mobile:w-4 @mobile:h-4 w-[1.125rem] h-[1.125rem] object-contain"
+											className="w-4 h-4 object-contain"
 											src={
 												currentUserInfo?.favoriteTeams.length > 0
 													? currentUserInfo?.favoriteTeams[0].logoUrl

--- a/src/services/apis/board/dto.ts
+++ b/src/services/apis/board/dto.ts
@@ -35,6 +35,7 @@ export interface BoardItemDto {
 	pk: number;
 	title: string;
 	user: UserDto;
+	team: TeamDto;
 	createdAt: string;
 	hasImage?: boolean;
 	views: number;

--- a/src/services/auth/dto.ts
+++ b/src/services/auth/dto.ts
@@ -28,7 +28,7 @@ export interface UserInfoDto {
 	providerType: string;
 	privacyAgreedAt: string;
 	marketingAgreedAt: string;
-	favoriteTeams?: TeamDto[];
+	favoriteTeams: TeamDto[];
 	league?: LeagueDto;
 	isInfluencer?: boolean;
 }


### PR DESCRIPTION
## 작업 내용
- 게시글 아이템 수정된 ui 적용했습니다
- before 요소가 모바일에서 인플루언서 게시글 위로 올라오는 문제가 있었는데, 이걸 없애자니 뉴스 리스트에서 탭 하단 그림자가 보이는 문제가 생겼습니다. 기존 h-4를 복구하고, 뉴스 리스트에서만 before 요소를 조건부로 렌더링해서 두 문제 모두 해결했습니다.
- 홈 승부예측에서 응원탭이 하나일 때에는 전체 탭이 안 뜨도록 수정했습니다.