### PR TITLE
[KO-538] 댓글 로직 1차 리팩토링

### DIFF
--- a/src/app/(with-side)/[type]/[id]/page.tsx
+++ b/src/app/(with-side)/[type]/[id]/page.tsx
@@ -55,6 +55,7 @@ const DetailPage = () => {
 			setTotalReplies(contentData.data.replies);
 
 			// 세션 스토리지에 저장 (같은 키로 항상 덮어쓰기)
+			// IDEA: 수정 버튼을 클릭할 때 저장하면 어떨지
 			sessionStorage.setItem('detailContent', JSON.stringify(finalContents));
 			console.log('상세조회', contentData);
 		} catch (error) {

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -151,14 +151,14 @@ const CommentInput = ({
 						onFocus={handleFocus}
 						onInput={handleInput}
 						className={clsx(
-							'p-4 pb-3 w-full h-full focus:outline-none body6-regular text-left overflow-y-scroll custom-scrollbar before:pointer-events-none before:select-none',
+							'relative p-4 pb-3 w-full h-full focus:outline-none body6-regular text-left overflow-y-scroll custom-scrollbar before:pointer-events-none before:select-none',
 							{
 								'before:content-[attr(data-mention)] before:text-primary-900 before:pr-1': isReply,
-								'before:content-[attr(data-placeholder)] before:text-black-600':
+								'before:absolute before:top-4 before:left-4 before:content-[attr(data-placeholder)] before:text-black-600':
 									!isReply && content.trim().length === 0,
 							},
 						)}
-						data-mention={isReply ? `@${replyTo.nickname}` + ' ' : undefined}
+						data-mention={isReply ? `@${replyTo.nickname}` : undefined}
 						data-placeholder="욕설 및 유해한 내용의 댓글은 통보없이 삭제될 수 있습니다."
 						suppressContentEditableWarning
 					/>

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -166,7 +166,7 @@ const CommentInput = ({
 
 		setIsSubmitting(true);
 		const isReply = type === 'reply';
-		setTimeout(() => onCommentSubmit?.(isReply), 300);
+		setTimeout(onCommentSubmit, 300);
 
 		let sanitizedContent = content;
 		if (hasMention && replyTo) {

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -28,8 +28,6 @@ const CommentInput = ({
 	const [content, setContent] = useState('');
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-	const [hasMention, setHasMention] = useState(false);
-	const [hasNewLine, setHasNewLine] = useState(false);
 
 	useEffect(() => {
 		if (type === 'comment') {
@@ -39,67 +37,10 @@ const CommentInput = ({
 		}
 	}, [isMobile, type]);
 
-	// 멘션 추가 처리
-	const insertMentionIfNeeded = () => {
-		if (isReply && inputRef.current) {
-			const mention = `<span contenteditable="false" style="color: #890f0e" class="mention">@${replyTo.nickname}</span>&nbsp;`;
-			inputRef.current.innerHTML = mention;
-			setHasMention(true);
-
-			// 커서를 멘션 뒤로 이동
-			const range = document.createRange();
-			const sel = window.getSelection();
-			if (inputRef.current.lastChild) {
-				range.setStartAfter(inputRef.current.lastChild);
-				range.collapse(true);
-				sel?.removeAllRanges();
-				sel?.addRange(range);
-			}
-		}
-	};
-
-	// 키 이벤트 처리 (엔터, 백스페이스 등)
-	const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-		if (!hasMention) return;
-
-		const mentionEl = inputRef.current?.querySelector('.mention');
-		if (!mentionEl) return;
-
-		const selection = window.getSelection();
-		if (!selection || selection.rangeCount === 0) return;
-
-		const range = selection.getRangeAt(0);
-
-		if (e.key === 'Enter') {
-			setHasNewLine(true);
-			return;
-		}
-
-		if (e.key === 'Backspace') {
-			const mentionRect = mentionEl.getBoundingClientRect();
-			const cursorRect = range.getBoundingClientRect();
-
-			if (hasNewLine) {
-				if (cursorRect.left <= mentionRect.right + 5 && Math.abs(cursorRect.top - mentionRect.top) < 5) {
-					e.preventDefault(); // 멘션 바로 뒤면 삭제 막음
-					return;
-				}
-				return; // 그 외는 허용
-			}
-
-			// 줄바꿈 없을 때 멘션 보호
-			if (cursorRect.left <= mentionRect.right + 5) {
-				e.preventDefault();
-			}
-		}
-	};
-
 	// 입력 이벤트 처리
 	const handleInput = () => {
 		if (!inputRef.current) return;
 
-		const html = inputRef.current.innerHTML;
-		setHasNewLine(/<br>|<div>/i.test(html));
 		const el = inputRef.current;
 		const newScrollHeight = el.scrollHeight;
 
@@ -117,45 +58,8 @@ const CommentInput = ({
 			setInputHeight(clampedHeight);
 		}
 
-		if (hasMention && replyTo) {
-			const mentionEl = inputRef.current.querySelector('.mention');
-			if (!mentionEl) {
-				// 멘션 복구
-				const mention = document.createElement('span');
-				mention.contentEditable = 'false';
-				mention.style.color = '#890f0e';
-				mention.className = 'mention';
-				mention.textContent = `@${replyTo.nickname}`;
-
-				const currentHTML = inputRef.current.innerHTML;
-				inputRef.current.innerHTML = '';
-				inputRef.current.appendChild(mention);
-				inputRef.current.insertAdjacentHTML('beforeend', '&nbsp;');
-
-				const tempDiv = document.createElement('div');
-				tempDiv.innerHTML = currentHTML;
-				let cleanHTML = tempDiv.innerHTML;
-				cleanHTML = cleanHTML.replace(new RegExp(`<span[^>]*>@${replyTo.nickname}</span>&nbsp;`, 'i'), '');
-				if (cleanHTML.trim()) {
-					inputRef.current.insertAdjacentHTML('beforeend', cleanHTML);
-				}
-
-				// 커서 이동
-				const range = document.createRange();
-				const sel = window.getSelection();
-				range.setStartAfter(inputRef.current.lastChild!);
-				range.collapse(true);
-				sel?.removeAllRanges();
-				sel?.addRange(range);
-			}
-
-			const inputText = inputRef.current.innerText;
-			const textWithoutMention = inputText.replace(`@${replyTo.nickname}`, '').trim();
-			setContent(textWithoutMention);
-		} else {
-			const inputText = inputRef.current.innerText.trim();
-			setContent(inputText);
-		}
+		const inputText = inputRef.current.innerText.trim();
+		setContent(inputText);
 	};
 
 	// 댓글 등록
@@ -170,11 +74,7 @@ const CommentInput = ({
 		setIsSubmitting(true);
 		setTimeout(onCommentSubmit, 300);
 
-		let sanitizedContent = content;
-		if (hasMention && replyTo) {
-			const mentionPattern = new RegExp(`^@${replyTo.nickname}&nbsp;`);
-			sanitizedContent = sanitizedContent.replace(mentionPattern, '');
-		}
+		const sanitizedContent = content.replace(/\u200B/g, '');
 
 		try {
 			let response;
@@ -203,7 +103,6 @@ const CommentInput = ({
 
 			setContent('');
 			if (inputRef.current) inputRef.current.innerHTML = '';
-			setHasNewLine(false);
 		} catch (error) {
 			console.error('댓글 처리 중 오류', error);
 			alert('댓글 처리 중 오류가 발생했습니다.');
@@ -212,9 +111,19 @@ const CommentInput = ({
 		}
 	};
 
-	useEffect(insertMentionIfNeeded, [replyTo, type]);
+	// 멘션 뒤로 커서 이동
+	const handleFocus = () => {
+		if (!inputRef.current || !isReply) return;
+		inputRef.current.innerHTML = '\u200B'; // zero-width space 추가
+	};
+
 	useEffect(() => {
-		if (type === 'edit' && defaultContent && inputRef.current) {
+		if (!inputRef.current) return;
+
+		if (type === 'reply') {
+			inputRef.current.focus(); // 자동 포커싱
+		}
+		if (type === 'edit' && defaultContent) {
 			inputRef.current.innerText = defaultContent;
 			setContent(defaultContent);
 		}
@@ -238,14 +147,17 @@ const CommentInput = ({
 					<div
 						ref={inputRef}
 						contentEditable
+						onFocus={handleFocus}
 						onInput={handleInput}
-						onKeyDown={handleKeyDown}
 						className={clsx(
-							'p-4 pb-3 w-full h-full focus:outline-none body6-regular text-left overflow-y-scroll custom-scrollbar',
+							'p-4 pb-3 w-full h-full focus:outline-none body6-regular text-left overflow-y-scroll custom-scrollbar before:pointer-events-none before:select-none',
 							{
-								'empty-placeholder': content.trim().length === 0,
+								'before:content-[attr(data-mention)] before:text-primary-900 before:pr-1': isReply,
+								'before:content-[attr(data-placeholder)] before:text-black-600':
+									!isReply && content.trim().length === 0,
 							},
 						)}
+						data-mention={isReply ? `@${replyTo.nickname}` + ' ' : undefined}
 						data-placeholder="욕설 및 유해한 내용의 댓글은 통보없이 삭제될 수 있습니다."
 						suppressContentEditableWarning
 					/>

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -10,11 +10,10 @@ import { createBoardReply, patchBoardReply } from '@/services/apis/board/board-r
 
 const CommentInput = ({
 	type = 'comment',
-	mentionNickname,
-	contentsId,
-	parentReplyId,
-	editingCommentId,
+	replyTo,
 	contentType,
+	contentsId,
+	editingCommentId,
 	defaultContent,
 	onCommentSubmit,
 	onCommentCancel,
@@ -39,8 +38,8 @@ const CommentInput = ({
 
 	// 멘션 추가 처리
 	const insertMentionIfNeeded = () => {
-		if (type === 'reply' && mentionNickname && mentionNickname !== 'undefined' && inputRef.current) {
-			const mention = `<span contenteditable="false" style="color: #890f0e" class="mention">@${mentionNickname}</span>&nbsp;`;
+		if (type === 'reply' && replyTo && inputRef.current) {
+			const mention = `<span contenteditable="false" style="color: #890f0e" class="mention">@${replyTo.nickname}</span>&nbsp;`;
 			inputRef.current.innerHTML = mention;
 			setHasMention(true);
 
@@ -115,15 +114,15 @@ const CommentInput = ({
 			setInputHeight(clampedHeight);
 		}
 
-		if (hasMention) {
+		if (hasMention && replyTo) {
 			const mentionEl = inputRef.current.querySelector('.mention');
-			if (!mentionEl && mentionNickname) {
+			if (!mentionEl) {
 				// 멘션 복구
 				const mention = document.createElement('span');
 				mention.contentEditable = 'false';
 				mention.style.color = '#890f0e';
 				mention.className = 'mention';
-				mention.textContent = `@${mentionNickname}`;
+				mention.textContent = `@${replyTo.nickname}`;
 
 				const currentHTML = inputRef.current.innerHTML;
 				inputRef.current.innerHTML = '';
@@ -133,7 +132,7 @@ const CommentInput = ({
 				const tempDiv = document.createElement('div');
 				tempDiv.innerHTML = currentHTML;
 				let cleanHTML = tempDiv.innerHTML;
-				cleanHTML = cleanHTML.replace(new RegExp(`<span[^>]*>@${mentionNickname}</span>&nbsp;`, 'i'), '');
+				cleanHTML = cleanHTML.replace(new RegExp(`<span[^>]*>@${replyTo.nickname}</span>&nbsp;`, 'i'), '');
 				if (cleanHTML.trim()) {
 					inputRef.current.insertAdjacentHTML('beforeend', cleanHTML);
 				}
@@ -148,7 +147,7 @@ const CommentInput = ({
 			}
 
 			const inputText = inputRef.current.innerText;
-			const textWithoutMention = inputText.replace(`@${mentionNickname}`, '').trim();
+			const textWithoutMention = inputText.replace(`@${replyTo.nickname}`, '').trim();
 			setContent(textWithoutMention);
 		} else {
 			const inputText = inputRef.current.innerText.trim();
@@ -170,8 +169,8 @@ const CommentInput = ({
 		setTimeout(() => onCommentSubmit?.(isReply), 300);
 
 		let sanitizedContent = content;
-		if (hasMention && mentionNickname) {
-			const mentionPattern = new RegExp(`^@${mentionNickname}&nbsp;`);
+		if (hasMention && replyTo) {
+			const mentionPattern = new RegExp(`^@${replyTo.nickname}&nbsp;`);
 			sanitizedContent = sanitizedContent.replace(mentionPattern, '');
 		}
 
@@ -192,13 +191,13 @@ const CommentInput = ({
 				if (contentType === 'news') {
 					await createNewsReply({
 						contents: sanitizedContent,
-						...(isReply && parentReplyId ? { parentReply: parentReplyId } : {}),
+						...(isReply && replyTo.pk ? { parentReply: replyTo.pk } : {}),
 						news: contentsId,
 					});
 				} else {
 					await createBoardReply({
 						contents: sanitizedContent,
-						...(isReply && parentReplyId ? { parentReply: parentReplyId } : {}),
+						...(isReply && replyTo.pk ? { parentReply: replyTo.pk } : {}),
 						board: contentsId,
 					});
 				}
@@ -215,7 +214,7 @@ const CommentInput = ({
 		}
 	};
 
-	useEffect(insertMentionIfNeeded, [mentionNickname, type]);
+	useEffect(insertMentionIfNeeded, [replyTo, type]);
 	useEffect(() => {
 		if (type === 'edit' && defaultContent && inputRef.current) {
 			inputRef.current.innerText = defaultContent;

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -68,17 +68,17 @@ const CommentInput = ({
 			setIsLoginModalOpen(true);
 			return;
 		}
-		if (!content.trim()) return alert('내용을 입력해주세요!');
+		if (!content.trim()) {
+			alert('내용을 입력해주세요!');
+			return;
+		}
 		if (isSubmitting) return;
-
 		setIsSubmitting(true);
-		setTimeout(onCommentSubmit, 300);
-
-		const sanitizedContent = content.replace(/\u200B/g, '');
 
 		try {
 			let response;
 			const isNews = contentType === 'news';
+			const sanitizedContent = content.replace(/\u200B/g, '');
 
 			if (type === 'edit') {
 				const body = {
@@ -101,8 +101,9 @@ const CommentInput = ({
 			}
 			console.log('댓글 수정/등록', response);
 
-			setContent('');
 			if (inputRef.current) inputRef.current.innerHTML = '';
+			setContent('');
+			onCommentSubmit();
 		} catch (error) {
 			console.error('댓글 처리 중 오류', error);
 			alert('댓글 처리 중 오류가 발생했습니다.');

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -7,6 +7,8 @@ import { CommentInputProps } from './type';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { createNewsReply, patchNewsReply } from '@/services/apis/news/news-reply.api';
 import { createBoardReply, patchBoardReply } from '@/services/apis/board/board-reply.api';
+import { CreateNewsReplyRequest } from '@/services/apis/news/news-reply.type';
+import { CreateBoardReplyRequest } from '@/services/apis/board/board-reply.type';
 
 const CommentInput = ({
 	type = 'comment',
@@ -19,6 +21,7 @@ const CommentInput = ({
 	onCommentCancel,
 }: CommentInputProps) => {
 	const isMobile = useIsMobile();
+	const isReply = type === 'reply' && replyTo;
 	const currentUserInfo = useCurrentUserInfoStore();
 	const inputRef = useRef<HTMLDivElement>(null);
 	const [inputHeight, setInputHeight] = useState(0);
@@ -38,7 +41,7 @@ const CommentInput = ({
 
 	// 멘션 추가 처리
 	const insertMentionIfNeeded = () => {
-		if (type === 'reply' && replyTo && inputRef.current) {
+		if (isReply && inputRef.current) {
 			const mention = `<span contenteditable="false" style="color: #890f0e" class="mention">@${replyTo.nickname}</span>&nbsp;`;
 			inputRef.current.innerHTML = mention;
 			setHasMention(true);
@@ -165,7 +168,6 @@ const CommentInput = ({
 		if (isSubmitting) return;
 
 		setIsSubmitting(true);
-		const isReply = type === 'reply';
 		setTimeout(onCommentSubmit, 300);
 
 		let sanitizedContent = content;
@@ -174,34 +176,30 @@ const CommentInput = ({
 			sanitizedContent = sanitizedContent.replace(mentionPattern, '');
 		}
 
-		const editedRequestBody = {
-			contents: sanitizedContent,
-		};
-
 		try {
 			let response;
+			const isNews = contentType === 'news';
 
 			if (type === 'edit') {
-				response =
-					contentType === 'news'
-						? await patchNewsReply(editingCommentId, editedRequestBody)
-						: await patchBoardReply(editingCommentId, editedRequestBody);
-				console.log('댓글 수정 완료:', response);
+				const body = {
+					contents: sanitizedContent,
+				};
+
+				response = isNews
+					? await patchNewsReply(editingCommentId, body)
+					: await patchBoardReply(editingCommentId, body);
 			} else {
-				if (contentType === 'news') {
-					await createNewsReply({
-						contents: sanitizedContent,
-						...(isReply && replyTo.pk ? { parentReply: replyTo.pk } : {}),
-						news: contentsId,
-					});
-				} else {
-					await createBoardReply({
-						contents: sanitizedContent,
-						...(isReply && replyTo.pk ? { parentReply: replyTo.pk } : {}),
-						board: contentsId,
-					});
-				}
+				const isReply = type === 'reply' && replyTo;
+				const body: CreateNewsReplyRequest | CreateBoardReplyRequest = {
+					contents: sanitizedContent,
+					...(isReply ? { parentReply: replyTo.pk } : {}),
+					...(isNews ? { news: contentsId } : { board: contentsId }),
+				};
+				response = isNews
+					? await createNewsReply(body as CreateNewsReplyRequest)
+					: await createBoardReply(body as CreateBoardReplyRequest);
 			}
+			console.log('댓글 수정/등록', response);
 
 			setContent('');
 			if (inputRef.current) inputRef.current.innerHTML = '';

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -42,11 +42,6 @@ function CommentItem({
 	const { openLoginModal } = useIsLoginModalOpenStore();
 
 	const handleCommentSubmit = async () => {
-		if (!currentUserInfo) {
-			openLoginModal();
-			return;
-		}
-
 		if (isEditing) {
 			setEditingCommentId(null);
 		}

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -1,50 +1,147 @@
 'use client';
 
 import Image from 'next/image';
-import { useMemo, useRef } from 'react';
+import { useState } from 'react';
 import clsx from 'clsx';
 import CommentInput from './comment-input';
 import { formatDate } from '@/lib/utils';
 import { CommentItemProps } from './type';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { CommentMoreButton } from './comment-more-button';
+import useIsMobile from '@/lib/hooks/useIsMobile';
+import { createNewsCommentKick, deleteNewsReply } from '@/services/apis/news/news-reply.api';
+import { createBoardCommentKick, deleteBoardReply } from '@/services/apis/board/board-reply.api';
+import AlertModal from '../alert-modal';
+import { useIsLoginModalOpenStore } from '@/lib/store/useIsLoginModalOpenStore';
 
 function CommentItem({
 	content,
 	type,
-	handleLikeToggle,
-	handleReply,
-	closeReplyInput,
-	toggleReplyVisibility,
-	replyingTo,
-	replyVisibilities,
 	isCommentAllowed,
 	contentsId,
-	parentReply,
 	isReply = false,
-	parentReplyId,
-	onCommentSubmit,
-	onEnterEditMode,
-	onDeleteComment,
+	replyTo,
 	editingCommentId,
 	setEditingCommentId,
+	setComments,
 }: CommentItemProps) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
-	const isMyComment = currentUserInfo?.id === content.user.id;
-	const isRepliesOpen = useMemo(() => {
-		return !isReply && Array.isArray(content.replies) && content.replies.length > 0;
-	}, [content.replies, isReply]);
-
-	const isReplyInputOpen = useMemo(() => replyingTo.includes(content.pk), [replyingTo, content.pk]);
-	const moreButtonRef = useRef(null);
-
-	const isEditing = editingCommentId === content.pk;
-
 	const { formattedDate, formattedTime } = formatDate(content.createdAt, '2-digit');
+
+	const isMobile = useIsMobile();
+
+	const isNews = type === 'news';
+	const isEditing = editingCommentId === content.pk;
+	const isMyComment = currentUserInfo?.id === content.user.id;
+
+	const [isReplyListOpen, setIsReplyListOpen] = useState(false);
+	const [isReplyInputOpen, setIsReplyInputOpen] = useState(false);
+
+	const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+	const { openLoginModal } = useIsLoginModalOpenStore();
+
+	const handleCommentSubmit = async (isReply: boolean, parentPk?: number) => {
+		if (!currentUserInfo) {
+			openLoginModal();
+			return;
+		}
+
+		if (isReply && parentPk !== undefined) {
+			setIsReplyInputOpen(false);
+			setIsReplyListOpen(true);
+
+			// TODO: 댓글 리스트 업데이트 로직 추가
+			// TODO: total comments 카운트 업데이트 로직 추가
+		}
+	};
+
+	// 좋아요 토글 -> kicked가 서버한테 잘 오는지 판단하고 다시!! kickCount 이건 잘 돼!
+	const toggleCommentLike = async (commentPk: number) => {
+		if (!currentUserInfo) {
+			openLoginModal();
+			return;
+		}
+
+		const result = isNews ? await createNewsCommentKick(commentPk) : await createBoardCommentKick(commentPk);
+		if (!result) return;
+
+		setComments((prev) =>
+			prev.map((c) => {
+				if (c.pk !== commentPk) return c;
+				const isCurrentlyLiked = c.kicked;
+				return {
+					...c,
+					kicked: !isCurrentlyLiked,
+					kickCount: c.kickCount + (isCurrentlyLiked ? -1 : 1), // 즉시 +1/-1 반영
+				};
+			}),
+		);
+	};
+
+	const handleReplyInputOpen = () => {
+		if (isMobile) {
+			// 모바일: 무조건 열기만
+			setIsReplyInputOpen(true);
+		} else {
+			// PC: 토글
+			setIsReplyInputOpen(!isReplyInputOpen);
+		}
+	};
+
+	// 수정 모드로 진입
+	const handleEnterEditMode = (commentPk: number) => {
+		if (editingCommentId && editingCommentId !== commentPk) {
+			setIsConfirmModalOpen(true);
+			return;
+		}
+		setEditingCommentId(commentPk);
+	};
+
+	const handleDeleteComment = async (commentPk: number, parentCommentPk?: number) => {
+		try {
+			const response = isNews ? await deleteNewsReply(commentPk) : await deleteBoardReply(commentPk);
+			if (response?.code === 'GET_SUCCESS') {
+				if (isReply && parentCommentPk) {
+					// 답글 삭제
+					setComments((prev) =>
+						prev.map((parentComment) =>
+							parentComment.pk === parentCommentPk
+								? {
+										...parentComment,
+										replies: parentComment.replies?.filter((reply) => reply.pk !== commentPk),
+									}
+								: parentComment,
+						),
+					);
+				} else {
+					// 댓글 삭제
+					setComments((prev) => prev.filter((comment) => comment.pk !== commentPk));
+				}
+
+				// 만약 현재 수정 중이던 댓글을 삭제했다면, 수정 상태도 초기화
+				if (editingCommentId === commentPk) {
+					setEditingCommentId(null);
+				}
+			} else {
+				console.error('댓글 삭제 실패', response);
+			}
+		} catch (error) {
+			console.error('댓글 삭제 중 오류 발생', error);
+		}
+	};
+
+	const commentItemProps = {
+		type,
+		isCommentAllowed,
+		contentsId,
+		editingCommentId,
+		setEditingCommentId,
+		setComments,
+	};
 
 	return (
 		<div>
-			<div className={clsx('flex items-start mt-5 pb-3.5', isReply && 'pl-10')}>
+			<div className={clsx('flex items-start mt-5 pb-3.5')}>
 				<Image
 					src={content.user?.profileImageUrl || '/default-profile.svg'}
 					alt="프로필"
@@ -68,27 +165,21 @@ function CommentItem({
 
 						{/* 더보기 버튼 (내 댓글일 때만)*/}
 						{isMyComment && (
-							<div ref={moreButtonRef} className="relative">
-								<CommentMoreButton
-									onDeleteClick={() => {
-										if (isReply) {
-											onDeleteComment(content.pk, parentReplyId);
-										} else {
-											onDeleteComment(content.pk);
-										}
-									}}
-									onEditClick={() => {
-										onEnterEditMode(content.pk);
-									}}
-								/>
-							</div>
+							<CommentMoreButton
+								onDeleteClick={() => handleDeleteComment(content.pk, replyTo?.pk)}
+								onEditClick={() => {
+									handleEnterEditMode(content.pk);
+								}}
+							/>
 						)}
 					</div>
+
 					{/* 본문 */}
 					<div className="body5-regular text-black-900 mt-3 mb-3.5 whitespace-pre-line">
-						{isReply && <span className="text-[#890f0e] mr-1">@{parentReply}</span>}
+						{isReply && replyTo && <span className="text-[#890f0e] mr-1">@{replyTo.nickname}</span>}
 						{content.contents}
 					</div>
+
 					{/* 하단 영역: 답글 버튼, 답글 토글, 킥 버튼 */}
 					<div className="flex justify-between items-center gap-3.5">
 						<div className="flex flex-col gap-3.5">
@@ -98,30 +189,30 @@ function CommentItem({
 										'button5-regular rounded-sm px-2 py-1 mb-0.5 w-fit',
 										isReplyInputOpen ? 'text-black-100 bg-black-500' : 'text-black-700 bg-black-200',
 									)}
-									onClick={() => handleReply(content.pk)}
+									onClick={handleReplyInputOpen}
 								>
 									답글
 								</button>
 							)}
 
-							{isRepliesOpen && (
+							{content.replies?.length > 0 && (
 								<button
 									className="flex items-center gap-[0.625rem] text-black-600 body6-regular"
-									onClick={() => toggleReplyVisibility(content.pk)}
+									onClick={() => setIsReplyListOpen(!isReplyListOpen)}
 								>
 									<Image
-										src={replyVisibilities[content.pk] ? '/chevron/score-up.svg' : '/chevron/score-down.svg'}
+										src={isReplyListOpen ? '/chevron/score-up.svg' : '/chevron/score-down.svg'}
 										alt="toggle replies"
 										width={16}
 										height={16}
 									/>
-									{replyVisibilities[content.pk] ? '답글 숨기기' : `답글 ${content.replies.length}개`}
+									{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
 								</button>
 							)}
 						</div>
 
 						{/* 킥 버튼 (하단 우측) */}
-						<button onClick={() => handleLikeToggle(content.pk)} className="flex items-center gap-2">
+						<button onClick={() => toggleCommentLike(content.pk)} className="flex items-center gap-2">
 							<Image src={content.kicked ? '/kick/red.svg' : '/kick/gray.svg'} alt="kick" width={16} height={16} />
 							<span className={content.kicked ? 'text-black-900' : 'text-gray-500'}>{content.kickCount}</span>
 						</button>
@@ -138,22 +229,47 @@ function CommentItem({
 							mentionNickname={isEditing ? undefined : content.user.nickname}
 							defaultContent={isEditing ? content.contents : ''}
 							onCommentSubmit={(isReply) => {
-								onCommentSubmit(isReply, content.pk);
+								handleCommentSubmit(isReply, content.pk);
 								setEditingCommentId(null);
 							}}
 							onCommentCancel={() => {
 								if (isEditing) {
 									setEditingCommentId(null);
-									closeReplyInput(content.pk);
+									handleReplyInputOpen();
 								} else {
-									closeReplyInput(content.pk);
+									handleReplyInputOpen();
 								}
 							}}
 						/>
 					)}
+
+					{isReplyListOpen &&
+						content.replies?.map((reply) => (
+							<CommentItem
+								key={reply.pk}
+								content={reply}
+								isReply
+								replyTo={{ pk: content.pk, nickname: content.user.nickname }}
+								{...commentItemProps}
+							/>
+						))}
 				</div>
 			</div>
 			<hr className="border-t border-black-200 -mx-6 -ml-4" />
+
+			{isConfirmModalOpen && (
+				<AlertModal
+					type="confirm"
+					description={`작성 중인 수정사항이 초기화됩니다.\n이 댓글을 수정하시겠습니까?`}
+					onCancel={() => {
+						setIsConfirmModalOpen(false);
+					}}
+					onConfirm={() => {
+						setEditingCommentId(content.pk);
+						setIsConfirmModalOpen(false);
+					}}
+				/>
+			)}
 		</div>
 	);
 }

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -228,7 +228,7 @@ function CommentItem({
 					{(isReplyInputOpen || isEditing) && (
 						<CommentInput
 							type={isEditing ? 'edit' : 'reply'}
-							replyTo={replyTo}
+							replyTo={isEditing ? replyTo : { pk: content.pk, nickname: content.user.nickname }}
 							contentType={type}
 							contentsId={contentsId}
 							editingCommentId={editingCommentId}

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -78,7 +78,7 @@ function CommentItem({
 		);
 	};
 
-	const handleReplyInputOpen = () => {
+	const toggleReplyInputOpen = () => {
 		if (isMobile) {
 			// 모바일: 무조건 열기만
 			setIsReplyInputOpen(true);
@@ -189,7 +189,7 @@ function CommentItem({
 										'button5-regular rounded-sm px-2 py-1 mb-0.5 w-fit',
 										isReplyInputOpen ? 'text-black-100 bg-black-500' : 'text-black-700 bg-black-200',
 									)}
-									onClick={handleReplyInputOpen}
+									onClick={toggleReplyInputOpen}
 								>
 									답글
 								</button>
@@ -235,10 +235,8 @@ function CommentItem({
 							onCommentCancel={() => {
 								if (isEditing) {
 									setEditingCommentId(null);
-									handleReplyInputOpen();
-								} else {
-									handleReplyInputOpen();
 								}
+								setIsReplyInputOpen(false);
 							}}
 						/>
 					)}

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -19,11 +19,11 @@ function CommentItem({
 	type,
 	isCommentAllowed,
 	contentsId,
-	isReply = false,
 	replyTo,
 	editingCommentId,
 	setEditingCommentId,
 	setComments,
+	setTotalReplies,
 }: CommentItemProps) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const { formattedDate, formattedTime } = formatDate(content.createdAt, '2-digit');
@@ -31,6 +31,7 @@ function CommentItem({
 	const isMobile = useIsMobile();
 
 	const isNews = type === 'news';
+	const isReply = Boolean(replyTo);
 	const isEditing = editingCommentId === content.pk;
 	const isMyComment = currentUserInfo?.id === content.user.id;
 
@@ -40,13 +41,17 @@ function CommentItem({
 	const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
 	const { openLoginModal } = useIsLoginModalOpenStore();
 
-	const handleCommentSubmit = async (isReply: boolean, parentPk?: number) => {
+	const handleCommentSubmit = async () => {
 		if (!currentUserInfo) {
 			openLoginModal();
 			return;
 		}
 
-		if (isReply && parentPk !== undefined) {
+		if (isEditing) {
+			setEditingCommentId(null);
+		}
+
+		if (isReply) {
 			setIsReplyInputOpen(false);
 			setIsReplyListOpen(true);
 
@@ -130,13 +135,14 @@ function CommentItem({
 		}
 	};
 
-	const commentItemProps = {
+	const commentItemProps: Omit<CommentItemProps, 'content'> = {
 		type,
 		isCommentAllowed,
 		contentsId,
 		editingCommentId,
 		setEditingCommentId,
 		setComments,
+		setTotalReplies,
 	};
 
 	return (
@@ -227,10 +233,7 @@ function CommentItem({
 							contentsId={contentsId}
 							editingCommentId={editingCommentId}
 							defaultContent={isEditing ? content.contents : ''}
-							onCommentSubmit={(isReply) => {
-								handleCommentSubmit(isReply, content.pk);
-								setEditingCommentId(null);
-							}}
+							onCommentSubmit={handleCommentSubmit}
 							onCommentCancel={() => {
 								if (isEditing) {
 									setEditingCommentId(null);
@@ -245,7 +248,6 @@ function CommentItem({
 							<CommentItem
 								key={reply.pk}
 								content={reply}
-								isReply
 								replyTo={{ pk: content.pk, nickname: content.user.nickname }}
 								{...commentItemProps}
 							/>

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -222,11 +222,10 @@ function CommentItem({
 					{(isReplyInputOpen || isEditing) && (
 						<CommentInput
 							type={isEditing ? 'edit' : 'reply'}
+							replyTo={replyTo}
+							contentType={type}
 							contentsId={contentsId}
 							editingCommentId={editingCommentId}
-							parentReplyId={isEditing ? undefined : content.pk}
-							contentType={type}
-							mentionNickname={isEditing ? undefined : content.user.nickname}
 							defaultContent={isEditing ? content.contents : ''}
 							onCommentSubmit={(isReply) => {
 								handleCommentSubmit(isReply, content.pk);

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -42,8 +42,6 @@ function CommentSection({
 	const [editingCommentId, setEditingCommentId] = useState<number | null>(null); // 수정 중인 코멘트 id
 	const [stagedCommentId, setStagedCommentId] = useState<number | null>(null); // 수정을 시도하는 코멘트 id
 
-	const [loadedPages, setLoadedPages] = useState([1]); // infinite lastReply + 스프레드 -> 제거 예정
-
 	// 현재 페이지 추출
 	const pageParam = searchParams.get('page');
 	const [currentPage, setCurrentPage] = useState(pageParam ? Number(pageParam) : 1);
@@ -55,72 +53,37 @@ function CommentSection({
 	const [hasError, setHasError] = useState(false);
 	const [totalPages, setTotalPages] = useState(1);
 
-	// TODO: 2. 모바일에서 infinite와 lastReply 추가 + 스프레드
-	const fetchComments = useCallback(
-		async (page: number, append = false) => {
-			if (!contentsId || contentsId < 1) return;
-			try {
-				const response = isNews
-					? await getNewsCommentList({
-							id: contentsId,
-							page: currentPage,
-							size: commentsPerPage,
-						})
-					: await getBoardCommentList(contentsId, page, commentsPerPage);
+	const fetchComments = async () => {
+		if (!contentsId || contentsId < 1) return;
 
-				console.log('댓글 리스트', response);
-				if (append) {
-					// 중복되지 않는 새 댓글만 추가
-					setComments((prev) => {
-						const newComments = response?.data?.filter((c) => !prev.find((p) => p.pk === c.pk)) || [];
-						return [...prev, ...newComments];
-					});
-				} else {
-					setComments(response?.data || []);
-				}
-				setTotalPages(response.meta?.totalPages || 1);
-				setHasError(false);
-				return response;
-			} catch {
-				setHasError(true);
-				return null;
+		const query = {
+			id: contentsId,
+			page: currentPage,
+			size: commentsPerPage,
+			...(isMobile ? { infinite: true, lastReply: comments.at(-1).pk } : {}),
+		};
+		try {
+			const response = isNews ? await getNewsCommentList(query) : await getBoardCommentList(query);
+
+			console.log('댓글 리스트', response);
+			if (isMobile) {
+				setComments((prev) => [...prev, ...response?.data]);
+			} else {
+				setComments(response?.data || []);
 			}
-		},
-		[contentsId, isNews],
-	);
-
-	// 모든 로드된 페이지의 댓글을 다시 불러오는 함수
-	const reloadAllLoadedComments = useCallback(async () => {
-		if (isMobile && loadedPages.length > 0) {
-			let allComments = [];
-
-			// 모든 로드된 페이지를 순서대로 불러옴
-			for (const page of loadedPages.sort((a, b) => a - b)) {
-				const response = isNews
-					? await getNewsCommentList({
-							id: contentsId,
-							page: currentPage,
-							size: commentsPerPage,
-						})
-					: await getBoardCommentList(contentsId, page, commentsPerPage);
-
-				if (response?.data) {
-					// 중복 제거하면서 댓글 추가
-					const newComments = response.data.filter((c) => !allComments.find((existing) => existing.pk === c.pk));
-					allComments = [...allComments, ...newComments];
-				}
-			}
-
-			setComments(allComments);
-			return true;
+			setTotalPages(response.meta?.totalPages || 1);
+			setHasError(false);
+			return response;
+		} catch {
+			setHasError(true);
+			return null;
 		}
-		return false;
-	}, [loadedPages, contentsId, commentsPerPage, isNews, isMobile]);
+	};
 
-	// 초기 또는 페이지 변경 시 댓글 불러오기
+	// 초기 접속 또는 페이지 변경 시 댓글 불러오기
 	useEffect(() => {
-		fetchComments(currentPage, isMobile); // 모바일은 append 방식
-	}, [currentPage, fetchComments, isMobile]);
+		fetchComments();
+	}, [currentPage, contentsId]);
 
 	// searchParams가 바뀌었을 때 currentPage를 갱신
 	useEffect(() => {
@@ -140,20 +103,19 @@ function CommentSection({
 	// 모바일에서 '더 보기' 클릭 시 댓글 추가 로드
 	const handleLoadMoreComment = async () => {
 		const nextPage = currentPage + 1;
-		const response = isNews
-			? await getNewsCommentList({
-					id: contentsId,
-					page: currentPage,
-					size: commentsPerPage,
-				})
-			: await getBoardCommentList(contentsId, nextPage, commentsPerPage);
+		const query = {
+			id: contentsId,
+			page: nextPage,
+			size: commentsPerPage,
+			infinite: true,
+			lastReply: comments.at(-1).pk,
+		};
+		const response = isNews ? await getNewsCommentList(query) : await getBoardCommentList(query);
 
 		const newComments = response?.data || [];
 
 		setComments((prev) => [...prev, ...newComments]);
 		setCurrentPage(nextPage);
-		// 로드된 페이지 추적
-		setLoadedPages((prev) => [...prev, nextPage]);
 
 		if (nextPage >= (response.meta?.totalPages || 1)) {
 			setIsLastPageLoaded(true);
@@ -169,32 +131,7 @@ function CommentSection({
 			setReplyingTo((prev) => prev.filter((id) => id !== parentPk));
 			setReplyVisibilities((prev) => ({ ...prev, [parentPk]: true }));
 
-			// 해당 댓글의 최신 상태를 다시 불러와 갱신
-			try {
-				const response = isNews
-					? await getNewsCommentList({
-							id: contentsId,
-							page: currentPage,
-							size: commentsPerPage,
-						})
-					: await getBoardCommentList(contentsId, currentPage, commentsPerPage);
-
-				const updatedComment = response?.data.find((c) => c.pk === parentPk);
-				if (updatedComment) {
-					setComments((prev) => prev.map((c) => (c.pk === parentPk ? updatedComment : c)));
-				}
-			} catch {
-				console.error('대댓글 업데이트 실패');
-			}
-			return;
-		}
-
-		// 모바일에서 여러 페이지가 로드된 경우 모든 페이지 다시 불러오기
-		const reloadedAll = await reloadAllLoadedComments();
-
-		// 모바일이 아니거나 모든 페이지 다시 불러오기 실패한 경우 현재 페이지만 다시 불러오기
-		if (!reloadedAll) {
-			await fetchComments(currentPage, false);
+			// 댓글 리스트 업데이트 로직 추가
 		}
 	};
 

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -12,7 +12,13 @@ import { CommentSectionProps } from './type';
 import { getNewsCommentList } from '@/services/apis/news/news-reply.api';
 import { getBoardCommentList } from '@/services/apis/board/board-reply.api';
 
-function CommentSection({ type, isCommentAllowed, contentsId, totalreplies = 0 }: CommentSectionProps) {
+function CommentSection({
+	type,
+	isCommentAllowed,
+	contentsId,
+	totalreplies = 0,
+	setTotalReplies,
+}: CommentSectionProps) {
 	const searchParams = useSearchParams();
 	const isMobile = useIsMobile();
 	const isNews = type === 'news';

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -8,7 +8,7 @@ import PaginationBar from '@/components/common/pagination-bar';
 import { useSearchParams } from 'next/navigation';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import Image from 'next/image';
-import { CommentSectionProps } from './type';
+import { CommentItemProps, CommentSectionProps } from './type';
 import { getNewsCommentList } from '@/services/apis/news/news-reply.api';
 import { getBoardCommentList } from '@/services/apis/board/board-reply.api';
 
@@ -105,13 +105,14 @@ function CommentSection({
 		}
 	};
 
-	const commentItemProps = {
+	const commentItemProps: Omit<CommentItemProps, 'content'> = {
 		type,
 		isCommentAllowed,
 		contentsId,
 		editingCommentId,
 		setEditingCommentId,
 		setComments,
+		setTotalReplies,
 	};
 
 	// 에러 발생 시 에러 카드 표시

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -1,57 +1,34 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import CommentInput from './comment-input';
 import CommentItem from './comment-item';
 import FetchingFailedCard from '@/components/common/fetching-failed-card';
 import PaginationBar from '@/components/common/pagination-bar';
 import { useSearchParams } from 'next/navigation';
-import LoginModal from '@/components/common/login-modal/login-content';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import Image from 'next/image';
 import { CommentSectionProps } from './type';
-import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
-import AlertModal from '../alert-modal';
-import { createNewsCommentKick, deleteNewsReply, getNewsCommentList } from '@/services/apis/news/news-reply.api';
-import { createBoardCommentKick, deleteBoardReply, getBoardCommentList } from '@/services/apis/board/board-reply.api';
+import { getNewsCommentList } from '@/services/apis/news/news-reply.api';
+import { getBoardCommentList } from '@/services/apis/board/board-reply.api';
 
-function CommentSection({
-	type,
-	isCommentAllowed,
-	contentsId,
-	totalreplies = 0,
-	setTotalReplies,
-}: CommentSectionProps) {
-	const currentUserInfo = useCurrentUserInfoStore();
+function CommentSection({ type, isCommentAllowed, contentsId, totalreplies = 0 }: CommentSectionProps) {
 	const searchParams = useSearchParams();
 	const isMobile = useIsMobile();
 	const isNews = type === 'news';
 	const baseUrl = `/${type}/${contentsId}`;
 
-	const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
-	const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
-	const [isLastPageLoaded, setIsLastPageLoaded] = useState(false); // 모바일에서 더보기 버튼 나올지 말지
-
-	// TODO: 4. 다른 TODO 처리 후 재귀 컴포넌트로 각 comment item이 답글을 관리하도록 수정
-	const [replyingTo, setReplyingTo] = useState([]); // 열어둔 답글 리스트
-	const [replyVisibilities, setReplyVisibilities] = useState({}); // 댓글의 답글을 열지 말지
-
-	// TODO: 3. 가능하면 하나의 상태로 만들기 / 불가능하면 네이밍 명확하게 수정! -> 네이밍 수정!!
-	// -> 하나의 상태로 통합했으나 ({mode, commentId} 객체 형태로) mode로 관리함으로써 A 댓글을 편집 중이다가 B 댓글의 수정하기 버튼을 누르면 mode가 바뀌면서 state 자체가 바뀌니 편집 중이던 내용이 초기화 됨. (원래는 상태가 독립이었어서 문제 x)
-	// 이를 해결하려면 편집 중이던 내용을 따로 저장 (map으로 댓글마다 저장)해야 했는데 그럼 복잡도가 올라감
-	const [editingCommentId, setEditingCommentId] = useState<number | null>(null); // 수정 중인 코멘트 id
-	const [stagedCommentId, setStagedCommentId] = useState<number | null>(null); // 수정을 시도하는 코멘트 id
-
-	// 현재 페이지 추출
 	const pageParam = searchParams.get('page');
 	const [currentPage, setCurrentPage] = useState(pageParam ? Number(pageParam) : 1);
+	const [isLastPageLoaded, setIsLastPageLoaded] = useState(false); // 모바일에서 더보기 버튼 나올지 말지
 
-	const commentsPerPage = 10;
+	const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
 
 	// 댓글 리스트 조회
 	const [comments, setComments] = useState([]);
 	const [hasError, setHasError] = useState(false);
 	const [totalPages, setTotalPages] = useState(1);
+	const commentsPerPage = 10;
 
 	const fetchComments = async () => {
 		if (!contentsId || contentsId < 1) return;
@@ -122,40 +99,13 @@ function CommentSection({
 		}
 	};
 
-	// 댓글 또는 대댓글 작성 후 처리
-	const handleCommentSubmit = async (isReply: boolean, parentPk?: number) => {
-		setTotalReplies(totalreplies + 1); // 댓글 수 증가
-
-		if (isReply && parentPk !== undefined) {
-			// 대댓글 작성 후 대댓글 입력창 닫고 대댓글 보이게 하기
-			setReplyingTo((prev) => prev.filter((id) => id !== parentPk));
-			setReplyVisibilities((prev) => ({ ...prev, [parentPk]: true }));
-
-			// 댓글 리스트 업데이트 로직 추가
-		}
-	};
-
-	// 좋아요 토글 -> kicked가 서버한테 잘 오는지 판단하고 다시!! kickCount 이건 잘 돼!
-	const toggleCommentLike = async (commentId: number) => {
-		if (!currentUserInfo) {
-			setIsLoginModalOpen(true);
-			return;
-		}
-
-		const result = isNews ? await createNewsCommentKick(commentId) : await createBoardCommentKick(commentId);
-		if (!result) return;
-
-		setComments((prev) =>
-			prev.map((c) => {
-				if (c.pk !== commentId) return c;
-				const isCurrentlyLiked = c.kicked; // 현재 상태
-				return {
-					...c,
-					kicked: !isCurrentlyLiked, // 토글
-					kickCount: c.kickCount + (isCurrentlyLiked ? -1 : 1), // 즉시 +1/-1 반영
-				};
-			}),
-		);
+	const commentItemProps = {
+		type,
+		isCommentAllowed,
+		contentsId,
+		editingCommentId,
+		setEditingCommentId,
+		setComments,
 	};
 
 	// 에러 발생 시 에러 카드 표시
@@ -163,96 +113,10 @@ function CommentSection({
 		return <FetchingFailedCard height="300px" marginTop="50px" onClick={() => window.location.reload()} />;
 	}
 
-	const handleReply = (id: number) => {
-		setReplyingTo((prev) => {
-			const isAlreadyOpen = prev.includes(id);
-
-			if (isMobile) {
-				// 모바일: 무조건 열기만
-				return isAlreadyOpen ? prev : [...prev, id];
-			} else {
-				// PC: 토글
-				return isAlreadyOpen ? prev.filter((i) => i !== id) : [...prev, id];
-			}
-		});
-	};
-
-	const closeReplyInput = (id: number) => {
-		setReplyingTo((prev) => prev.filter((i) => i !== id));
-	};
-
-	// 수정 모드로 진입
-	const handleEnterEditMode = (commentId: number) => {
-		if (editingCommentId && editingCommentId !== commentId) {
-			setStagedCommentId(commentId);
-			setIsConfirmModalOpen(true);
-			return;
-		}
-		setEditingCommentId(commentId);
-	};
-	const handleDeleteComment = async (commentId: number, parentReplyId: number) => {
-		try {
-			const response = isNews ? await deleteNewsReply(commentId) : await deleteBoardReply(commentId);
-			console.log('댓글 삭제', response);
-			if (response?.code === 'GET_SUCCESS') {
-				// 삭제 성공 시, 상태 업데이트
-				if (parentReplyId) {
-					// 대댓글 삭제
-					setComments((prev) =>
-						prev.map((comment) =>
-							comment.pk === parentReplyId
-								? {
-										...comment,
-										replies: comment.replies?.filter((reply) => reply.pk !== commentId),
-									}
-								: comment,
-						),
-					);
-				} else {
-					// 댓글 삭제
-					setComments((prev) => prev.filter((comment) => comment.pk !== commentId));
-				}
-				setTotalReplies(totalreplies - 1);
-
-				// 만약 현재 수정 중이던 댓글을 삭제했다면, 수정 상태도 초기화
-				if (editingCommentId === commentId) {
-					setEditingCommentId(null);
-				}
-			} else {
-				console.error('댓글 삭제 실패', response);
-			}
-		} catch (error) {
-			console.error('댓글 삭제 중 오류 발생', error);
-		}
-	};
-
-	// 공통으로 자식 컴포넌트에 전달할 props 모음
-	const commentItemProps = {
-		type,
-		handleLikeToggle: toggleCommentLike,
-		handleReply,
-		closeReplyInput,
-		toggleReplyVisibility: (id) => setReplyVisibilities((prev) => ({ ...prev, [id]: !prev[id] })),
-		replyingTo,
-		replyVisibilities,
-		isCommentAllowed,
-		contentsId,
-		onCommentSubmit: handleCommentSubmit,
-		onEnterEditMode: handleEnterEditMode,
-		onDeleteComment: handleDeleteComment,
-		editingCommentId,
-		setEditingCommentId,
-	};
-
 	return (
 		<div className="px-4">
 			{isCommentAllowed && (
-				<CommentInput
-					contentType={type}
-					contentsId={contentsId}
-					editingCommentId={editingCommentId}
-					onCommentSubmit={(isReply) => handleCommentSubmit(isReply)}
-				/>
+				<CommentInput contentType={type} contentsId={contentsId} editingCommentId={editingCommentId} />
 			)}
 
 			<p className="body5-regular -mx-4 text-black-600 border-t border-b border-black-200 px-4 py-3">
@@ -264,25 +128,7 @@ function CommentSection({
 			) : (
 				<div className="flex flex-col pr-2">
 					{comments.map((comment) => (
-						<div key={comment.pk}>
-							<CommentItem
-								key={comment.pk}
-								content={comment}
-								parentReply={comment.user.nickname}
-								{...commentItemProps}
-							/>
-							{replyVisibilities[comment.pk] &&
-								comment.replies?.map((reply) => (
-									<CommentItem
-										key={reply.pk}
-										content={reply}
-										isReply
-										parentReply={comment.user.nickname}
-										parentReplyId={comment.pk}
-										{...commentItemProps}
-									/>
-								))}
-						</div>
+						<CommentItem key={comment.pk} content={comment} {...commentItemProps} />
 					))}
 				</div>
 			)}
@@ -302,25 +148,6 @@ function CommentSection({
 						</div>
 					)}
 				</>
-			)}
-
-			{isLoginModalOpen && <LoginModal onClose={() => setIsLoginModalOpen(false)} />}
-			{isConfirmModalOpen && (
-				<AlertModal
-					type="confirm"
-					description={`작성 중인 수정사항이 초기화됩니다.\n이 댓글을 수정하시겠습니까?`}
-					onCancel={() => {
-						setIsConfirmModalOpen(false);
-						setStagedCommentId(null);
-					}}
-					onConfirm={() => {
-						if (stagedCommentId !== null) {
-							setEditingCommentId(stagedCommentId);
-						}
-						setIsConfirmModalOpen(false);
-						setStagedCommentId(null);
-					}}
-				/>
 			)}
 		</div>
 	);

--- a/src/components/features/detail/comment/type.ts
+++ b/src/components/features/detail/comment/type.ts
@@ -26,12 +26,14 @@ export interface CommentItemProps {
 // 코멘트 입력 props
 export interface CommentInputProps {
 	type?: 'comment' | 'reply' | 'edit';
-	mentionNickname?: string;
-	parentReplyId?: number;
-	editingCommentId: number;
+	replyTo?: {
+		pk: number;
+		nickname: string;
+	};
 	contentType: 'news' | 'board';
-	defaultContent?: string;
 	contentsId: number;
+	editingCommentId: number;
+	defaultContent?: string;
 	onCommentSubmit?: (isReply: boolean) => void;
 	onCommentCancel?: () => void;
 }

--- a/src/components/features/detail/comment/type.ts
+++ b/src/components/features/detail/comment/type.ts
@@ -1,4 +1,5 @@
 import { CommonCommentDto } from '@/services/apis/common/types';
+import { Dispatch, SetStateAction } from 'react';
 
 // comment section props
 export interface CommentSectionProps {
@@ -13,22 +14,13 @@ export interface CommentSectionProps {
 export interface CommentItemProps {
 	content: CommonCommentDto;
 	type: 'news' | 'board';
-	handleLikeToggle: (commentId: number) => void;
-	handleReply: (commentId: number) => void;
-	closeReplyInput: (commentId: number) => void;
-	toggleReplyVisibility: (commentId: number) => void;
-	replyingTo: number[];
-	replyVisibilities: Record<number, boolean>;
 	isCommentAllowed: boolean;
 	contentsId: number;
-	parentReply?: string;
-	parentReplyId?: number;
 	isReply?: boolean;
-	onCommentSubmit: (isReply: boolean, pk?: number) => void;
-	onEnterEditMode: (commentId: number, isReply?: boolean) => void;
-	onDeleteComment: (commentId: number, parentReplyId?: number) => void;
+	replyTo?: { pk: number; nickname: string };
 	editingCommentId?: number;
 	setEditingCommentId?: (id: number | null) => void;
+	setComments: Dispatch<SetStateAction<CommonCommentDto[]>>;
 }
 
 // 코멘트 입력 props

--- a/src/components/features/detail/comment/type.ts
+++ b/src/components/features/detail/comment/type.ts
@@ -16,11 +16,11 @@ export interface CommentItemProps {
 	type: 'news' | 'board';
 	isCommentAllowed: boolean;
 	contentsId: number;
-	isReply?: boolean;
 	replyTo?: { pk: number; nickname: string };
 	editingCommentId?: number;
 	setEditingCommentId?: (id: number | null) => void;
 	setComments: Dispatch<SetStateAction<CommonCommentDto[]>>;
+	setTotalReplies: (count: number) => void;
 }
 
 // 코멘트 입력 props
@@ -34,6 +34,6 @@ export interface CommentInputProps {
 	contentsId: number;
 	editingCommentId: number;
 	defaultContent?: string;
-	onCommentSubmit?: (isReply: boolean) => void;
+	onCommentSubmit?: () => void;
 	onCommentCancel?: () => void;
 }

--- a/src/services/apis/board/board-reply.api.ts
+++ b/src/services/apis/board/board-reply.api.ts
@@ -3,18 +3,23 @@ import { EmptySuccessResponse, SuccessResponse } from '@/services/config/dto';
 import { fetcher } from '@/lib/server/fetcher';
 import { createBoardReplyRequest, GetBoardCommentsResponse } from './board-reply.type';
 import { CommonCommentKickDto, CommonPatchReplyDto } from '../common/types';
+import { GetCommentsRequest } from '../news/news.type';
 
 // 게시글 댓글 목록 조회
-export const getBoardCommentList = async (
-	id: number,
-	page: number = 1,
-	size: number = 10,
-): Promise<GetBoardCommentsResponse | null> => {
+export const getBoardCommentList = async ({
+	id,
+	page,
+	size,
+	infinite,
+	lastReply,
+}: GetCommentsRequest): Promise<GetBoardCommentsResponse | null> => {
 	const params = new URLSearchParams({
 		board: String(id),
 		page: String(page),
 		size: String(size),
 	});
+	if (infinite !== undefined) params.append('infinite', String(infinite));
+	if (lastReply !== undefined) params.append('lastReply', String(infinite));
 
 	const response = await fetch(`${SERVER_URL}/api/board-reply?${params.toString()}`);
 

--- a/src/services/apis/board/board-reply.api.ts
+++ b/src/services/apis/board/board-reply.api.ts
@@ -1,7 +1,7 @@
 import { SERVER_URL } from '@/services/config/constants';
 import { EmptySuccessResponse, SuccessResponse } from '@/services/config/dto';
 import { fetcher } from '@/lib/server/fetcher';
-import { createBoardReplyRequest, GetBoardCommentsResponse } from './board-reply.type';
+import { CreateBoardReplyRequest, GetBoardCommentsResponse } from './board-reply.type';
 import { CommonCommentKickDto, CommonPatchReplyDto } from '../common/types';
 import { GetCommentsRequest } from '../news/news.type';
 
@@ -51,7 +51,7 @@ export const createBoardCommentKick = async (id: number): Promise<SuccessRespons
 };
 
 // 댓글 생성
-export const createBoardReply = async (requestBody: createBoardReplyRequest): Promise<EmptySuccessResponse> => {
+export const createBoardReply = async (requestBody: CreateBoardReplyRequest): Promise<EmptySuccessResponse> => {
 	try {
 		const response = await fetcher<EmptySuccessResponse>({
 			method: 'POST',

--- a/src/services/apis/board/board-reply.type.ts
+++ b/src/services/apis/board/board-reply.type.ts
@@ -10,6 +10,6 @@ export interface CreateNewsCommentKickRequest {
 }
 
 // 새로운 댓글 생성 요청
-export interface createBoardReplyRequest extends CommonCreateNewReplyDto {
+export interface CreateBoardReplyRequest extends CommonCreateNewReplyDto {
 	board: number;
 }

--- a/src/services/apis/common/types.ts
+++ b/src/services/apis/common/types.ts
@@ -37,7 +37,7 @@ export interface CommonCommentDto {
 	user: UserDto;
 	createdAt: string;
 	kickCount: number;
-	replies: string[];
+	replies: CommonCommentDto[];
 	kicked: boolean;
 }
 

--- a/src/services/apis/news/news-reply.api.ts
+++ b/src/services/apis/news/news-reply.api.ts
@@ -1,8 +1,9 @@
 import { SERVER_URL } from '@/services/config/constants';
 import { EmptySuccessResponse, SuccessResponse } from '@/services/config/dto';
 import { fetcher } from '@/lib/server/fetcher';
-import { createNewsReplyRequest, GetNewsCommentsRequest, GetNewsCommentsResponse } from './news-reply.type';
+import { createNewsReplyRequest, GetNewsCommentsResponse } from './news-reply.type';
 import { CommonCommentKickDto, CommonPatchReplyDto } from '../common/types';
+import { GetCommentsRequest } from './news.type';
 
 // 뉴스 댓글 목록 조회
 export const getNewsCommentList = async ({
@@ -11,7 +12,7 @@ export const getNewsCommentList = async ({
 	size,
 	infinite,
 	lastReply,
-}: GetNewsCommentsRequest): Promise<GetNewsCommentsResponse | null> => {
+}: GetCommentsRequest): Promise<GetNewsCommentsResponse | null> => {
 	const params = new URLSearchParams({
 		news: String(id),
 		page: String(page),

--- a/src/services/apis/news/news-reply.api.ts
+++ b/src/services/apis/news/news-reply.api.ts
@@ -1,7 +1,7 @@
 import { SERVER_URL } from '@/services/config/constants';
 import { EmptySuccessResponse, SuccessResponse } from '@/services/config/dto';
 import { fetcher } from '@/lib/server/fetcher';
-import { createNewsReplyRequest, GetNewsCommentsResponse } from './news-reply.type';
+import { CreateNewsReplyRequest, GetNewsCommentsResponse } from './news-reply.type';
 import { CommonCommentKickDto, CommonPatchReplyDto } from '../common/types';
 import { GetCommentsRequest } from './news.type';
 
@@ -51,7 +51,7 @@ export const createNewsCommentKick = async (id: number): Promise<SuccessResponse
 };
 
 // 뉴스 댓글 생성
-export const createNewsReply = async (requestBody: createNewsReplyRequest): Promise<EmptySuccessResponse> => {
+export const createNewsReply = async (requestBody: CreateNewsReplyRequest): Promise<EmptySuccessResponse> => {
 	try {
 		const response = await fetcher<EmptySuccessResponse>({ method: 'POST', url: '/api/news-reply', body: requestBody });
 

--- a/src/services/apis/news/news-reply.type.ts
+++ b/src/services/apis/news/news-reply.type.ts
@@ -1,14 +1,6 @@
 import { SuccessResponse } from '@/services/config/dto';
 import { CommonCommentDto, CommonCreateNewReplyDto } from '../common/types';
 
-// 뉴스 댓글 조회 요청
-export interface GetNewsCommentsRequest {
-	id: number;
-	page: number;
-	size: number;
-	infinite?: boolean;
-	lastReply?: number;
-}
 // 뉴스 댓글 조회 응답
 export type GetNewsCommentsResponse = SuccessResponse<CommonCommentDto[]>;
 

--- a/src/services/apis/news/news-reply.type.ts
+++ b/src/services/apis/news/news-reply.type.ts
@@ -5,6 +5,6 @@ import { CommonCommentDto, CommonCreateNewReplyDto } from '../common/types';
 export type GetNewsCommentsResponse = SuccessResponse<CommonCommentDto[]>;
 
 // 새로운 댓글 생성 요청
-export interface createNewsReplyRequest extends CommonCreateNewReplyDto {
+export interface CreateNewsReplyRequest extends CommonCreateNewReplyDto {
 	news: number;
 }

--- a/src/services/apis/news/news.type.ts
+++ b/src/services/apis/news/news.type.ts
@@ -16,6 +16,15 @@ export interface NewsDetailDto extends CommonPostDetailDto {
 	category: Category;
 }
 
+// 댓글 조회 요청
+export interface GetCommentsRequest {
+	id: number;
+	page: number;
+	size: number;
+	infinite?: boolean;
+	lastReply?: number;
+}
+
 // 뉴스 리스트 조회
 export interface GetNewsListRequest {
 	team?: number;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -204,13 +204,6 @@ iframe.responsive-youtube {
 	display: none;
 }
 
-/* placeholder */
-.empty-placeholder:empty:before {
-	content: attr(data-placeholder);
-	color: #999;
-	pointer-events: none;
-}
-
 @keyframes pulse-scale-in {
 	0% {
 		transform: scale(0.5);


### PR DESCRIPTION
작업 복잡도에 따라 상세페이지 및 댓글 리팩토링을 4차례 정도로 나눠서 올리려고 합니다!

이번 브랜치에서는 크게 **댓글 로직 책임 분리**와 **변수명 개선**, **멘션 로직 단순화** 작업 진행했습니다.
현재 추가적인 로직 구현을 위해 서버 응답 수정이 필요한데, 해당 부분을 다음 스프린트에 진행하기로 했습니다. 그에 따라 로직 구현은 잠시 중단하고, ui 작업을 먼저 진행하기 위해서 이 시점에서 끊어가게 되었습니다!
현재 ui는 리뷰 편의성을 위해 거의 건드리지 않은 상태라, ui가 많이 깨져 있는 점은 감안하고 확인해 주세요!

무엇보다 댓글 로직 대규모 이동과 변수명 변경으로 리뷰가 어려울 것이라고 판단되어 **비대면 PR 설명회**를 진행하고자 하니 간단하게 살펴보시고 가능하신 시간 알려주시면 감사하겠습니닷!

## 작업 내용

### 댓글 로직 책임 분리

포인트는 이것입니다!!: 
> comment section → 댓글 리스트 관리
comment item → 각 댓글 아이템 + 종속된 답글 리스트 관리

기존에 comment section에서 댓글과 답글을 모두 관리함에 따라 무수히 많은 state 관리가 필요했는데요, **각각의 독립적인 comment item component가 자신의 답글 리스트를 관리**하면 많은 복잡도가 감소할 것이라고 생각했습니다.
실제로 각각의 comment item이 자신의 답글, 답글 입력 상태, 답글 리스트 오픈 상태를 독자적으로 관리하기 때문에 여러 배열로 관리하던 상태들도 제거할 수 있었습니다.

책임 분리를 위해 comment section에서 comment item으로 넘겨주던 이벤트 핸들러를 모두 comment item으로 옮겼습니다. 기본적으로 comemnt item이 들고 있는 pk 값이 있기 때문에, 이벤트 핸들러의 파라미터를 대부분 없앨 수 있었고, 

특히 댓글 수정 로직에서, editing comment id만 알고 있으면 staged comment id는 현재 컴포넌트에서 들고 있기 때문에 별도의 state로 관리하지 않고 처리할 수 있었습니다.

### 변수명 개선
면밀히 살펴보면서 느꼈던 가장 큰 혼란 유발지는 아래와 같습니다.
> comment와 reply의 혼합 -> 댓글과 답글 구분 모호
content와 contents의 혼합 -> 댓글과 본문 구분 모호

1. **comment와 reply**
comment와 reply가 댓글에도, 답글에도 큰 구분 없이 사용됨에 따라 큰 혼란이 야기됩니다. . .
일반적으로 댓글은 comment를 사용하고, 명시적으로 답글로 구분되는 경우 reply를 사용하도록 리팩토링하고자 합니다. 이런 방향으로 수정된 변수 및 함수명이 있으며, 아직 남아 있는 변수명도 있습니다!

2. **content와 contents**
a. 서버에서 댓글을 `contents`라는 이름으로 내려주고, 우리 코드에서는 `content`라는 이름으로 사용합니다.
b. 본문 id(pk)를 댓글 리스트 조회 및 댓글 생성 등에 사용하기 때문에 props로 넘겨주는데, 이때 `contentsId`라는 이름을 사용합니다.
c. b에 따라 본문의 type과 comment input의 type을 구분하기 위해 각각 `contentType`과 `type`이라는 이름을 사용합니다.

a에서는 contents의 대상이 댓글인데, b-c에서는 본문이기 때문에 혼란의 여지가 있습니다.
본문에 대한 값을 post-로 바꾸는 등 추후 개선될 예정입니다.
comment input 관련 ui 수정에 따라 props 변경이 예상되어서, ui 수정 후에 진행하고자 합니다!

그 외에도 컴포넌트마다 다른 이름으로 사용되던 parent 댓글 관련 props 네이밍을 replyTo 객체로 묶어 관리하도록 수정했습니다!

### 멘션 로직 단순화
직접 돔에 멘션 요소를 만들어 넣고, 이벤트 핸들러를 통해 그 요소가 제거되지 않도록 했던 기존 로직은 **멘션이 comment input의 핵심 요소가 아님에도 로직이 지나치게 많고 복잡해** 수정이 필요하다고 생각했습니다.

직접 돔에 추가하는 대신 before 가상요소를 사용해 돔에 추가하고 이벤트를 제어하는 로직을 제거했습니다.
대신 input 렌더링 초기에 커서가 가상요소 앞에 위치하는 문제가 있어서, 커서를 가상요소 뒤로 움직이기 위해 focus 시에 `zero width space`를 추가하도록 했습니다.

`zero width space`는 width가 매우 작은 공백으로, ui를 크게 저하하지 않으면서도 안정적으로 커서를 움직일 수 있습니다. 여전히 서버로 contents를 보내기 전에 `zero width space`를 제거해야 하는 번거로움은 있지만, 그 정규식이 매우 단순하기 때문에 큰 문제는 되지 않을 것 같습니다!

---

위에서 말씀드린 대로 PR을 여러 차례 나눠서 올리게 될 텐데, ui적으로도, 로직 측면에서도 완성된 모습은 아니기 때문에 그 분할된 브랜치의 작업 내용이 dev나 prod에 병합되기에는 문제가 있다고 생각됩니다.
따라서 아래처럼 진행하고자 하니 pr을 머지하지 말아주세요!

> **PR 작성, 머지 안 함 (단순 비교를 위한 PR)**
KO-538 -> dev
KO-538-2(KO-538에서 파생) -> KO-538
KO-538-3(KO-538-2에서 파생) -> KO-538-2
...
KO-538-N(최종 브랜치) -> KO-538-(N-1)

=> KO-538-2 -> dev로 PR을 열면, KO-538에서의 변경 사항까지 포함되기 때문에, 직전 브랜치에서 파생한 새 브랜치에서, 그 직전 브랜치로 PR을 쏘려고 합니다.

> **마지막에만 dev로 병합**
KO-538-N -> dev

=> 모든 작업이 완료된 후에 dev로 가는 PR을 열고 바로 병합합니다!