### PR TITLE
[KO-495] 매치 온 캘린더 UI 수정

### DIFF
--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -188,9 +188,14 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	const canGoNext = dateForActiveMonth.getTime() < new Date(todayYear, todayMonth + 1, 1).getTime();
 
 	return (
-		<div className="calendar-wrapper">
-			<div className={`calendar-container ${isCollapsed ? 'collapsed' : ''}`}>
-				<div ref={calendarRef} className="relative">
+		<div className="w-full">
+			<div className={`relative opacity-100 ${isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'}`}>
+				<div
+					ref={calendarRef}
+					className={`relative transition-all duration-[400ms] ease opacity-100 ${
+						isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'
+					}`}
+				>
 					<Calendar
 						key={dateForActiveMonth.toISOString()}
 						view="month"

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -190,7 +190,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	return (
 		<div className="calendar-wrapper">
 			<div className={`calendar-container ${isCollapsed ? 'collapsed' : ''}`}>
-				<div ref={calendarRef} className="calendar-anim-wrapper">
+				<div ref={calendarRef} className="relative">
 					<Calendar
 						key={dateForActiveMonth.toISOString()}
 						view="month"
@@ -349,7 +349,10 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 						}}
 					/>
 				</div>
-				<button className="calendar-toggle w-full flex justify-center" onClick={() => setIsCollapsed((prev) => !prev)}>
+				<button
+					onClick={() => setIsCollapsed((prev) => !prev)}
+					className="flex w-full justify-center absolute bottom-2 left-1/2 -translate-x-1/2 z-10 bg-transparent border-none cursor-pointer"
+				>
 					<Image
 						src="/chevron/calendar-up.svg"
 						alt="toggle"

--- a/src/components/features/home/predict-card/team-button/index.tsx
+++ b/src/components/features/home/predict-card/team-button/index.tsx
@@ -4,8 +4,8 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import Score from './score';
 import { Dispatch, SetStateAction } from 'react';
-import { GameDto } from '@/services/apis/user-game-gamble/dto';
 import MobileUpdownButton from './mobile-updown-button';
+import { GameDto } from '@/services/apis/game/dto';
 
 interface TeamButtonInfoDto {
 	teamName: string;

--- a/src/components/layouts/root/mobile-navbar/index.tsx
+++ b/src/components/layouts/root/mobile-navbar/index.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import LoginButton from '../navbar/login-button';
 import Link from 'next/link';
 import clsx from 'clsx';
-import { useCallback, useState } from 'react';
+import { Suspense, useCallback, useState } from 'react';
 import Sidebar from './sidebar';
 import SideNavbar from './sidebar/side-navbar';
 import { default as SideProfile } from '../navbar/profile';
@@ -54,7 +54,9 @@ export default function MobileNavbar({ navButtons }: { navButtons: NavButton[] }
 					<Link href="/" className="w-auto h-full flex justify-center">
 						<Image src={'/logo/icon-red.svg'} alt="킥온 로고 이미지" width={45} height={36} />
 					</Link>
-					<LoginButton onClickProfile={handleToggleProfile} />
+					<Suspense>
+						<LoginButton onClickProfile={handleToggleProfile} />
+					</Suspense>
 				</div>
 			</header>
 

--- a/src/components/layouts/root/navbar/index.tsx
+++ b/src/components/layouts/root/navbar/index.tsx
@@ -8,6 +8,7 @@ import LoginButton from './login-button';
 import MobileNavbar from '../mobile-navbar';
 import useIsLeftSideVisible from '@/lib/hooks/useIsLeftSideVisible';
 import useIsDesktop from '@/lib/hooks/useIsDesktop';
+import { Suspense } from 'react';
 
 export interface NavButton {
 	href: string;
@@ -56,7 +57,11 @@ export default function Navbar() {
 					/>
 					{navButtons.map((props) => props && <NavButton key={props.content} {...props} />)}
 				</nav>
-				{(pathname === '/signup' || isTabletWidth) && <LoginButton />}
+				{(pathname === '/signup' || isTabletWidth) && (
+					<Suspense>
+						<LoginButton />
+					</Suspense>
+				)}
 			</div>
 		</header>
 	);

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -16,10 +16,6 @@
 	cursor: default;
 }
 
-.calendar-wrapper {
-	width: 100%;
-}
-
 .calendar-container {
 	position: relative;
 	max-height: 1000px;
@@ -60,17 +56,7 @@
 	transition:
 		max-height 1.5s ease,
 		opacity 1.5s ease;
-	padding: 26px 5px 30px 5px;
-}
-
-/* 토글 버튼을 달력 하단에 고정 */
-.calendar-toggle {
-	position: absolute;
-	bottom: 0;
-	left: 50%;
-	transform: translateX(-50%);
-	cursor: pointer;
-	z-index: 10;
+	padding: 26px 5px 48px 5px;
 }
 
 /* 오늘 날짜는 abbr 숨기기 */

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -16,29 +16,6 @@
 	cursor: default;
 }
 
-.calendar-container {
-	position: relative;
-	max-height: 1000px;
-	opacity: 1;
-}
-
-.calendar-container.collapsed {
-	max-height: 250px;
-	opacity: 1;
-}
-
-.calendar-anim-wrapper {
-	transition:
-		max-height 0.4s ease,
-		opacity 0.4s ease;
-	max-height: 500px;
-	opacity: 1;
-}
-
-.collapsed .calendar-anim-wrapper {
-	max-height: 250px;
-}
-
 .custom-calendar {
 	position: relative;
 	overflow: hidden;

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -37,7 +37,6 @@
 
 .collapsed .calendar-anim-wrapper {
 	max-height: 250px;
-	pointer-events: none;
 }
 
 .custom-calendar {


### PR DESCRIPTION
## 작업 내용
- 토글 버튼 부분의 위치를 수정했습니다. 처음에는 달마다 날짜의 수가 달라서 전체 달력 크기가 달라지기 때문에 절대적 위치로 잡은 토글 버튼 위치도 종잡을 수 없는 줄 알았는데, max-height이 충분하지 않고 달력 높이보다 적었어서 위로 올라가 있던 것이었습니다... 😅 충분히 큰 수인 1000으로 잡아 수정했고 캘린더 자체가 아닌 캘린더 외부 배치 부분에 대한 스타일링은 tailwind로 변환했습니다.
- 달력이 접힌 상태에서 달 이동이 안 된 이유는 접힌 상태에서 `pointer-events: none;` 클릭을 막았기 때문입니다. 해당 부분 삭제했습니다.
- 빌드 체크하며 gameDto의 import 버그를 수정했습니다.