### PR TITLE
[KO-518] 예측 결과 UI 수정

### DIFF
--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -77,10 +77,10 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 
 		// 범위 체크
 		const newDate = new Date(newYear, newMonth, 1);
-		if (newDate >= minDate && newDate < maxDate) {
-			setDateForActiveMonth(newDate);
-			updateUrlParams(newDate); // URL 파라미터 업데이트
-		}
+		// if (newDate >= minDate && newDate < maxDate) {
+		setDateForActiveMonth(newDate);
+		updateUrlParams(newDate); // URL 파라미터 업데이트
+		// }
 	};
 
 	// URL 파라미터가 변경될 때 activeDate 업데이트
@@ -184,8 +184,9 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	const maxDate = new Date(todayYear, todayMonth + 2, 1); // 다음 달의 다음 달 1일
 
 	// 화살표 표시 여부
-	const canGoPrev = dateForActiveMonth.getTime() > minDate.getTime();
-	const canGoNext = dateForActiveMonth.getTime() < new Date(todayYear, todayMonth + 1, 1).getTime();
+	const canGoPrev = isMatch ? dateForActiveMonth.getTime() > minDate.getTime() : true;
+	const canGoNext =
+		dateForActiveMonth.getTime() < new Date(todayYear, isMatch ? todayMonth + 1 : todayMonth, 1).getTime();
 
 	return (
 		<div className="w-full">
@@ -314,6 +315,8 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 							const isFocused = selectedDate && isSameDate(d, selectedDate);
 							const isToday = isSameDate(d, today);
 
+							// TODO: 단순히 과거 미래에 따른 분기보다는 개별 isActive로 관리하는 게 나을 것 같음
+							// -> 예측 결과 페이지에서는 예측 참여한 날짜만 active되어야 함
 							let baseClass = '';
 							if (isFocused && isToday) baseClass = 'focused-today-tile';
 							else if (isFocused) baseClass = 'focused-tile';

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -341,7 +341,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 
 							return (
 								<div className="flex flex-col items-center gap-1 mt-1">
-									{isToday && <span className="text-primary-900">오늘</span>}
+									{isToday && <span>오늘</span>}
 
 									{count > 0 && (
 										<div className="flex flex-row items-center gap-2">

--- a/src/components/features/gamble/chart.tsx
+++ b/src/components/features/gamble/chart.tsx
@@ -6,17 +6,19 @@ export default function Chart({ totalSuccessRate }: { totalSuccessRate: number }
 	return (
 		<svg viewBox="0 0 124 124">
 			<circle cx="62" cy="62" r={R} fill="none" stroke="var(--color-black-200)" strokeWidth={strokeWidth} />
-			<circle
-				cx="62"
-				cy="62"
-				r={R}
-				fill="none"
-				stroke="var(--color-primary-900)"
-				strokeWidth={strokeWidth}
-				strokeLinecap="round"
-				strokeDasharray={`${CIRCUMFERENCE * totalSuccessRate} ${CIRCUMFERENCE * (1 - totalSuccessRate)}`}
-				strokeDashoffset={CIRCUMFERENCE * 0.25}
-			/>
+			{totalSuccessRate > 0 && (
+				<circle
+					cx="62"
+					cy="62"
+					r={R}
+					fill="none"
+					stroke="var(--color-primary-900)"
+					strokeWidth={strokeWidth}
+					strokeLinecap="round"
+					strokeDasharray={`${CIRCUMFERENCE * totalSuccessRate} ${CIRCUMFERENCE * (1 - totalSuccessRate)}`}
+					strokeDashoffset={CIRCUMFERENCE * 0.25}
+				/>
+			)}
 		</svg>
 	);
 }

--- a/src/components/features/gamble/most-hit-team.tsx
+++ b/src/components/features/gamble/most-hit-team.tsx
@@ -1,29 +1,52 @@
+import clsx from 'clsx';
+
 export default function MostHitTeam({
+	totalParticipationCount,
 	teamName,
 	teamLogo,
 	teamColor,
 }: {
+	totalParticipationCount: number;
 	teamName: string;
 	teamLogo: string;
 	teamColor: string;
 }) {
+	const hasColor = Boolean(totalParticipationCount && teamName);
 	return (
 		<div
-			className="relative overflow-hidden h-15 body7-medium bg-black-100
+			className={clsx(
+				`relative overflow-hidden h-15 body7-medium bg-black-100
 				border rounded-lg border-[var(--team-color)]
         before:content-[''] before:absolute before:top-1/2 before:-right-5
         before:h-[13px] before:w-20 before:rotate-311 before:bg-[var(--team-color)]
         after:content-[''] after:absolute after:top-1/2 after:-translate-y-1/2
-        after:-right-3 after:h-[13px] after:w-30 after:rotate-311 after:bg-[var(--team-color)]"
-			style={{ '--team-color': teamColor } as React.CSSProperties}
+        after:-right-3 after:h-[13px] after:w-30 after:rotate-311 after:bg-[var(--team-color)]`,
+				{ 'before:hidden after:hidden': !hasColor },
+			)}
+			style={{ '--team-color': hasColor ? teamColor : 'var(--color-black-200)' } as React.CSSProperties}
 		>
-			<div
-				className="absolute z-10 top-1/2 left-4 -translate-y-1/2
+			{hasColor && (
+				<div
+					className="absolute z-10 top-1/2 left-4 -translate-y-1/2
           bg-no-repeat bg-center bg-contain opacity-20 w-27 h-auto aspect-square"
-				style={{ backgroundImage: `url(${teamLogo || '/kick/red.svg'})` }}
-			/>
-			<div className="absolute z-10 top-1/2 left-1/2 -translate-y-1/2 -translate-x-5/11 w-[60%] text-center">
-				<span className="font-semibold break-keep">{teamName}</span>의 승부예측을 가장 많이 적중했어요.
+					style={{ backgroundImage: `url(${teamLogo || '/kick/red.svg'})` }}
+				/>
+			)}
+			<div
+				className={clsx(
+					'absolute z-10 top-1/2 left-1/2 -translate-y-1/2 text-center',
+					totalParticipationCount && teamName ? '-translate-x-5/11 w-[60%]' : '-translate-x-1/2 w-full',
+				)}
+			>
+				{!totalParticipationCount ? (
+					'승부예측에 참여한 이력이 없어요.'
+				) : !teamName ? (
+					'아직 예측에 적중한 팀이 없어요.'
+				) : (
+					<>
+						<span className="font-semibold break-keep">{teamName}</span>의 승부예측을 가장 많이 적중했어요.
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/features/gamble/predict-result.tsx
+++ b/src/components/features/gamble/predict-result.tsx
@@ -39,7 +39,7 @@ export default function PredictResult() {
 		};
 
 		apiCaller();
-	}, [selectedDate]);
+	}, [selectedDate, currentUserInfo]);
 
 	if (!currentUserInfo) {
 		router.replace('/gamble?type=match');

--- a/src/components/features/gamble/stat.tsx
+++ b/src/components/features/gamble/stat.tsx
@@ -81,6 +81,7 @@ export default function Stat() {
 
 					{!isMobile && (
 						<MostHitTeam
+							totalParticipationCount={statData.totalParticipationCount}
 							teamName={statData.mostHitTeamName}
 							teamLogo={statData.mostHitTeamLogoUrl}
 							teamColor={statData.mostHitTeamColor ?? 'var(--color-primary-900)'}
@@ -92,6 +93,7 @@ export default function Stat() {
 			{isMobile && (
 				<div className="mt-6">
 					<MostHitTeam
+						totalParticipationCount={statData.totalParticipationCount}
 						teamName={statData.mostHitTeamName}
 						teamLogo={statData.mostHitTeamLogoUrl}
 						teamColor={statData.mostHitTeamColor ?? 'var(--color-primary-900)'}

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -110,7 +110,7 @@
 .custom-calendar .focused-today-tile {
 	color: #c00c0b;
 	border: 2px solid #c00c0b !important;
-	background-color: #c00c0b0d;
+	background-color: #c00c0b0d !important;
 	border-radius: 8px;
 	padding: 10px 10px 30px 10px;
 	width: 100%;
@@ -202,7 +202,7 @@
 .custom-calendar-mobile .focused-today-tile {
 	color: #c00c0b;
 	border: 2px solid #c00c0b !important;
-	background-color: #c00c0b0d;
+	background-color: #c00c0b0d !important;
 	border-radius: 8px;
 	padding: 12px 8px 28px 8px;
 	width: 100%;

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -12,7 +12,7 @@
 .react-calendar__tile:hover,
 .focused-today-tile:hover {
 	background-color: #c00c0b0d !important; /* 기존 배경 유지 */
-	color: #c00c0b !important; /* 기존 텍스트 색상 유지 */
+	/* color: #c00c0b !important; 기존 텍스트 색상 유지 */
 	cursor: default;
 }
 
@@ -108,6 +108,7 @@
 
 /* 오늘 날짜 타일 스타일 */
 .custom-calendar .focused-today-tile {
+	color: #c00c0b;
 	border: 2px solid #c00c0b !important;
 	background-color: #c00c0b0d;
 	border-radius: 8px;
@@ -124,7 +125,8 @@
 }
 
 .custom-calendar .not-focused-today-tile {
-	border: 2px solid #c00c0b !important;
+	color: #c00c0b4d;
+	border: 2px solid #c00c0b4d !important;
 	background-color: #fff;
 	border-radius: 8px;
 	padding: 10px 10px 30px 10px;
@@ -139,7 +141,8 @@
 	font-weight: 500;
 }
 .custom-calendar-mobile .not-focused-today-tile {
-	border: 2px solid #c00c0b !important;
+	color: #c00c0b4d;
+	border: 2px solid #c00c0b4d !important;
 	background-color: #fff;
 	border-radius: 8px;
 	padding: 12px 8px 28px 8px;
@@ -190,7 +193,6 @@
 
 .custom-calendar .today-text {
 	display: flex;
-	color: #c00c0b;
 	text-align: center;
 	font-size: 15px;
 	font-weight: 600;
@@ -198,6 +200,7 @@
 }
 
 .custom-calendar-mobile .focused-today-tile {
+	color: #c00c0b;
 	border: 2px solid #c00c0b !important;
 	background-color: #c00c0b0d;
 	border-radius: 8px;
@@ -213,7 +216,6 @@
 }
 
 .custom-calendar-mobile .today-text {
-	color: #c00c0b;
 	text-align: center;
 	font-size: 13px;
 	font-weight: 600;


### PR DESCRIPTION
## 작업 내용
- 참여한 예측이 없거나, 적중 팀이 없는 경우 stat 컴포넌트 UI 수정
- 캘린더 '오늘' UI 수정
- 예측 결과에서 캘린더를 이전 달로 넘길 수 있도록 수정(날짜 유효성 검사 로직 주석 처리)

## 작업 화면
<img width="1038" height="991" alt="image" src="https://github.com/user-attachments/assets/6fc766a6-e536-4c26-ae24-ca87b092a227" />

## 캘린더 관련 남은 작업
- 예측 결과 페이지에서는 참여한 예측이 있는 날짜만 클릭 가능한 상태로 활성화돼야 한다고 합니다!
- 현재는 단순히 과거인지 미래인지로 날짜를 관리하고 있어서, 해당 부분은 처리가 어려울 것 같아 남겨두었습니다.
- 캘린더 리팩토링하면서 단순 과거/미래보다는 개별 isActive를 관리하는 게 좋지 않을까 싶습니다.
