### PR TITLE
[KO-530] 응원팀이 없는 경우 프로필 설정에 응원팀 리스트가 뜨지 않는 문제 해결

### DIFF
--- a/src/components/common/account/favorite-team-item.tsx
+++ b/src/components/common/account/favorite-team-item.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
+import { NO_CHEERING_TEAM_PK } from '@/lib/constants/noCheeringTeam';
 
 export default function FavoriteTeamItem({
 	team,

--- a/src/components/common/account/favorite-team-list.tsx
+++ b/src/components/common/account/favorite-team-list.tsx
@@ -15,7 +15,7 @@ import {
 } from '@dnd-kit/core';
 import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { arrayMove } from '@dnd-kit/sortable';
-import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
+import { NO_CHEERING_TEAM_PK } from '@/lib/constants/noCheeringTeam';
 import { TeamDto } from '@/services/apis/team/dto';
 
 export default function FavoriteTeamList({

--- a/src/components/common/account/favorite-team-section.tsx
+++ b/src/components/common/account/favorite-team-section.tsx
@@ -44,7 +44,22 @@ export default function FavoriteTeamSection({
 
 	useEffect(() => {
 		if (initialTeams) {
-			setFavoriteTeams(initialTeams);
+			const teams =
+				initialTeams.length === 0
+					? [
+							{
+								pk: -1,
+								nameKr: '응원팀이 없어요',
+								nameEn: 'no cheering team',
+								logoUrl: '/ban.svg',
+								leaguePk: -1,
+								leagueNameKr: '응원팀이 없어요',
+								leagueNameEn: 'no cheering team',
+								leagueLogoUrl: '/ban.svg',
+							},
+						]
+					: initialTeams;
+			setFavoriteTeams(teams);
 		}
 	}, [initialTeams]);
 

--- a/src/components/common/account/favorite-team-section.tsx
+++ b/src/components/common/account/favorite-team-section.tsx
@@ -5,7 +5,7 @@ import { TeamDto } from '@/services/apis/team/dto';
 import dynamic from 'next/dynamic';
 import FavoriteTeamItem from './favorite-team-item';
 import SelectSection from './select-section';
-import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
+import { NO_CHEERING_TEAM, NO_CHEERING_TEAM_PK } from '@/lib/constants/noCheeringTeam';
 import FavoriteTeamHeader from './favorite-team-header';
 
 // dnd-kit 컴포넌트 hydration mismatch 가능성 존재 -> ssr 비활성화
@@ -44,21 +44,7 @@ export default function FavoriteTeamSection({
 
 	useEffect(() => {
 		if (initialTeams) {
-			const teams =
-				initialTeams.length === 0
-					? [
-							{
-								pk: -1,
-								nameKr: '응원팀이 없어요',
-								nameEn: 'no cheering team',
-								logoUrl: '/ban.svg',
-								leaguePk: -1,
-								leagueNameKr: '응원팀이 없어요',
-								leagueNameEn: 'no cheering team',
-								leagueLogoUrl: '/ban.svg',
-							},
-						]
-					: initialTeams;
+			const teams = initialTeams.length === 0 ? [NO_CHEERING_TEAM] : initialTeams;
 			setFavoriteTeams(teams);
 		}
 	}, [initialTeams]);

--- a/src/components/common/account/select-section.tsx
+++ b/src/components/common/account/select-section.tsx
@@ -6,7 +6,7 @@ import { LeagueDto } from '@/services/apis/league/dto';
 import { TeamDto } from '@/services/apis/team/dto';
 import { getLeague } from '@/services/apis/league';
 import { getTeam } from '@/services/apis/team';
-import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
+import { NO_CHEERING_TEAM, NO_CHEERING_TEAM_PK } from '@/lib/constants/noCheeringTeam';
 import { Option } from '../option-item';
 
 export default function SelectSection({
@@ -70,20 +70,7 @@ export default function SelectSection({
 
 	const handleLeagueChange = (pk: number) => {
 		if (pk === NO_CHEERING_TEAM_PK) {
-			const newFavoriteTeams = favoriteTeams.map((team, i) =>
-				i === selectedIndex
-					? {
-							pk: -1,
-							nameKr: '응원팀이 없어요',
-							nameEn: 'no cheering team',
-							logoUrl: '/ban.svg',
-							leaguePk: -1,
-							leagueNameKr: '응원팀이 없어요',
-							leagueNameEn: 'no cheering team',
-							leagueLogoUrl: '/ban.svg',
-						}
-					: { ...team },
-			);
+			const newFavoriteTeams = favoriteTeams.map((team, i) => (i === selectedIndex ? NO_CHEERING_TEAM : { ...team }));
 			setFavoriteTeams(newFavoriteTeams);
 		} else if (pk !== selectedLeaguePk) {
 			setIsTeamDropdownOpen(true);

--- a/src/components/common/account/selectbox.tsx
+++ b/src/components/common/account/selectbox.tsx
@@ -6,7 +6,7 @@ import OptionItem, { Option } from '@/components/common/option-item';
 import clsx from 'clsx';
 import { TeamDto } from '@/services/apis/team/dto';
 import { LeagueDto } from '@/services/apis/league/dto';
-import { NO_CHEERING_TEAM_PK } from '@/lib/constants';
+import { NO_CHEERING_TEAM_PK } from '@/lib/constants/noCheeringTeam';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import AlertModal from '@/components/features/detail/alert-modal';
 import { separateMonthAndDay } from '@/lib/utils';

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -1,1 +1,0 @@
-export const NO_CHEERING_TEAM_PK = -1;

--- a/src/lib/constants/noCheeringTeam.ts
+++ b/src/lib/constants/noCheeringTeam.ts
@@ -1,0 +1,12 @@
+export const NO_CHEERING_TEAM_PK = -1;
+
+export const NO_CHEERING_TEAM = {
+	pk: NO_CHEERING_TEAM_PK,
+	nameKr: '응원팀이 없어요',
+	nameEn: 'no cheering team',
+	logoUrl: '/ban.svg',
+	leaguePk: -1,
+	leagueNameKr: '응원팀이 없어요',
+	leagueNameEn: 'no cheering team',
+	leagueLogoUrl: '/ban.svg',
+};


### PR DESCRIPTION
## 문제 상황
- favorite team list 컴포넌트에서는 pk가 -1일 때 응원팀이 없어요 ui를 보여줌
- 유저가 응원팀이 없어요를 선택한 경우 user의 favoriteTeams 가 빈 배열로 옴
- 해당 배열을 그대로 사용할 경우 [].map -> 요소가 없어서 favorite team list가 렌더링이 안 됨

## 해결
- initialTeams가 있고(user.favoriteTeams를 사용하고), initialTeams가 빈 배열인 경우 명시적으로 pk가 -1인 원소를 추가함!
