### PR TITLE
[KO-544] 이미지 업로드 최적화

### DIFF
--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -11,6 +11,7 @@ import { extractEmbeddedLinks, extractMediaFilenamesFromContent } from '@/lib/ut
 import { PostPinToggle } from '@/components/features/post/post-pin-toggle';
 import { CreateBoardRequest, PatchBoardDetailRequest } from '@/services/apis/board/board.type';
 import { createBoard, patchBoardDetail } from '@/services/apis/board/board.api';
+import { useEditorContext } from '@/lib/contexts/editor/context';
 
 export default function Page() {
 	const router = useRouter();
@@ -39,11 +40,14 @@ export default function Page() {
 
 	const [title, setTitle] = useState('');
 	const [body, setBody] = useState('');
-	const isFormValid = !!(selectedOption.value !== undefined && title.trim() && body.trim());
 	const [isPinned, setIsPinned] = useState(false);
 
 	const [isVisibleDropdown, setIsVisibleDropdown] = useState(false);
 	const dropdownRef = useRef<HTMLDivElement>(null);
+
+	const isFormValid = !!(selectedOption.value !== undefined && title.trim() && body.trim());
+	const { uploadingCount } = useEditorContext();
+	const canSubmit = isFormValid && !uploadingCount;
 
 	const handleDropdownToggle = () => {
 		setIsVisibleDropdown((prev) => !prev);
@@ -255,11 +259,11 @@ export default function Page() {
 					취소
 				</button>
 				<button
-					onClick={isFormValid ? postCommunityContents : undefined}
-					disabled={!isFormValid}
+					onClick={canSubmit ? postCommunityContents : undefined}
+					disabled={!canSubmit}
 					className={clsx(
 						'w-41 @mobile:w-37 button2-semibold px-4 py-2 rounded-lg transition-all',
-						isFormValid ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
+						canSubmit ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
 					)}
 				>
 					{isEditMode ? '수정 완료' : '작성 완료'}

--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -11,7 +11,6 @@ import { extractEmbeddedLinks, extractMediaFilenamesFromContent } from '@/lib/ut
 import { PostPinToggle } from '@/components/features/post/post-pin-toggle';
 import { CreateBoardRequest, PatchBoardDetailRequest } from '@/services/apis/board/board.type';
 import { createBoard, patchBoardDetail } from '@/services/apis/board/board.api';
-import { useEditorContext } from '@/lib/contexts/editor/context';
 
 export default function Page() {
 	const router = useRouter();
@@ -46,8 +45,8 @@ export default function Page() {
 	const dropdownRef = useRef<HTMLDivElement>(null);
 
 	const isFormValid = !!(selectedOption.value !== undefined && title.trim() && body.trim());
-	const { uploadingCount } = useEditorContext();
-	const canSubmit = isFormValid && !uploadingCount;
+	//const { uploadingCount } = useEditorContext();
+	const canSubmit = isFormValid;
 
 	const handleDropdownToggle = () => {
 		setIsVisibleDropdown((prev) => !prev);

--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -11,6 +11,7 @@ import { extractEmbeddedLinks, extractMediaFilenamesFromContent } from '@/lib/ut
 import { PostPinToggle } from '@/components/features/post/post-pin-toggle';
 import { CreateBoardRequest, PatchBoardDetailRequest } from '@/services/apis/board/board.type';
 import { createBoard, patchBoardDetail } from '@/services/apis/board/board.api';
+import { EditorProvider } from '@/lib/contexts/editor/provider';
 
 export default function Page() {
 	const router = useRouter();
@@ -233,7 +234,9 @@ export default function Page() {
 				)}
 			</div>
 
-			<PostEditor setTitle={setTitle} setBody={setBody} isNews={false} editedTitle={title} editedBody={body} />
+			<EditorProvider setBody={setBody} isNews={false} editedBody={body}>
+				<PostEditor setTitle={setTitle} editedTitle={title} />
+			</EditorProvider>
 
 			{currentUserInfo?.isInfluencer && <PostPinToggle isPinned={isPinned} onPinChange={setIsPinned} />}
 

--- a/src/app/(without-side)/post/board/page.tsx
+++ b/src/app/(without-side)/post/board/page.tsx
@@ -46,8 +46,6 @@ export default function Page() {
 	const dropdownRef = useRef<HTMLDivElement>(null);
 
 	const isFormValid = !!(selectedOption.value !== undefined && title.trim() && body.trim());
-	//const { uploadingCount } = useEditorContext();
-	const canSubmit = isFormValid;
 
 	const handleDropdownToggle = () => {
 		setIsVisibleDropdown((prev) => !prev);
@@ -261,11 +259,11 @@ export default function Page() {
 					취소
 				</button>
 				<button
-					onClick={canSubmit ? postCommunityContents : undefined}
-					disabled={!canSubmit}
+					onClick={isFormValid ? postCommunityContents : undefined}
+					disabled={!isFormValid}
 					className={clsx(
 						'w-41 @mobile:w-37 button2-semibold px-4 py-2 rounded-lg transition-all',
-						canSubmit ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
+						isFormValid ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
 					)}
 				>
 					{isEditMode ? '수정 완료' : '작성 완료'}

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -27,12 +27,17 @@ export default function Page() {
 		value: '',
 	});
 	const { currentUserInfo, setCurrentUserInfo } = useCurrentUserInfoStore();
+	const searchParams = useSearchParams();
+	const isEditMode = searchParams.get('edit') === 'true';
+
 	const [title, setTitle] = useState('');
 	const [body, setBody] = useState('');
 	const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
 	const isFormValid = !!(selectedImage?.trim() && selectedOption.value && title.trim() && body.trim());
-	const searchParams = useSearchParams();
-	const isEditMode = searchParams.get('edit') === 'true';
+	const [isThumbnailUploaded, setIsThumbnailUploaded] = useState(false);
+	const isLoading = useRef(false); // 더블 클릭 -> 중복 호출 방지
+	const canSubmit = isFormValid && isThumbnailUploaded && !isLoading;
 
 	useEffect(() => {
 		if (!isEditMode) return;
@@ -101,9 +106,6 @@ export default function Page() {
 		}
 	}, [currentUserInfo, setCurrentUserInfo, router]);
 
-	// 중복 호출 방지
-	const isLoading = useRef(false);
-
 	const postNewsContents = async () => {
 		console.log('isLoading', isLoading.current);
 		if (!currentUserInfo || isLoading.current) {
@@ -163,7 +165,11 @@ export default function Page() {
 
 	return (
 		<div className="flex flex-col w-full">
-			<ThumbnailUploader selectedImage={selectedImage} onChange={setSelectedImage} />
+			<ThumbnailUploader
+				selectedImage={selectedImage}
+				onChange={setSelectedImage}
+				onUploadingChange={setIsThumbnailUploaded}
+			/>
 
 			<div className="flex gap-4 mb-4">
 				<TeamSearchInput selectedTeam={selectedTeam} setSelectedTeam={setSelectedTeam} />
@@ -200,10 +206,10 @@ export default function Page() {
 				</button>
 				<button
 					onClick={selectedImage ? postNewsContents : () => alert('대표 이미지를 등록해 주세요.')}
-					disabled={!isFormValid && !isLoading}
+					disabled={!canSubmit}
 					className={clsx(
 						'w-41 @mobile:w-37 button2-semibold @mobile:text-15 px-4 py-2 rounded-lg transition-all',
-						isFormValid ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
+						canSubmit ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
 					)}
 				>
 					{isEditMode ? '수정 완료' : '작성 완료'}

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -37,9 +37,9 @@ export default function Page() {
 	const [selectedImage, setSelectedImage] = useState<string | null>(null);
 
 	const isFormValid = !!(selectedImage?.trim() && selectedOption.value && title.trim() && body.trim());
-	const [isThumbnailUploaded, setIsThumbnailUploaded] = useState(false);
+
 	//const { uploadingCount } = useEditorContext();
-	const canSubmit = isFormValid && isThumbnailUploaded;
+	const canSubmit = isFormValid;
 
 	useEffect(() => {
 		if (!isEditMode) return;
@@ -169,11 +169,7 @@ export default function Page() {
 
 	return (
 		<div className="flex flex-col w-full">
-			<ThumbnailUploader
-				selectedImage={selectedImage}
-				onChange={setSelectedImage}
-				setIsThumbnailUploaded={setIsThumbnailUploaded}
-			/>
+			<ThumbnailUploader selectedImage={selectedImage} onChange={setSelectedImage} />
 
 			<div className="flex gap-4 mb-4">
 				<TeamSearchInput selectedTeam={selectedTeam} setSelectedTeam={setSelectedTeam} />

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -16,6 +16,7 @@ import { extractEmbeddedLinks, extractMediaFilenamesFromContent } from '@/lib/ut
 import { categories } from '@/lib/constants/options';
 import { createNews, patchNewsDetail } from '@/services/apis/news/news.api';
 import { CreateNewsRequest, PatchNewsDetailRequest } from '@/services/apis/news/news.type';
+import { useEditorContext } from '@/lib/contexts/editor/context';
 
 export default function Page() {
 	const router = useRouter();
@@ -36,8 +37,8 @@ export default function Page() {
 
 	const isFormValid = !!(selectedImage?.trim() && selectedOption.value && title.trim() && body.trim());
 	const [isThumbnailUploaded, setIsThumbnailUploaded] = useState(false);
-	const isLoading = useRef(false); // 더블 클릭 -> 중복 호출 방지
-	const canSubmit = isFormValid && isThumbnailUploaded && !isLoading;
+	const { uploadingCount } = useEditorContext();
+	const canSubmit = isFormValid && isThumbnailUploaded && !uploadingCount;
 
 	useEffect(() => {
 		if (!isEditMode) return;
@@ -105,6 +106,8 @@ export default function Page() {
 			fetchUserInfo();
 		}
 	}, [currentUserInfo, setCurrentUserInfo, router]);
+
+	const isLoading = useRef(false); // 더블 클릭 -> 중복 호출 방지
 
 	const postNewsContents = async () => {
 		console.log('isLoading', isLoading.current);

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -16,6 +16,7 @@ import { extractEmbeddedLinks, extractMediaFilenamesFromContent } from '@/lib/ut
 import { categories } from '@/lib/constants/options';
 import { createNews, patchNewsDetail } from '@/services/apis/news/news.api';
 import { CreateNewsRequest, PatchNewsDetailRequest } from '@/services/apis/news/news.type';
+import { EditorProvider } from '@/lib/contexts/editor/provider';
 //import { useEditorContext } from '@/lib/contexts/editor/context';
 
 export default function Page() {
@@ -189,8 +190,9 @@ export default function Page() {
 					<Image src="/help-circle.svg" alt="게시글 작성 가이드라인" width={20} height={20} />
 				</button>
 			</div>
-
-			<PostEditor setTitle={setTitle} setBody={setBody} isNews={true} editedTitle={title} editedBody={body} />
+			<EditorProvider setBody={setBody} isNews={true} editedBody={body}>
+				<PostEditor setTitle={setTitle} editedTitle={title} />
+			</EditorProvider>
 
 			<div className="flex w-full justify-center gap-4 mt-[30px] mb-[100px] @mobile:mt-[38px] @mobile:mb-[50px]">
 				<button

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -16,7 +16,7 @@ import { extractEmbeddedLinks, extractMediaFilenamesFromContent } from '@/lib/ut
 import { categories } from '@/lib/constants/options';
 import { createNews, patchNewsDetail } from '@/services/apis/news/news.api';
 import { CreateNewsRequest, PatchNewsDetailRequest } from '@/services/apis/news/news.type';
-import { useEditorContext } from '@/lib/contexts/editor/context';
+//import { useEditorContext } from '@/lib/contexts/editor/context';
 
 export default function Page() {
 	const router = useRouter();
@@ -37,8 +37,8 @@ export default function Page() {
 
 	const isFormValid = !!(selectedImage?.trim() && selectedOption.value && title.trim() && body.trim());
 	const [isThumbnailUploaded, setIsThumbnailUploaded] = useState(false);
-	const { uploadingCount } = useEditorContext();
-	const canSubmit = isFormValid && isThumbnailUploaded && !uploadingCount;
+	//const { uploadingCount } = useEditorContext();
+	const canSubmit = isFormValid && isThumbnailUploaded;
 
 	useEffect(() => {
 		if (!isEditMode) return;

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -38,9 +38,6 @@ export default function Page() {
 
 	const isFormValid = !!(selectedImage?.trim() && selectedOption.value && title.trim() && body.trim());
 
-	//const { uploadingCount } = useEditorContext();
-	const canSubmit = isFormValid;
-
 	useEffect(() => {
 		if (!isEditMode) return;
 
@@ -207,10 +204,10 @@ export default function Page() {
 				</button>
 				<button
 					onClick={selectedImage ? postNewsContents : () => alert('대표 이미지를 등록해 주세요.')}
-					disabled={!canSubmit}
+					disabled={!isFormValid}
 					className={clsx(
 						'w-41 @mobile:w-37 button2-semibold @mobile:text-15 px-4 py-2 rounded-lg transition-all',
-						canSubmit ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
+						isFormValid ? 'text-black-100 bg-primary-900' : 'bg-black-600 text-black-000',
 					)}
 				>
 					{isEditMode ? '수정 완료' : '작성 완료'}

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -171,7 +171,7 @@ export default function Page() {
 			<ThumbnailUploader
 				selectedImage={selectedImage}
 				onChange={setSelectedImage}
-				onUploadingChange={setIsThumbnailUploaded}
+				setIsThumbnailUpdoad={setIsThumbnailUploaded}
 			/>
 
 			<div className="flex gap-4 mb-4">

--- a/src/app/(without-side)/post/news/page.tsx
+++ b/src/app/(without-side)/post/news/page.tsx
@@ -172,7 +172,7 @@ export default function Page() {
 			<ThumbnailUploader
 				selectedImage={selectedImage}
 				onChange={setSelectedImage}
-				setIsThumbnailUpdoad={setIsThumbnailUploaded}
+				setIsThumbnailUploaded={setIsThumbnailUploaded}
 			/>
 
 			<div className="flex gap-4 mb-4">

--- a/src/components/features/post/post-editor.tsx.tsx
+++ b/src/components/features/post/post-editor.tsx.tsx
@@ -9,6 +9,21 @@ import { compressImage } from '@/lib/utils';
 
 const PostEditor = ({ setTitle, editedTitle }: { setTitle: (title: string) => void; editedTitle: string }) => {
 	const { editor, showModal, pendingFile, setPendingFile, setShowModal, handleImageUpload } = useEditorContext();
+
+	const handleConfirmModal = async () => {
+		const previewUrl = URL.createObjectURL(pendingFile);
+		editor.chain().focus().setImage({ src: previewUrl }).run(); // 미리보기 삽입 후 압축
+		const compressedFile = await compressImage(pendingFile);
+		await handleImageUpload(compressedFile); // 압축한 이미지 업로드
+		setPendingFile(null);
+		setShowModal(false);
+	};
+
+	const handleCancleModal = () => {
+		setPendingFile(null);
+		setShowModal(false);
+	};
+
 	return (
 		<>
 			<input
@@ -25,16 +40,8 @@ const PostEditor = ({ setTitle, editedTitle }: { setTitle: (title: string) => vo
 				<AlertModal
 					type="confirm"
 					description={'파일의 용량이 커 압축이 진행됩니다.\n계속하시겠습니까?'}
-					onConfirm={async () => {
-						const compressedFile = await compressImage(pendingFile);
-						await handleImageUpload(compressedFile);
-						setPendingFile(null);
-						setShowModal(false);
-					}}
-					onCancel={() => {
-						setPendingFile(null);
-						setShowModal(false);
-					}}
+					onConfirm={handleConfirmModal}
+					onCancel={handleCancleModal}
 				/>
 			)}
 		</>

--- a/src/components/features/post/post-editor.tsx.tsx
+++ b/src/components/features/post/post-editor.tsx.tsx
@@ -4,6 +4,9 @@ import Toolbar from './editor/tool-bar';
 import { EditorContent } from '@tiptap/react';
 import { useEditorContext } from '@/lib/contexts/editor/context';
 import { EditorProvider } from '@/lib/contexts/editor/provider';
+import AlertModal from '../detail/alert-modal';
+import { compressImage } from '@/lib/utils';
+import { useState } from 'react';
 
 const EditorBody = () => {
 	const { editor } = useEditorContext();
@@ -29,8 +32,17 @@ const PostEditor = ({
 	editedTitle: string;
 	editedBody: string;
 }) => {
+	const { handleImageUpload } = useEditorContext();
+	const [pendingFile, setPendingFile] = useState<File | null>(null);
+	const [showModal, setShowModal] = useState(false);
 	return (
-		<EditorProvider setBody={setBody} isNews={isNews} editedBody={editedBody}>
+		<EditorProvider
+			setBody={setBody}
+			isNews={isNews}
+			editedBody={editedBody}
+			setPendingFile={setPendingFile}
+			setShowModal={setShowModal}
+		>
 			<input
 				placeholder="제목"
 				value={editedTitle ?? ''}
@@ -38,6 +50,22 @@ const PostEditor = ({
 				onChange={(e) => setTitle(e.target.value)}
 			/>
 			<EditorBody />
+			{showModal && pendingFile && (
+				<AlertModal
+					type="confirm"
+					description="파일의 용량이 커 압축이 진행될 예정입니다.\n계속하시겠습니까?"
+					onConfirm={async () => {
+						const compressedFile = await compressImage(pendingFile);
+						await handleImageUpload(compressedFile);
+						setPendingFile(null);
+						setShowModal(false);
+					}}
+					onCancel={() => {
+						setPendingFile(null);
+						setShowModal(false);
+					}}
+				/>
+			)}
 		</EditorProvider>
 	);
 };

--- a/src/components/features/post/post-editor.tsx.tsx
+++ b/src/components/features/post/post-editor.tsx.tsx
@@ -19,6 +19,36 @@ const EditorBody = () => {
 		</>
 	);
 };
+
+const ModalWrapper = ({
+	pendingFile,
+	setPendingFile,
+	setShowModal,
+}: {
+	pendingFile: File;
+	setPendingFile: (file: File | null) => void;
+	setShowModal: (open: boolean) => void;
+}) => {
+	const { handleImageUpload } = useEditorContext();
+
+	return (
+		<AlertModal
+			type="confirm"
+			description={'파일의 용량이 커 압축이 진행됩니다.\n계속하시겠습니까?'}
+			onConfirm={async () => {
+				const compressedFile = await compressImage(pendingFile);
+				await handleImageUpload(compressedFile);
+				setPendingFile(null);
+				setShowModal(false);
+			}}
+			onCancel={() => {
+				setPendingFile(null);
+				setShowModal(false);
+			}}
+		/>
+	);
+};
+
 const PostEditor = ({
 	setTitle,
 	setBody,
@@ -32,7 +62,6 @@ const PostEditor = ({
 	editedTitle: string;
 	editedBody: string;
 }) => {
-	const { handleImageUpload } = useEditorContext();
 	const [pendingFile, setPendingFile] = useState<File | null>(null);
 	const [showModal, setShowModal] = useState(false);
 	return (
@@ -51,20 +80,7 @@ const PostEditor = ({
 			/>
 			<EditorBody />
 			{showModal && pendingFile && (
-				<AlertModal
-					type="confirm"
-					description="파일의 용량이 커 압축이 진행될 예정입니다.\n계속하시겠습니까?"
-					onConfirm={async () => {
-						const compressedFile = await compressImage(pendingFile);
-						await handleImageUpload(compressedFile);
-						setPendingFile(null);
-						setShowModal(false);
-					}}
-					onCancel={() => {
-						setPendingFile(null);
-						setShowModal(false);
-					}}
-				/>
+				<ModalWrapper pendingFile={pendingFile} setPendingFile={setPendingFile} setShowModal={setShowModal} />
 			)}
 		</EditorProvider>
 	);

--- a/src/components/features/post/post-editor.tsx.tsx
+++ b/src/components/features/post/post-editor.tsx.tsx
@@ -3,86 +3,41 @@
 import Toolbar from './editor/tool-bar';
 import { EditorContent } from '@tiptap/react';
 import { useEditorContext } from '@/lib/contexts/editor/context';
-import { EditorProvider } from '@/lib/contexts/editor/provider';
+
 import AlertModal from '../detail/alert-modal';
 import { compressImage } from '@/lib/utils';
-import { useState } from 'react';
 
-const EditorBody = () => {
-	const { editor } = useEditorContext();
+const PostEditor = ({ setTitle, editedTitle }: { setTitle: (title: string) => void; editedTitle: string }) => {
+	const { editor, showModal, pendingFile, setPendingFile, setShowModal, handleImageUpload } = useEditorContext();
 	return (
 		<>
-			<Toolbar />
-			<div className="w-full h-[460px] overflow-y-auto custom-scrollbar rounded-lg @mobile:rounded-none @mobile:rounded-bl-lg @mobile:rounded-br-lg border border-black-300">
-				<EditorContent editor={editor} className="pl-4 p-3 w-full h-full focus:outline-none" />
-			</div>
-		</>
-	);
-};
-
-const ModalWrapper = ({
-	pendingFile,
-	setPendingFile,
-	setShowModal,
-}: {
-	pendingFile: File;
-	setPendingFile: (file: File | null) => void;
-	setShowModal: (open: boolean) => void;
-}) => {
-	const { handleImageUpload } = useEditorContext();
-
-	return (
-		<AlertModal
-			type="confirm"
-			description={'파일의 용량이 커 압축이 진행됩니다.\n계속하시겠습니까?'}
-			onConfirm={async () => {
-				const compressedFile = await compressImage(pendingFile);
-				await handleImageUpload(compressedFile);
-				setPendingFile(null);
-				setShowModal(false);
-			}}
-			onCancel={() => {
-				setPendingFile(null);
-				setShowModal(false);
-			}}
-		/>
-	);
-};
-
-const PostEditor = ({
-	setTitle,
-	setBody,
-	isNews,
-	editedTitle,
-	editedBody,
-}: {
-	setTitle: (title: string) => void;
-	setBody: (body: string) => void;
-	isNews: boolean;
-	editedTitle: string;
-	editedBody: string;
-}) => {
-	const [pendingFile, setPendingFile] = useState<File | null>(null);
-	const [showModal, setShowModal] = useState(false);
-	return (
-		<EditorProvider
-			setBody={setBody}
-			isNews={isNews}
-			editedBody={editedBody}
-			setPendingFile={setPendingFile}
-			setShowModal={setShowModal}
-		>
 			<input
 				placeholder="제목"
 				value={editedTitle ?? ''}
 				className="title1-bold @mobile:text-20 w-full @mobile:font-semibold h-[3.5rem] @mobile:h-12 px-4 py-[15px] @mobile:py-3 border border-black-300 rounded-lg mb-8 focus:outline-none"
 				onChange={(e) => setTitle(e.target.value)}
 			/>
-			<EditorBody />
+			<Toolbar />
+			<div className="w-full h-[460px] overflow-y-auto custom-scrollbar rounded-lg @mobile:rounded-none @mobile:rounded-bl-lg @mobile:rounded-br-lg border border-black-300">
+				<EditorContent editor={editor} className="pl-4 p-3 w-full h-full focus:outline-none" />
+			</div>
 			{showModal && pendingFile && (
-				<ModalWrapper pendingFile={pendingFile} setPendingFile={setPendingFile} setShowModal={setShowModal} />
+				<AlertModal
+					type="confirm"
+					description={'파일의 용량이 커 압축이 진행됩니다.\n계속하시겠습니까?'}
+					onConfirm={async () => {
+						const compressedFile = await compressImage(pendingFile);
+						await handleImageUpload(compressedFile);
+						setPendingFile(null);
+						setShowModal(false);
+					}}
+					onCancel={() => {
+						setPendingFile(null);
+						setShowModal(false);
+					}}
+				/>
 			)}
-		</EditorProvider>
+		</>
 	);
 };
 export default PostEditor;

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -10,10 +10,10 @@ import AlertModal from '../detail/alert-modal';
 interface ThumbnailUploaderProps {
 	selectedImage: string | null;
 	onChange: (url: string | null) => void;
-	setIsThumbnailUpdoad: (uploading: boolean) => void;
+	setIsThumbnailUploaded: (uploading: boolean) => void;
 }
 
-export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbnailUpdoad }: ThumbnailUploaderProps) {
+export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbnailUploaded }: ThumbnailUploaderProps) {
 	const [isPortrait, setIsPortrait] = useState(false);
 	const [showModal, setShowModal] = useState(false);
 	const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -52,7 +52,7 @@ export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbn
 
 	const handleFileUpload = async (file: File) => {
 		try {
-			setIsThumbnailUpdoad?.(false); // 업로드 시작 (아직 업로드 안 됨)
+			setIsThumbnailUploaded?.(false); // 업로드 시작 (아직 업로드 안 됨)
 
 			const presignedResponse = await getPresignedUrl({
 				type: 'news-files',
@@ -63,11 +63,10 @@ export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbn
 			await uploadToS3(presignedUrl, file);
 
 			onChange(s3Url);
-			setIsThumbnailUpdoad?.(true); // 업로드 성공
+			setIsThumbnailUploaded?.(true); // 업로드 성공
 		} catch (error) {
 			console.error('파일 업로드 실패:', error);
-		} finally {
-			setIsThumbnailUpdoad?.(false); // 업로드 종료
+			setIsThumbnailUploaded?.(false); // 실패 시 false
 		}
 	};
 

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -5,61 +5,66 @@ import { useRef, useState } from 'react';
 import clsx from 'clsx';
 import { getPresignedUrl, uploadToS3 } from '@/services/apis/image-upload';
 import { compressImage } from '@/lib/utils';
+import AlertModal from '../detail/alert-modal';
 
 interface ThumbnailUploaderProps {
 	selectedImage: string | null;
 	onChange: (url: string | null) => void;
+	onUploadingChange?: (uploading: boolean) => void;
 }
 
-export default function ThumbnailUploader({ selectedImage, onChange }: ThumbnailUploaderProps) {
+export default function ThumbnailUploader({ selectedImage, onChange, onUploadingChange }: ThumbnailUploaderProps) {
 	const [isPortrait, setIsPortrait] = useState(false);
+	const [showModal, setShowModal] = useState(false);
+	const [pendingFile, setPendingFile] = useState<File | null>(null);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
-	const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+	const handleImageClick = () => {
+		fileInputRef.current?.click();
+	};
+
+	const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
 		const file = event.target.files?.[0];
 		if (!file) return;
 
-		// 로컬 미리보기 URL 먼저 보여주기
+		// 미리보기 먼저 보여주기
 		const previewUrl = URL.createObjectURL(file);
 		onChange(previewUrl);
 
-		// orientation 판별 (미리보기 용)
+		// orientation 체크
 		const img = document.createElement('img');
 		img.src = previewUrl;
 		img.onload = () => {
 			setIsPortrait(img.height > img.width);
 		};
 
+		if (file.size > 5 * 1024 * 1024) {
+			// 5MB 이상 -> 모달 열고 confirm 대기
+			setPendingFile(file);
+			setShowModal(true);
+		} else {
+			// 5MB 미만 -> s3 업로드
+			handleFileUpload(file);
+		}
+	};
+
+	const handleFileUpload = async (file: File) => {
 		try {
-			let fileToUpload = file;
+			onUploadingChange?.(true); // 업로드 시작 알림
 
-			// 이미지가 5MB 이상일 때: alert 띄우고 확인되면 압축 진행
-			if (file.size > 5 * 1024 * 1024) {
-				const proceed = window.confirm(
-					'선택하신 파일은 5MB 이상입니다.\n압축을 진행하며 시간이 다소 소요될 수 있습니다.\n계속하시겠습니까?',
-				);
-				if (!proceed) return;
-
-				console.log(`압축 전 파일 크기: ${(file.size / 1024 / 1024).toFixed(2)} MB`);
-				fileToUpload = await compressImage(file);
-				console.log(`압축 후 파일 크기: ${(fileToUpload.size / 1024 / 1024).toFixed(2)} MB`);
-			}
-
-			// presigned URL 발급
 			const presignedResponse = await getPresignedUrl({
 				type: 'news-files',
-				fileName: fileToUpload.name || file.name,
+				fileName: file.name,
 			});
 
 			const { presignedUrl, s3Url } = presignedResponse.data;
+			await uploadToS3(presignedUrl, file);
 
-			// S3 업로드
-			await uploadToS3(presignedUrl, fileToUpload);
-
-			// 업로드 완료되면 미리보기 URL → s3Url로 교체
 			onChange(s3Url);
 		} catch (error) {
 			console.error('파일 업로드 실패:', error);
+		} finally {
+			onUploadingChange?.(false); // 업로드 종료 알림
 		}
 	};
 
@@ -68,10 +73,6 @@ export default function ThumbnailUploader({ selectedImage, onChange }: Thumbnail
 		if (fileInputRef.current) {
 			fileInputRef.current.value = '';
 		}
-	};
-
-	const handleImageClick = () => {
-		fileInputRef.current?.click();
 	};
 
 	return (
@@ -102,6 +103,33 @@ export default function ThumbnailUploader({ selectedImage, onChange }: Thumbnail
 				</div>
 			)}
 			<input type="file" ref={fileInputRef} onChange={handleFileChange} style={{ display: 'none' }} accept="image/*" />
+
+			{showModal && pendingFile && (
+				<AlertModal
+					type="confirm"
+					description={'파일의 용량이 커 압축이 진행될 예정입니다.\n계속하시겠습니까?'}
+					onConfirm={async () => {
+						setShowModal(false);
+						if (pendingFile) {
+							const compressedFile = await compressImage(pendingFile);
+							await handleFileUpload(compressedFile);
+							setPendingFile(null);
+						}
+					}}
+					onCancel={() => {
+						setShowModal(false);
+						setPendingFile(null);
+					}}
+				/>
+			)}
 		</>
 	);
 }
+
+// 사용자가 파일 선택 -> 미리보기 url 삽입 -> 파일의 용량 확인 -> 5mb 이상? -> 압축될 거라고 alert -> 압축 -> s3 업로드 -> 미리보기 url을 s3 url로 교체
+// 사용자가 파일 선택 -> 미리보기 url 삽입 -> 파일의 용량 확인 -> 5mb 이하? -> 압축 ㄴㄴ -> s3 업로드 -> 교체
+
+// 걍 두 경우 모두 s3 업로드 되기 전까지 작성 완료 버튼 비활성화 시키고 5mb 이상은 파일의 크기가 커서 압축 진행된다. 계속하겠냐 alert 띄우기
+// 5mb으로 한 이유는? 쿠팡 페이지를 보면 로딩되는 이미지는 1mb 이하임 -> 우리는 next.js의 image 컴포넌트로 최적화 진행할 거고
+// lambda로 리사이징 할 거임 -> 즉 로딩되는 건 업로드될 때의 이미지가 아니라 이미 축소된 것임.
+// 그런데도 압축하는 이유는? s3 업로드 시간을 단축하고자. 그리고 너무 큰 이미지를 서버에 저장시키지 않으려고...

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -52,7 +52,7 @@ export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbn
 
 	const handleFileUpload = async (file: File) => {
 		try {
-			setIsThumbnailUpdoad?.(true); // 업로드 시작 알림
+			setIsThumbnailUpdoad?.(false); // 업로드 시작 (아직 업로드 안 됨)
 
 			const presignedResponse = await getPresignedUrl({
 				type: 'news-files',
@@ -63,10 +63,11 @@ export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbn
 			await uploadToS3(presignedUrl, file);
 
 			onChange(s3Url);
+			setIsThumbnailUpdoad?.(true); // 업로드 성공
 		} catch (error) {
 			console.error('파일 업로드 실패:', error);
 		} finally {
-			setIsThumbnailUpdoad?.(false); // 업로드 종료 알림
+			setIsThumbnailUpdoad?.(false); // 업로드 종료
 		}
 	};
 

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -38,7 +38,7 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 			setIsPortrait(img.height > img.width);
 		};
 
-		if (file.size > 5 * 1024 * 1024) {
+		if (file.size > 2 * 1024 * 1024) {
 			// 5MB 이상 -> 모달 열고 confirm 대기
 			setPendingFile(file);
 			setShowModal(true);

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -27,25 +27,27 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 		const file = event.target.files?.[0];
 		if (!file) return;
 
-		// 미리보기 먼저 보여주기
+		if (file.size > 2 * 1024 * 1024) {
+			// 2MB 이상 -> 모달 먼저
+			setPendingFile(file);
+			setShowModal(true);
+		} else {
+			// 2MB 미만 -> 미리보기 + 업로드
+			showPreviewAndUpload(file);
+		}
+	};
+
+	const showPreviewAndUpload = (file: File) => {
 		const previewUrl = URL.createObjectURL(file);
 		onChange(previewUrl);
 
-		// orientation 체크
 		const img = document.createElement('img');
 		img.src = previewUrl;
 		img.onload = () => {
 			setIsPortrait(img.height > img.width);
 		};
 
-		if (file.size > 2 * 1024 * 1024) {
-			// 2MB 이상 -> 모달 열고 confirm 대기
-			setPendingFile(file);
-			setShowModal(true);
-		} else {
-			// 2MB 미만 -> s3 업로드
-			handleFileUpload(file);
-		}
+		handleFileUpload(file);
 	};
 
 	const handleFileUpload = async (file: File) => {
@@ -112,7 +114,7 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 						setShowModal(false);
 						if (pendingFile) {
 							const compressedFile = await compressImage(pendingFile);
-							await handleFileUpload(compressedFile);
+							showPreviewAndUpload(compressedFile);
 							setPendingFile(null);
 						}
 					}}

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -10,10 +10,10 @@ import AlertModal from '../detail/alert-modal';
 interface ThumbnailUploaderProps {
 	selectedImage: string | null;
 	onChange: (url: string | null) => void;
-	onUploadingChange?: (uploading: boolean) => void;
+	setIsThumbnailUpdoad: (uploading: boolean) => void;
 }
 
-export default function ThumbnailUploader({ selectedImage, onChange, onUploadingChange }: ThumbnailUploaderProps) {
+export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbnailUpdoad }: ThumbnailUploaderProps) {
 	const [isPortrait, setIsPortrait] = useState(false);
 	const [showModal, setShowModal] = useState(false);
 	const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -52,7 +52,7 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 
 	const handleFileUpload = async (file: File) => {
 		try {
-			onUploadingChange?.(true); // 업로드 시작 알림
+			setIsThumbnailUpdoad?.(true); // 업로드 시작 알림
 
 			const presignedResponse = await getPresignedUrl({
 				type: 'news-files',
@@ -66,7 +66,7 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 		} catch (error) {
 			console.error('파일 업로드 실패:', error);
 		} finally {
-			onUploadingChange?.(false); // 업로드 종료 알림
+			setIsThumbnailUpdoad?.(false); // 업로드 종료 알림
 		}
 	};
 

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -19,30 +19,44 @@ export default function ThumbnailUploader({ selectedImage, onChange }: Thumbnail
 		const file = event.target.files?.[0];
 		if (!file) return;
 
+		// 로컬 미리보기 URL 먼저 보여주기
+		const previewUrl = URL.createObjectURL(file);
+		onChange(previewUrl);
+
+		// orientation 판별 (미리보기 용)
+		const img = document.createElement('img');
+		img.src = previewUrl;
+		img.onload = () => {
+			setIsPortrait(img.height > img.width);
+		};
+
 		try {
-			console.log(`압축 전 파일 크기: ${(file.size / 1024).toFixed(2)} KB`);
+			let fileToUpload = file;
 
-			const compressedFile = await compressImage(file);
+			// 이미지가 5MB 이상일 때: alert 띄우고 확인되면 압축 진행
+			if (file.size > 5 * 1024 * 1024) {
+				const proceed = window.confirm(
+					'선택하신 파일은 5MB 이상입니다.\n압축을 진행하며 시간이 다소 소요될 수 있습니다.\n계속하시겠습니까?',
+				);
+				if (!proceed) return;
 
-			// 압축 후 파일 크기 출력
-			console.log(`압축 후 파일 크기: ${(compressedFile.size / 1024).toFixed(2)} KB`);
+				console.log(`압축 전 파일 크기: ${(file.size / 1024 / 1024).toFixed(2)} MB`);
+				fileToUpload = await compressImage(file);
+				console.log(`압축 후 파일 크기: ${(fileToUpload.size / 1024 / 1024).toFixed(2)} MB`);
+			}
 
-			const img = document.createElement('img');
-			img.src = URL.createObjectURL(compressedFile);
-			img.onload = () => {
-				setIsPortrait(img.height > img.width);
-				URL.revokeObjectURL(img.src);
-			};
-
+			// presigned URL 발급
 			const presignedResponse = await getPresignedUrl({
 				type: 'news-files',
-				fileName: compressedFile.name || file.name,
+				fileName: fileToUpload.name || file.name,
 			});
 
 			const { presignedUrl, s3Url } = presignedResponse.data;
 
-			await uploadToS3(presignedUrl, compressedFile);
+			// S3 업로드
+			await uploadToS3(presignedUrl, fileToUpload);
 
+			// 업로드 완료되면 미리보기 URL → s3Url로 교체
 			onChange(s3Url);
 		} catch (error) {
 			console.error('파일 업로드 실패:', error);

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -39,11 +39,11 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 		};
 
 		if (file.size > 2 * 1024 * 1024) {
-			// 5MB 이상 -> 모달 열고 confirm 대기
+			// 2MB 이상 -> 모달 열고 confirm 대기
 			setPendingFile(file);
 			setShowModal(true);
 		} else {
-			// 5MB 미만 -> s3 업로드
+			// 2MB 미만 -> s3 업로드
 			handleFileUpload(file);
 		}
 	};
@@ -107,7 +107,7 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 			{showModal && pendingFile && (
 				<AlertModal
 					type="confirm"
-					description={'파일의 용량이 커 압축이 진행될 예정입니다.\n계속하시겠습니까?'}
+					description={'파일의 용량이 커 압축이 진행됩니다.\n계속하시겠습니까?'}
 					onConfirm={async () => {
 						setShowModal(false);
 						if (pendingFile) {
@@ -119,17 +119,11 @@ export default function ThumbnailUploader({ selectedImage, onChange, onUploading
 					onCancel={() => {
 						setShowModal(false);
 						setPendingFile(null);
+						onChange(null);
+						if (fileInputRef.current) fileInputRef.current.value = '';
 					}}
 				/>
 			)}
 		</>
 	);
 }
-
-// 사용자가 파일 선택 -> 미리보기 url 삽입 -> 파일의 용량 확인 -> 5mb 이상? -> 압축될 거라고 alert -> 압축 -> s3 업로드 -> 미리보기 url을 s3 url로 교체
-// 사용자가 파일 선택 -> 미리보기 url 삽입 -> 파일의 용량 확인 -> 5mb 이하? -> 압축 ㄴㄴ -> s3 업로드 -> 교체
-
-// 걍 두 경우 모두 s3 업로드 되기 전까지 작성 완료 버튼 비활성화 시키고 5mb 이상은 파일의 크기가 커서 압축 진행된다. 계속하겠냐 alert 띄우기
-// 5mb으로 한 이유는? 쿠팡 페이지를 보면 로딩되는 이미지는 1mb 이하임 -> 우리는 next.js의 image 컴포넌트로 최적화 진행할 거고
-// lambda로 리사이징 할 거임 -> 즉 로딩되는 건 업로드될 때의 이미지가 아니라 이미 축소된 것임.
-// 그런데도 압축하는 이유는? s3 업로드 시간을 단축하고자. 그리고 너무 큰 이미지를 서버에 저장시키지 않으려고...

--- a/src/components/features/post/thumbnail-uploader.tsx
+++ b/src/components/features/post/thumbnail-uploader.tsx
@@ -10,10 +10,9 @@ import AlertModal from '../detail/alert-modal';
 interface ThumbnailUploaderProps {
 	selectedImage: string | null;
 	onChange: (url: string | null) => void;
-	setIsThumbnailUploaded: (uploading: boolean) => void;
 }
 
-export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbnailUploaded }: ThumbnailUploaderProps) {
+export default function ThumbnailUploader({ selectedImage, onChange }: ThumbnailUploaderProps) {
 	const [isPortrait, setIsPortrait] = useState(false);
 	const [showModal, setShowModal] = useState(false);
 	const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -52,8 +51,6 @@ export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbn
 
 	const handleFileUpload = async (file: File) => {
 		try {
-			setIsThumbnailUploaded?.(false); // 업로드 시작 (아직 업로드 안 됨)
-
 			const presignedResponse = await getPresignedUrl({
 				type: 'news-files',
 				fileName: file.name,
@@ -61,12 +58,9 @@ export default function ThumbnailUploader({ selectedImage, onChange, setIsThumbn
 
 			const { presignedUrl, s3Url } = presignedResponse.data;
 			await uploadToS3(presignedUrl, file);
-
 			onChange(s3Url);
-			setIsThumbnailUploaded?.(true); // 업로드 성공
 		} catch (error) {
 			console.error('파일 업로드 실패:', error);
-			setIsThumbnailUploaded?.(false); // 실패 시 false
 		}
 	};
 

--- a/src/lib/contexts/editor/context.tsx
+++ b/src/lib/contexts/editor/context.tsx
@@ -23,6 +23,10 @@ interface EditorContextProps {
 
 	handleImageUpload: (file: File) => Promise<void>;
 	uploadingCount: number;
+	pendingFile: File;
+	showModal: boolean;
+	setPendingFile: React.Dispatch<React.SetStateAction<File | null>>;
+	setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const EditorContext = createContext<EditorContextProps | null>(null);

--- a/src/lib/contexts/editor/context.tsx
+++ b/src/lib/contexts/editor/context.tsx
@@ -20,6 +20,8 @@ interface EditorContextProps {
 	handleTextFormatToggle: (type: string) => void;
 	handleHeadingChange: (value: string) => void;
 	handleAddVideo: (e: React.ChangeEvent<HTMLInputElement>) => void;
+
+	handleImageUpload: (file: File) => Promise<void>;
 }
 
 export const EditorContext = createContext<EditorContextProps | null>(null);

--- a/src/lib/contexts/editor/context.tsx
+++ b/src/lib/contexts/editor/context.tsx
@@ -22,6 +22,7 @@ interface EditorContextProps {
 	handleAddVideo: (e: React.ChangeEvent<HTMLInputElement>) => void;
 
 	handleImageUpload: (file: File) => Promise<void>;
+	uploadingCount: number;
 }
 
 export const EditorContext = createContext<EditorContextProps | null>(null);

--- a/src/lib/contexts/editor/provider.tsx
+++ b/src/lib/contexts/editor/provider.tsx
@@ -169,18 +169,17 @@ export const EditorProvider = ({ children, setBody, isNews, editedBody }: Editor
 		if (!event.target.files?.length || !editor) return;
 		const file = event.target.files[0];
 
-		// 미리보기 url 먼저 삽입
-		const previewUrl = URL.createObjectURL(file);
-		editor.chain().focus().setImage({ src: previewUrl }).run();
-
 		// 파일 크기 확인
 		if (file.size > 2 * 1024 * 1024) {
+			// 용량이 큰 경우 -> 우선 모달만 띄움 (미리보기 X)
 			setPendingFile(file);
 			setShowModal(true);
 			return;
 		}
 
-		// 5MB 이하 -> 바로 업로드
+		const previewUrl = URL.createObjectURL(file);
+		editor.chain().focus().setImage({ src: previewUrl }).run();
+		// 작은 파일(<=2MB)은 바로 업로드 + 삽입
 		await handleImageUpload(file);
 	};
 

--- a/src/lib/contexts/editor/provider.tsx
+++ b/src/lib/contexts/editor/provider.tsx
@@ -181,7 +181,7 @@ export const EditorProvider = ({
 		editor.chain().focus().setImage({ src: previewUrl }).run();
 
 		// 파일 크기 확인
-		if (file.size > 5 * 1024 * 1024) {
+		if (file.size > 2 * 1024 * 1024) {
 			setPendingFile(file);
 			setShowModal(true);
 			return;

--- a/src/lib/contexts/editor/provider.tsx
+++ b/src/lib/contexts/editor/provider.tsx
@@ -18,23 +18,16 @@ type EditorProviderProps = {
 	setBody: (body: string) => void;
 	isNews: boolean;
 	editedBody: string;
-	setPendingFile: React.Dispatch<React.SetStateAction<File | null>>;
-	setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-export const EditorProvider = ({
-	children,
-	setBody,
-	isNews,
-	editedBody,
-	setPendingFile,
-	setShowModal,
-}: EditorProviderProps) => {
+export const EditorProvider = ({ children, setBody, isNews, editedBody }: EditorProviderProps) => {
 	const [linkUrl, setLinkUrl] = useState('');
 	const [isLinkInputOpen, setIsLinkInputOpen] = useState(false);
 	const [youtubeUrl, setYoutubeUrl] = useState('');
 	const [isYoutubeInputOpen, setIsYoutubeInputOpen] = useState(false);
 	const [uploadingCount, setUploadingCount] = useState(0);
+	const [pendingFile, setPendingFile] = useState<File | null>(null);
+	const [showModal, setShowModal] = useState(false);
 
 	const editor = useEditor({
 		extensions: [
@@ -295,6 +288,10 @@ export const EditorProvider = ({
 				handleAddVideo,
 				handleImageUpload,
 				uploadingCount,
+				pendingFile,
+				showModal,
+				setPendingFile,
+				setShowModal,
 			}}
 		>
 			{children}

--- a/src/lib/contexts/editor/provider.tsx
+++ b/src/lib/contexts/editor/provider.tsx
@@ -12,16 +12,24 @@ import { useEffect, useState } from 'react';
 import { getPresignedUrl, uploadToS3 } from '@/services/apis/image-upload';
 import { EditorContext } from './context';
 import { Video } from '@/lib/extensions/video';
-import { compressImage } from '@/lib/utils';
 
 type EditorProviderProps = {
 	children: React.ReactNode;
 	setBody: (body: string) => void;
 	isNews: boolean;
 	editedBody: string;
+	setPendingFile: React.Dispatch<React.SetStateAction<File | null>>;
+	setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-export const EditorProvider = ({ children, setBody, isNews, editedBody }: EditorProviderProps) => {
+export const EditorProvider = ({
+	children,
+	setBody,
+	isNews,
+	editedBody,
+	setPendingFile,
+	setShowModal,
+}: EditorProviderProps) => {
 	const [linkUrl, setLinkUrl] = useState('');
 	const [isLinkInputOpen, setIsLinkInputOpen] = useState(false);
 	const [youtubeUrl, setYoutubeUrl] = useState('');
@@ -167,54 +175,47 @@ export const EditorProvider = ({ children, setBody, isNews, editedBody }: Editor
 		if (!event.target.files?.length || !editor) return;
 		const file = event.target.files[0];
 
-		try {
-			const compressedFile = await compressImage(file);
+		// 미리보기 url 먼저 삽입
+		const previewUrl = URL.createObjectURL(file);
+		editor.chain().focus().setImage({ src: previewUrl }).run();
 
-			// Presigned URL 요청
+		// 파일 크기 확인
+		if (file.size > 5 * 1024 * 1024) {
+			setPendingFile(file);
+			setShowModal(true);
+			return;
+		}
+
+		// 5MB 이하 -> 바로 업로드
+		await handleImageUpload(file);
+	};
+
+	const handleImageUpload = async (file: File) => {
+		try {
+			let fileToUpload = file;
+
 			const presignedResponse = await getPresignedUrl({
 				type: isNews ? 'news-files' : 'board-files',
-				fileName: compressedFile.name || file.name,
+				fileName: fileToUpload.name || file.name,
 			});
 
 			const { presignedUrl, s3Url } = presignedResponse.data;
+			await uploadToS3(presignedUrl, fileToUpload);
 
-			console.log('S3 업로드 요청:', presignedResponse);
+			// 삽입된 미리보기 url -> S3 url로 교체
+			editor.commands.updateAttributes('image', { src: s3Url });
 
-			// Presigned URL로 S3에 이미지 업로드
-			await uploadToS3(presignedUrl, compressedFile);
-			console.log('S3 업로드 완료:', s3Url);
-
-			// 업로드된 이미지 URL을 에디터에 추가
-			editor.chain().focus().setImage({ src: s3Url }).run();
-
-			// 이미지 삽입 후 빈 단락 추가하여 커서 위치시키기
+			// 커서 위치 조정
 			editor.chain().focus().createParagraphNear().run();
 
-			// 에디터 내용 업데이트 (비동기 반영 확인)
+			// body 업데이트
 			setTimeout(() => {
 				const updatedContent = editor.getHTML();
 				setBody(updatedContent);
-				console.log('업데이트된 에디터 내용:', updatedContent);
 			}, 100);
 		} catch (error) {
 			console.error('이미지 업로드 실패:', error);
 		}
-	};
-
-	const handleInsertLink = () => {
-		if (!editor || !linkUrl) return;
-		if (!isValidUrl(linkUrl)) {
-			alert('유효한 링크를 입력해주세요.');
-			return;
-		}
-		editor
-			.chain()
-			.focus()
-			.setLink({ href: linkUrl })
-			.createParagraphNear() // 커서 아래로 이동
-			.run();
-		setLinkUrl('');
-		setIsLinkInputOpen(false);
 	};
 
 	const handleAddVideo = async (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -256,6 +257,22 @@ export const EditorProvider = ({ children, setBody, isNews, editedBody }: Editor
 		}
 	};
 
+	const handleInsertLink = () => {
+		if (!editor || !linkUrl) return;
+		if (!isValidUrl(linkUrl)) {
+			alert('유효한 링크를 입력해주세요.');
+			return;
+		}
+		editor
+			.chain()
+			.focus()
+			.setLink({ href: linkUrl })
+			.createParagraphNear() // 커서 아래로 이동
+			.run();
+		setLinkUrl('');
+		setIsLinkInputOpen(false);
+	};
+
 	return (
 		<EditorContext.Provider
 			value={{
@@ -273,6 +290,7 @@ export const EditorProvider = ({ children, setBody, isNews, editedBody }: Editor
 				youtubeUrl,
 				setYoutubeUrl,
 				handleAddVideo,
+				handleImageUpload,
 			}}
 		>
 			{children}

--- a/src/lib/contexts/editor/provider.tsx
+++ b/src/lib/contexts/editor/provider.tsx
@@ -34,6 +34,7 @@ export const EditorProvider = ({
 	const [isLinkInputOpen, setIsLinkInputOpen] = useState(false);
 	const [youtubeUrl, setYoutubeUrl] = useState('');
 	const [isYoutubeInputOpen, setIsYoutubeInputOpen] = useState(false);
+	const [uploadingCount, setUploadingCount] = useState(0);
 
 	const editor = useEditor({
 		extensions: [
@@ -192,15 +193,15 @@ export const EditorProvider = ({
 
 	const handleImageUpload = async (file: File) => {
 		try {
-			let fileToUpload = file;
+			setUploadingCount((c) => c + 1); // 업로드 시작
 
 			const presignedResponse = await getPresignedUrl({
 				type: isNews ? 'news-files' : 'board-files',
-				fileName: fileToUpload.name || file.name,
+				fileName: file.name,
 			});
 
 			const { presignedUrl, s3Url } = presignedResponse.data;
-			await uploadToS3(presignedUrl, fileToUpload);
+			await uploadToS3(presignedUrl, file);
 
 			// 삽입된 미리보기 url -> S3 url로 교체
 			editor.commands.updateAttributes('image', { src: s3Url });
@@ -215,6 +216,8 @@ export const EditorProvider = ({
 			}, 100);
 		} catch (error) {
 			console.error('이미지 업로드 실패:', error);
+		} finally {
+			setUploadingCount((c) => c - 1); // 업로드 종료
 		}
 	};
 
@@ -291,6 +294,7 @@ export const EditorProvider = ({
 				setYoutubeUrl,
 				handleAddVideo,
 				handleImageUpload,
+				uploadingCount,
 			}}
 		>
 			{children}

--- a/src/lib/utils/business/compressImage.ts
+++ b/src/lib/utils/business/compressImage.ts
@@ -15,7 +15,7 @@ export const compressImage = async (file: File): Promise<File> => {
 		maxSizeMB: MAX_SIZE_MB,
 		maxWidthOrHeight: 1920,
 		useWebWorker: true,
-		initialQuality: 0.8,
+		initialQuality: 0.9,
 	};
 
 	const compressedFile = await imageCompression(file, options);


### PR DESCRIPTION
## 작업 내용
이미지 업로드 최적화 전략 구상했습니다!
1. 이미지 업로드
2. 이미지 로딩

지난번에 말씀드린대로 이미지 최적화를 이렇게 두 단계로 나누어 진행할 예정입니다.
이미지 업로드는 업로드되는 이미지 용량의 기준을 **2MB**로 잡고 기준을 넘으면 압축 후 업로드, 넘지 않으면 그냥 업로드 됩니다.

1MB가 아니라 2MB로 잡은 이유는 우리 서비스의 핵심 후킹 요소가 경기 배너 이미지라고 생각이 되어, 압축해서 품질을 떨어뜨리기 보다 선명하게 가지고 가는 게 맞다고 판단했습니다. (지금까지의 배너 이미지는 보통 1~2MB 사이의 용량을 가지고 있음. 그럼에도 2MB가 넘으면 압축은 필요) 
압축을 하지 않은 1MB 이상 2MB 이하 이미지들은 업로드 된 후 이미지 리사이징과 next의 image 컴포넌트로 webp 변환을 거쳐 브라우저에서는 KB로 다루어질 것으로 예상됩니닷

처음에는 이미지 용량이 클수록 업로드 속도가 느려지는 게 UX를 해치니 **미리보기 url을 먼저 사용자에게 보여주고 동시에 s3 업로드를 진행하여 업로드 된 s3 url을 미리보기 url과 바꿔치기** 하면 되는 게 아닌가? 해서 그렇게 임시방편으로 해두었는데, 이것의 문제점은 이미지 용량이 클 때 업로드 속도가 느려지니 미리보기 url과 바꿔치기를 하기도 전에!! 사용자가 작성 완료 버튼을 눌러버리는 경우입니다.

그렇기에 이미지 업로드 속도 > 사용자 작성 완료 속도인 경우의 이미지(2MB 이상)는 압축을 진행합니닷

- 이미지 용량 기준 초과 (2.5MB) -> 미리보기 URL로 사용자에게 먼저 제시 -> 이미지 용량 커 압축 진행 됨을 사용자에게 알림 (confirm modal) -> s3 업로드
- 이미지 용량 기준 미만 (1.5MB) -> 미리보기 URL로 사용자에게 먼저 제시 -> s3 업로드
(두 경우 모두 이미지들의 s3 업로드가 완료되지 않으면 작성 완료 버튼 비활성화)