### PR TITLE
[KO-194] PR 194 코멘트 적용

### DIFF
--- a/src/components/features/notice/notice-header.tsx
+++ b/src/components/features/notice/notice-header.tsx
@@ -14,7 +14,10 @@ export default function NoticeHeader({ isModal = false, onClose }: NoticeHeaderP
 
 	return (
 		<div
-			className={clsx('relative flex justify-center items-center border-b border-black-200', isModal ? 'py-5' : 'py-6')}
+			className={clsx(
+				'relative flex justify-center overflow-none items-center rounded-t-[0.625rem] border-b border-black-200 bg-white',
+				isModal ? 'py-5' : 'py-6',
+			)}
 		>
 			{!isModal && (
 				<button

--- a/src/components/features/notice/notice-item.tsx
+++ b/src/components/features/notice/notice-item.tsx
@@ -72,23 +72,22 @@ export default function NoticeItem({
 	return (
 		<div
 			onClick={handleClickNotification}
-			className={clsx(
-				'relative flex gap-4 p-4 cursor-pointer hover:bg-black-100',
-				read ? 'bg-black-100' : 'bg-black-000',
-			)}
+			className={clsx('relative flex gap-4 p-4 cursor-pointer hover:bg-black-100', read ? 'bg-black-100' : 'bg-white')}
 		>
-			<div className="flex items-center justify-center w-8 h-8 rounded-full bg-black-200">
+			<div className="flex items-center justify-center w-8 h-8 rounded-full bg-black-200 flex-shrink-0">
 				<Image src={typeMap[normalizeType(type)].icon} alt="알림 출처" width={18} height={18} />
 			</div>
-			<div className="flex flex-col gap-[5px]">
+
+			<div className="flex flex-col gap-[5px] flex-1 min-w-0">
 				<div className="flex text-black-600">
 					<span className="mr-[2px] subtitle2-medium">{typeMap[normalizeType(type)].label}</span>
 					<span className="mx-2 mt-[1px] leading-none">·</span>
 					<span className="body7-regular">{relativeTime}</span>
 				</div>
-				<span className="body6-regular">{content}</span>
+				<span className="body6-regular break-words">{content}</span>
 			</div>
-			{!read && <div className="w-[6px] h-[6px] rounded-full bg-negative self-center ml-auto" />}
+
+			{!read && <div className="w-[6px] h-[6px] rounded-full bg-negative self-center ml-auto flex-shrink-0" />}
 		</div>
 	);
 }

--- a/src/components/features/notice/notice-item.tsx
+++ b/src/components/features/notice/notice-item.tsx
@@ -72,7 +72,10 @@ export default function NoticeItem({
 	return (
 		<div
 			onClick={handleClickNotification}
-			className={clsx('relative flex gap-4 p-4 cursor-pointer hover:bg-black-100', read ? 'bg-black-100' : 'bg-white')}
+			className={clsx(
+				'relative flex gap-4 p-4 cursor-pointer hover:bg-black-100 last:pb-8',
+				read ? 'bg-black-100' : 'bg-white',
+			)}
 		>
 			<div className="flex items-center justify-center w-8 h-8 rounded-full bg-black-200 flex-shrink-0">
 				<Image src={typeMap[normalizeType(type)].icon} alt="알림 출처" width={18} height={18} />

--- a/src/components/layouts/root/navbar/index.tsx
+++ b/src/components/layouts/root/navbar/index.tsx
@@ -46,7 +46,7 @@ export default function Navbar() {
 		<MobileNavbar navButtons={navButtons} />
 	) : (
 		<header className={`${isHome ? 'bg-black-000' : 'bg-black-800'} sticky z-30 transition-colors ease-out`}>
-			<div className="flex items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
+			<div className="flex justify-between items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
 				<nav className="flex items-center">
 					<Image
 						width={216}

--- a/src/components/layouts/root/navbar/index.tsx
+++ b/src/components/layouts/root/navbar/index.tsx
@@ -46,7 +46,7 @@ export default function Navbar() {
 		<MobileNavbar navButtons={navButtons} />
 	) : (
 		<header className={`${isHome ? 'bg-black-000' : 'bg-black-800'} sticky z-30 transition-colors ease-out`}>
-			<div className="flex justify-between items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
+			<div className="flex items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
 				<nav className="flex items-center">
 					<Image
 						width={216}

--- a/src/components/layouts/root/navbar/login-button.tsx
+++ b/src/components/layouts/root/navbar/login-button.tsx
@@ -61,11 +61,11 @@ export default function LoginButton({ onClickProfile }: { onClickProfile?: () =>
 	return (
 		<>
 			{isLoggedIn ? (
-				<div className="relative w-fit flex">
+				<div className="relative w-fit h-full flex">
 					<button
 						onClick={handleProfileButtonClick}
 						className={clsx(
-							`rounded-full w-[2.375rem] h-full mr-[0.3438rem] @mobile:w-7 @mobile:h-7 @mobile:mr-0
+							`rounded-full w-[2.375rem] h-[2.375rem] mr-[0.3438rem] @mobile:w-7 @mobile:h-7 @mobile:mr-0
 							outline-[0.5625rem] active:outline-black-500/45 transition-colors`,
 							isProfileModalOpen ? 'outline-black-500/45' : 'outline-transparent',
 						)}

--- a/src/components/layouts/root/navbar/login-button.tsx
+++ b/src/components/layouts/root/navbar/login-button.tsx
@@ -65,7 +65,7 @@ export default function LoginButton({ onClickProfile }: { onClickProfile?: () =>
 					<button
 						onClick={handleProfileButtonClick}
 						className={clsx(
-							`rounded-full w-[2.375rem] h-[2.375rem] mr-[0.3438rem] @mobile:w-7 @mobile:h-7 @mobile:mr-0
+							`rounded-full w-[2.375rem] h-full mr-[0.3438rem] @mobile:w-7 @mobile:h-7 @mobile:mr-0
 							outline-[0.5625rem] active:outline-black-500/45 transition-colors`,
 							isProfileModalOpen ? 'outline-black-500/45' : 'outline-transparent',
 						)}

--- a/src/components/layouts/root/navbar/notice-button.tsx
+++ b/src/components/layouts/root/navbar/notice-button.tsx
@@ -6,16 +6,12 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import NoticeModal from './notice-modal';
 import { useNotificationStore } from '@/lib/store/useNotificationStore';
-import clsx from 'clsx';
-import useIsTabletWidth from '@/lib/hooks/useIsTabletWidth';
-import useIsDesktop from '@/lib/hooks/useIsDesktop';
 
 export default function NoticeButton() {
 	const pathname = usePathname();
 	const router = useRouter();
 	const isMobile = useIsMobile();
-	const isTabletWidth = useIsTabletWidth();
-	const isDesktop = useIsDesktop();
+
 	const [isNoticeModalOpen, setIsNoticeModalOpen] = useState(false);
 
 	const handleNoticeIconClick = () => {
@@ -31,9 +27,7 @@ export default function NoticeButton() {
 	const unreadCount = useNotificationStore((s) => s.unreadCount);
 
 	return (
-		<div
-			className={clsx('relative w-fit h-full items-center flex', isDesktop && !isTabletWidth ? 'ml-[374px]' : 'ml-0')}
-		>
+		<div className="relative w-fit h-full items-center flex">
 			<button onClick={handleNoticeIconClick} className="relative w-6 h-6 @mobile:w-5 @mobile:h-5">
 				<Image src={iconSrc} alt="알림 아이콘" width={24} height={24} />
 

--- a/src/components/layouts/root/navbar/notice-button.tsx
+++ b/src/components/layouts/root/navbar/notice-button.tsx
@@ -6,11 +6,16 @@ import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import NoticeModal from './notice-modal';
 import { useNotificationStore } from '@/lib/store/useNotificationStore';
+import clsx from 'clsx';
+import useIsTabletWidth from '@/lib/hooks/useIsTabletWidth';
+import useIsDesktop from '@/lib/hooks/useIsDesktop';
 
 export default function NoticeButton() {
 	const pathname = usePathname();
 	const router = useRouter();
 	const isMobile = useIsMobile();
+	const isTabletWidth = useIsTabletWidth();
+	const isDesktop = useIsDesktop();
 	const [isNoticeModalOpen, setIsNoticeModalOpen] = useState(false);
 
 	const handleNoticeIconClick = () => {
@@ -26,7 +31,9 @@ export default function NoticeButton() {
 	const unreadCount = useNotificationStore((s) => s.unreadCount);
 
 	return (
-		<div className="relative w-fit h-full items-center flex">
+		<div
+			className={clsx('relative w-fit h-full items-center flex', isDesktop && !isTabletWidth ? 'ml-[374px]' : 'ml-0')}
+		>
 			<button onClick={handleNoticeIconClick} className="relative w-6 h-6 @mobile:w-5 @mobile:h-5">
 				<Image src={iconSrc} alt="알림 아이콘" width={24} height={24} />
 

--- a/src/components/layouts/root/navbar/notice-modal.tsx
+++ b/src/components/layouts/root/navbar/notice-modal.tsx
@@ -28,7 +28,7 @@ export default function NoticeModal({ onCloseModal }: { onCloseModal: () => void
 	return (
 		<div
 			ref={modalRef}
-			className="absolute top-[3.375rem] -right-[1.05rem] w-[20.25rem] h-[630px]
+			className="absolute top-[2.95rem] -right-[1.05rem] w-[20.25rem] h-[630px]
                 bg-black-000 border border-black-100 rounded-[0.625rem]
                 flex flex-col shadow-navbar-modal z-25"
 		>

--- a/src/components/layouts/root/navbar/notice-modal.tsx
+++ b/src/components/layouts/root/navbar/notice-modal.tsx
@@ -28,9 +28,9 @@ export default function NoticeModal({ onCloseModal }: { onCloseModal: () => void
 	return (
 		<div
 			ref={modalRef}
-			className="absolute top-[3.375rem] -right-[1.05rem] w-[20.25rem] h-[39.375rem] 
-                            bg-black-000 border border-black-100 rounded-[0.625rem]
-                            flex flex-col shadow-navbar-modal"
+			className="absolute top-[3.375rem] -right-[1.05rem] w-[20.25rem] h-[630px]
+                bg-black-000 border border-black-100 rounded-[0.625rem]
+                flex flex-col shadow-navbar-modal z-25"
 		>
 			<Image
 				className="absolute -top-2.5 right-[1.125rem]"
@@ -43,20 +43,22 @@ export default function NoticeModal({ onCloseModal }: { onCloseModal: () => void
 				alt="화살표"
 			/>
 			<NoticeHeader isModal={true} onClose={onCloseModal} />
-			{notifications.map((notice) => (
-				<NoticeItem
-					key={notice.pk}
-					pk={notice.pk}
-					type={notice.type}
-					read={notice.read}
-					teamLogo={notice.teamLogo}
-					redirectUrl={notice.redirectUrl}
-					relativeTime={notice.relativeTime}
-					content={notice.content}
-					isModal={true}
-					onCloseModal={onCloseModal}
-				/>
-			))}
+			<div className="flex-1 rounded-b-[0.625rem] overflow-y-auto no-scrollbar">
+				{notifications.map((notice) => (
+					<NoticeItem
+						key={notice.pk}
+						pk={notice.pk}
+						type={notice.type}
+						read={notice.read}
+						teamLogo={notice.teamLogo}
+						redirectUrl={notice.redirectUrl}
+						relativeTime={notice.relativeTime}
+						content={notice.content}
+						isModal={true}
+						onCloseModal={onCloseModal}
+					/>
+				))}
+			</div>
 		</div>
 	);
 }

--- a/src/components/layouts/root/navbar/notice-modal.tsx
+++ b/src/components/layouts/root/navbar/notice-modal.tsx
@@ -28,7 +28,7 @@ export default function NoticeModal({ onCloseModal }: { onCloseModal: () => void
 	return (
 		<div
 			ref={modalRef}
-			className="absolute top-[2.95rem] -right-[1.05rem] w-[20.25rem] h-[630px]
+			className="absolute top-[3.375rem] -right-[1.05rem] w-[20.25rem] h-[630px]
                 bg-black-000 border border-black-100 rounded-[0.625rem]
                 flex flex-col shadow-navbar-modal z-25"
 		>

--- a/src/components/layouts/root/navbar/notification-initializer.tsx
+++ b/src/components/layouts/root/navbar/notification-initializer.tsx
@@ -29,21 +29,6 @@ export default function NotificationInitializer() {
 		};
 
 		fetchInitialData();
-
-		// 폴링 (5분마다 unread count 동기화, 장시간 켜져 있어도 서버와 싱크 유지)
-		const interval = setInterval(
-			async () => {
-				try {
-					const unread = await getUnreadNotifications();
-					if (unread) setUnreadCount(unread.data.count);
-				} catch (error) {
-					console.error('unread count 폴링 실패:', error);
-				}
-			},
-			5 * 60 * 1000,
-		);
-
-		return () => clearInterval(interval);
 	}, [currentUserInfo?.id]);
 
 	return null;

--- a/src/components/layouts/root/navbar/right-buttons.tsx
+++ b/src/components/layouts/root/navbar/right-buttons.tsx
@@ -20,15 +20,11 @@ export default function RightButton({ isMobile = false, isTabletWidth = false, o
 	return (
 		<div
 			className={clsx(
-				'grid grid-cols-[auto_auto] items-center justify-center',
+				'h-[2.375rem] grid grid-cols-[auto_auto] items-center justify-center',
 				isMobile ? ' gap-[18px] ml-auto' : 'gap-6',
 			)}
 		>
-			{currentUserInfo && (
-				<div className="relative flex items-center">
-					<NoticeButton />
-				</div>
-			)}
+			{currentUserInfo && <NoticeButton />}
 			<Suspense>
 				{isMobile ? (
 					<LoginButton onClickProfile={onClickProfile} />

--- a/src/components/layouts/root/navbar/right-buttons.tsx
+++ b/src/components/layouts/root/navbar/right-buttons.tsx
@@ -24,7 +24,11 @@ export default function RightButton({ isMobile = false, isTabletWidth = false, o
 				isMobile ? ' gap-[18px] ml-auto' : 'gap-6',
 			)}
 		>
-			{currentUserInfo && <NoticeButton />}
+			{currentUserInfo && (
+				<div className="relative flex items-center">
+					<NoticeButton />
+				</div>
+			)}
 			<Suspense>
 				{isMobile ? (
 					<LoginButton onClickProfile={onClickProfile} />


### PR DESCRIPTION
### 작업 내용
- 불필요한 폴링 로직 제거했습니다. 그리고 addNotification에서 이미 안 읽은 알림 개수 증감을 적용하고 있기 때문에 폴링 로직만 제거했습니다!
- 알림 모달에 고정 너비를 주고 noticeitem을 뿌리는 영역에만 스크롤을 넣었습니다. 
- 알림 모달의 배경색을 조정하고(bg-black-000 → bg-white), flex 아이템에 flex-1/min-w-0/flex-shrink-0를 적용해 긴 텍스트 줄바꿈과 아이콘·뱃지 크기 고정이 되도록 수정했습니다.
- 알림 버튼과 프로필 버튼이 grid로 감싸져 있어 프로필 버튼 높이로 강제 되어 프로필 버튼 높이가 없으면 모달과 알림 버튼 사이에 간격이 생겼는데... 우선 알림 버튼만 relative로 감싸고 모달은 absolute로 띄웠으니 항상 알림 버튼 기준으로 위치 잡도록 수정했는데 어떠신가요...? 여러 기기에서 테스트해보니 프로필 모달과도 위치 동일해 보이고 혼자 있을 때도 괜찮습니다... ㅠㅠ