### PR TITLE
[KO-538] 댓글 UI 수정

### DIFF
--- a/src/app/(with-side)/[type]/[id]/page.tsx
+++ b/src/app/(with-side)/[type]/[id]/page.tsx
@@ -21,7 +21,7 @@ const DetailPage = () => {
 	const params = useParams();
 	const router = useRouter();
 
-	const [contents, setContents] = useState<CommonPostDetailDto | null>(null);
+	const [postDetail, setPostDetail] = useState<CommonPostDetailDto | null>(null);
 	const [totalReplies, setTotalReplies] = useState(0);
 
 	const type = params?.type as 'news' | 'board';
@@ -30,34 +30,34 @@ const DetailPage = () => {
 
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
-	const isTeamNull = contents?.team == null;
-	const isOurTeam = Boolean(currentUserInfo?.favoriteTeams.find((team) => team?.pk === contents?.team?.pk));
+	const isTeamNull = postDetail?.team == null;
+	const isOurTeam = Boolean(currentUserInfo?.favoriteTeams.find((team) => team?.pk === postDetail?.team?.pk));
 	const isCommentAllowed = isTeamNull || isOurTeam;
 
 	const shouldCallApi = usePostViewStatus(id);
 
-	const getDetailContentData = async () => {
+	const getPostDetail = async () => {
 		try {
-			const contentData = isNews ? await getNewsDetail(id) : await getBoardDetail(id);
+			const response = isNews ? await getNewsDetail(id) : await getBoardDetail(id);
 
-			const serverViewCount = contentData.data.views;
+			const serverViewCount = response.data.views;
 			const clientViewCount = shouldCallApi ? serverViewCount + 1 : serverViewCount;
 
-			const finalContents = {
-				...contentData,
+			const finalPostDetail = {
+				...response,
 				data: {
-					...contentData.data,
+					...response.data,
 					views: clientViewCount, // 수정한 조회수만 덮어씀
 				},
 			};
 
-			setContents(finalContents.data);
-			setTotalReplies(contentData.data.replies);
+			setPostDetail(finalPostDetail.data);
+			setTotalReplies(response.data.replies);
 
 			// 세션 스토리지에 저장 (같은 키로 항상 덮어쓰기)
 			// IDEA: 수정 버튼을 클릭할 때 저장하면 어떨지
-			sessionStorage.setItem('detailContent', JSON.stringify(finalContents));
-			console.log('상세조회', contentData);
+			sessionStorage.setItem('detailContent', JSON.stringify(finalPostDetail));
+			// console.log('상세조회', response);
 		} catch (error) {
 			console.error('데이터 불러오기 실패:', error);
 		}
@@ -69,14 +69,14 @@ const DetailPage = () => {
 			return;
 		}
 
-		getDetailContentData();
+		getPostDetail();
 	}, [type, id]);
 
 	// TODO: 로직 점검 -> hasViewApiCalled 안 쓰는 방향으로...!!
 	const hasViewApiCalled = useRef(false);
 
 	useEffect(() => {
-		if (!contents || hasViewApiCalled.current || !shouldCallApi) return;
+		if (!postDetail || hasViewApiCalled.current || !shouldCallApi) return;
 
 		if (isNews) {
 			createNewsView(id);
@@ -85,27 +85,27 @@ const DetailPage = () => {
 		}
 
 		hasViewApiCalled.current = true;
-	}, [contents, id, shouldCallApi, isNews]);
+	}, [postDetail, id, shouldCallApi, isNews]);
 
 	return (
 		<div className="flex flex-col gap-4 @mobile:mb-[80px]">
 			<ComponentFrame isMain={true}>
-				{contents ? (
-					<DetailContent commonDetailData={contents} type={type} isCommentAllowed={isCommentAllowed} />
+				{postDetail ? (
+					<DetailContent commonDetailData={postDetail} type={type} isCommentAllowed={isCommentAllowed} />
 				) : (
-					<FetchingFailedCard height="800px" marginTop="200px" onClick={getDetailContentData} />
+					<FetchingFailedCard height="800px" marginTop="200px" onClick={getPostDetail} />
 				)}
 
 				<CommentSection
 					isCommentAllowed={isCommentAllowed}
-					type={type}
-					contentsId={contents?.pk || 0}
+					postType={type}
+					postId={postDetail?.pk || 0}
 					totalreplies={totalReplies}
 					setTotalReplies={setTotalReplies}
 				/>
 			</ComponentFrame>
 
-			<RecommendedContent mode={type} teamName={isOurTeam ? contents?.team?.nameKr : ''} />
+			<RecommendedContent mode={type} teamName={isOurTeam ? postDetail?.team?.nameKr : ''} />
 		</div>
 	);
 };

--- a/src/app/(with-side)/[type]/[id]/page.tsx
+++ b/src/app/(with-side)/[type]/[id]/page.tsx
@@ -89,7 +89,7 @@ const DetailPage = () => {
 
 	return (
 		<div className="flex flex-col gap-4 @mobile:mb-[80px]">
-			<ComponentFrame isMain={true}>
+			<ComponentFrame isMain={true} className="overflow-hidden">
 				{postDetail ? (
 					<DetailContent commonDetailData={postDetail} type={type} isCommentAllowed={isCommentAllowed} />
 				) : (

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -132,9 +132,10 @@ const CommentInput = ({
 
 	return (
 		<div
-			className={
-				type === 'comment' ? 'bg-black-200 rounded-[0.625rem] mx-4 p-4 mb-19 flex flex-col gap-4 @mobile:h-53.5' : ''
-			}
+			className={clsx({
+				'bg-black-200 rounded-[0.625rem] mx-4 p-4 mb-19 flex flex-col gap-4 @mobile:h-53.5': type === 'comment',
+				'mt-3.5': type === 'reply'
+			})}
 		>
 			{type === 'comment' && <h3 className="subtitle1-medium">댓글 쓰기</h3>}
 			<div className="flex @mobile:flex-col h-full">

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -11,10 +11,10 @@ import { CreateNewsReplyRequest } from '@/services/apis/news/news-reply.type';
 import { CreateBoardReplyRequest } from '@/services/apis/board/board-reply.type';
 
 const CommentInput = ({
+	postType,
+	postId,
 	type = 'comment',
 	replyTo,
-	contentType,
-	contentsId,
 	editingCommentId,
 	defaultContent,
 	onCommentSubmit,
@@ -77,7 +77,7 @@ const CommentInput = ({
 
 		try {
 			let response;
-			const isNews = contentType === 'news';
+			const isNews = postType === 'news';
 			const sanitizedContent = content.replace(/\u200B/g, '');
 
 			if (type === 'edit') {
@@ -93,7 +93,7 @@ const CommentInput = ({
 				const body: CreateNewsReplyRequest | CreateBoardReplyRequest = {
 					contents: sanitizedContent,
 					...(isReply ? { parentReply: replyTo.pk } : {}),
-					...(isNews ? { news: contentsId } : { board: contentsId }),
+					...(isNews ? { news: postId } : { board: postId }),
 				};
 				response = isNews
 					? await createNewsReply(body as CreateNewsReplyRequest)

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -133,7 +133,8 @@ const CommentInput = ({
 	return (
 		<div
 			className={clsx({
-				'bg-black-200 rounded-[0.625rem] mx-4 p-4 mb-19 flex flex-col gap-4 @mobile:h-53.5': type === 'comment',
+				'bg-black-200 rounded-[0.625rem] mx-4 p-4 mb-19 @mobile:mb-11 flex flex-col gap-4 @mobile:h-53.5':
+					type === 'comment',
 				'mt-3.5': type === 'reply',
 			})}
 		>

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -134,7 +134,7 @@ const CommentInput = ({
 		<div
 			className={clsx({
 				'bg-black-200 rounded-[0.625rem] mx-4 p-4 mb-19 flex flex-col gap-4 @mobile:h-53.5': type === 'comment',
-				'mt-3.5': type === 'reply'
+				'mt-3.5': type === 'reply',
 			})}
 		>
 			{type === 'comment' && <h3 className="subtitle1-medium">댓글 쓰기</h3>}

--- a/src/components/features/detail/comment/comment-input.tsx
+++ b/src/components/features/detail/comment/comment-input.tsx
@@ -133,7 +133,7 @@ const CommentInput = ({
 	return (
 		<div
 			className={
-				type === 'comment' ? 'bg-black-200 rounded-[0.625rem] p-4 mb-10 flex flex-col gap-4 @mobile:h-53.5' : 'mt-5'
+				type === 'comment' ? 'bg-black-200 rounded-[0.625rem] mx-4 p-4 mb-19 flex flex-col gap-4 @mobile:h-53.5' : ''
 			}
 		>
 			{type === 'comment' && <h3 className="subtitle1-medium">댓글 쓰기</h3>}

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -158,7 +158,7 @@ function CommentItem({
 
 				<div className="flex flex-col flex-1 relative">
 					{/* 상단: 닉네임 + 날짜 + 더보기 */}
-					<div className="flex justify-between items-center">
+					<div className="flex justify-between items-start">
 						<div className="flex items-center gap-4 mb-3">
 							<span className="flex items-center gap-0.5 body5-medium text-black-900">
 								{content.user.nickname}

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -169,7 +169,14 @@ function CommentItem({
 							<CommentMoreButton
 								onDeleteClick={() => handleDeleteComment(content.pk, replyTo?.pk)}
 								onEditClick={() => {
-									handleEnterEditMode(content.pk);
+									if (isReplyInputOpen) {
+										if (window.confirm('작성 중인 내용이 사라집니다. 계속하시겠습니까?')) {
+											setIsReplyInputOpen(false);
+											handleEnterEditMode(content.pk);
+										}
+									} else {
+										handleEnterEditMode(content.pk);
+									}
 								}}
 							/>
 						)}

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -45,7 +45,7 @@ function CommentItem({
 		if (isEditing) {
 			setEditingCommentId(null);
 		}
-		
+
 		if (isReplyInputOpen) {
 			setIsReplyInputOpen(false);
 			setIsReplyListOpen(true);
@@ -142,7 +142,12 @@ function CommentItem({
 
 	return (
 		<div>
-			<div className={clsx('pr-6 pt-5 pb-3.5 flex items-start border-b border-black-200', isReply ? 'pl-[54px] bg-black-100' : 'pl-4')}>
+			<div
+				className={clsx(
+					'pr-6 pt-5 pb-3.5 flex items-start border-b border-black-200',
+					isReply ? 'pl-[54px] bg-black-100' : 'pl-4',
+				)}
+			>
 				<Image
 					src={content.user?.profileImageUrl || '/default-profile.svg'}
 					alt="프로필"
@@ -183,10 +188,12 @@ function CommentItem({
 					</div>
 
 					{/* 본문 */}
-					{!isEditing && <div className="body5-regular text-black-900 mb-3.5 whitespace-pre-line">
-						{isReply && replyTo && <span className="text-[#890f0e] mr-1">@{replyTo.nickname}</span>}
-						{content.contents}
-					</div>}
+					{!isEditing && (
+						<div className="body5-regular text-black-900 mb-3.5 whitespace-pre-line">
+							{isReply && replyTo && <span className="text-[#890f0e] mr-1">@{replyTo.nickname}</span>}
+							{content.contents}
+						</div>
+					)}
 
 					<div className="flex justify-between">
 						{/* 답글 입력 버튼 */}
@@ -203,13 +210,15 @@ function CommentItem({
 						)}
 
 						{/* 킥 버튼 (하단 우측) */}
-						{!isEditing && <button onClick={() => toggleCommentLike(content.pk)} className="ml-auto flex items-center gap-2">
-							<Image src={content.kicked ? '/kick/red.svg' : '/kick/gray.svg'} alt="kick" width={16} height={16} />
-							<span className={content.kicked ? 'text-black-900' : 'text-gray-500'}>{content.kickCount}</span>
-						</button>}
-					</div> 
+						{!isEditing && (
+							<button onClick={() => toggleCommentLike(content.pk)} className="ml-auto flex items-center gap-2">
+								<Image src={content.kicked ? '/kick/red.svg' : '/kick/gray.svg'} alt="kick" width={16} height={16} />
+								<span className={content.kicked ? 'text-black-900' : 'text-gray-500'}>{content.kickCount}</span>
+							</button>
+						)}
+					</div>
 
-					{(isReplyInputOpen || isEditing) && 
+					{(isReplyInputOpen || isEditing) && (
 						<CommentInput
 							type={isEditing ? 'edit' : 'reply'}
 							replyTo={isEditing ? replyTo : { pk: content.pk, nickname: content.user.nickname }}
@@ -218,12 +227,9 @@ function CommentItem({
 							editingCommentId={editingCommentId}
 							defaultContent={isEditing ? content.contents : ''}
 							onCommentSubmit={handleCommentSubmit}
-							onCommentCancel={isEditing 
-									? () => setEditingCommentId(null)
-									: () => setIsReplyInputOpen(false)
-							}
+							onCommentCancel={isEditing ? () => setEditingCommentId(null) : () => setIsReplyInputOpen(false)}
 						/>
-					}
+					)}
 
 					{/* 답글 토글 */}
 					{content.replies?.length > 0 && (
@@ -240,7 +246,6 @@ function CommentItem({
 							{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
 						</button>
 					)}
-
 				</div>
 			</div>
 
@@ -252,8 +257,7 @@ function CommentItem({
 						replyTo={{ pk: content.pk, nickname: content.user.nickname }}
 						{...commentItemProps}
 					/>
-				))
-			}
+				))}
 
 			{isConfirmModalOpen && (
 				<AlertModal

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -142,13 +142,13 @@ function CommentItem({
 
 	return (
 		<div>
-			<div className={clsx('flex items-start mt-5 pb-3.5')}>
+			<div className={clsx('pr-6 pt-5 pb-3.5 flex items-start border-b border-black-200', isReply ? 'pl-[54px] bg-black-100' : 'pl-4')}>
 				<Image
 					src={content.user?.profileImageUrl || '/default-profile.svg'}
 					alt="프로필"
-					width={24}
-					height={24}
-					className="w-6 h-6 rounded-full mr-[0.625rem] object-cover"
+					width={28}
+					height={28}
+					className="w-7 h-7 rounded-full mr-[0.625rem] object-cover"
 				/>
 
 				<div className="flex flex-col flex-1 relative">
@@ -204,8 +204,8 @@ function CommentItem({
 									<Image
 										src={isReplyListOpen ? '/chevron/score-up.svg' : '/chevron/score-down.svg'}
 										alt="toggle replies"
-										width={16}
-										height={16}
+										width={18}
+										height={18}
 									/>
 									{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
 								</button>
@@ -238,6 +238,8 @@ function CommentItem({
 						/>
 					)}
 
+				</div>
+			</div>
 					{isReplyListOpen &&
 						content.replies?.map((reply) => (
 							<CommentItem
@@ -247,9 +249,6 @@ function CommentItem({
 								{...commentItemProps}
 							/>
 						))}
-				</div>
-			</div>
-			<hr className="border-t border-black-200 -mx-6 -ml-4" />
 
 			{isConfirmModalOpen && (
 				<AlertModal

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -153,8 +153,8 @@ function CommentItem({
 
 				<div className="flex flex-col flex-1 relative">
 					{/* 상단: 닉네임 + 날짜 + 더보기 */}
-					<div className="flex justify-between items-center mb-0.5">
-						<div className="flex items-center gap-4">
+					<div className="flex justify-between items-center">
+						<div className="flex items-center gap-4 mb-3">
 							<span className="flex items-center gap-0.5 body5-medium text-black-900">
 								{content.user.nickname}
 								{content.user.isReporter && <Image width={12} height={12} src="/reporter-mark.svg" alt="구단 기자" />}
@@ -175,8 +175,41 @@ function CommentItem({
 						)}
 					</div>
 
+{
+
+(isEditing) ? (
+	<div className='space-y-4'>
+	<CommentInput
+		type={'edit'}
+		replyTo={replyTo}
+		contentType={type}
+		contentsId={contentsId}
+		editingCommentId={editingCommentId}
+		defaultContent={content.contents}
+		onCommentSubmit={handleCommentSubmit}
+		onCommentCancel={() => {
+			setEditingCommentId(null);
+			setIsReplyInputOpen(false);
+		}}
+		/>
+		{content.replies?.length > 0 && (
+			<button
+				className="flex items-center gap-[0.625rem] text-black-600 body6-regular"
+				onClick={() => setIsReplyListOpen(!isReplyListOpen)}
+			>
+				<Image
+					src={isReplyListOpen ? '/chevron/score-up.svg' : '/chevron/score-down.svg'}
+					alt="toggle replies"
+					width={18}
+					height={18}
+				/>
+				{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
+			</button>
+		)}
+		</div>
+) :<>
 					{/* 본문 */}
-					<div className="body5-regular text-black-900 mt-3 mb-3.5 whitespace-pre-line">
+					<div className="body5-regular text-black-900 mb-3.5 whitespace-pre-line">
 						{isReply && replyTo && <span className="text-[#890f0e] mr-1">@{replyTo.nickname}</span>}
 						{content.contents}
 					</div>
@@ -217,22 +250,19 @@ function CommentItem({
 							<Image src={content.kicked ? '/kick/red.svg' : '/kick/gray.svg'} alt="kick" width={16} height={16} />
 							<span className={content.kicked ? 'text-black-900' : 'text-gray-500'}>{content.kickCount}</span>
 						</button>
-					</div>
+					</div> </>}
 
 					{/* 댓글 입력창 */}
-					{(isReplyInputOpen || isEditing) && (
+					{(isReplyInputOpen) && (
 						<CommentInput
-							type={isEditing ? 'edit' : 'reply'}
-							replyTo={isEditing ? replyTo : { pk: content.pk, nickname: content.user.nickname }}
+							type={'reply'}
+							replyTo={{ pk: content.pk, nickname: content.user.nickname }}
 							contentType={type}
 							contentsId={contentsId}
 							editingCommentId={editingCommentId}
-							defaultContent={isEditing ? content.contents : ''}
+							defaultContent={''}
 							onCommentSubmit={handleCommentSubmit}
 							onCommentCancel={() => {
-								if (isEditing) {
-									setEditingCommentId(null);
-								}
 								setIsReplyInputOpen(false);
 							}}
 						/>

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -45,8 +45,8 @@ function CommentItem({
 		if (isEditing) {
 			setEditingCommentId(null);
 		}
-
-		if (isReply) {
+		
+		if (isReplyInputOpen) {
 			setIsReplyInputOpen(false);
 			setIsReplyListOpen(true);
 
@@ -175,110 +175,78 @@ function CommentItem({
 						)}
 					</div>
 
-{
-
-(isEditing) ? (
-	<div className='space-y-4'>
-	<CommentInput
-		type={'edit'}
-		replyTo={replyTo}
-		contentType={type}
-		contentsId={contentsId}
-		editingCommentId={editingCommentId}
-		defaultContent={content.contents}
-		onCommentSubmit={handleCommentSubmit}
-		onCommentCancel={() => {
-			setEditingCommentId(null);
-			setIsReplyInputOpen(false);
-		}}
-		/>
-		{content.replies?.length > 0 && (
-			<button
-				className="flex items-center gap-[0.625rem] text-black-600 body6-regular"
-				onClick={() => setIsReplyListOpen(!isReplyListOpen)}
-			>
-				<Image
-					src={isReplyListOpen ? '/chevron/score-up.svg' : '/chevron/score-down.svg'}
-					alt="toggle replies"
-					width={18}
-					height={18}
-				/>
-				{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
-			</button>
-		)}
-		</div>
-) :<>
 					{/* 본문 */}
-					<div className="body5-regular text-black-900 mb-3.5 whitespace-pre-line">
+					{!isEditing && <div className="body5-regular text-black-900 mb-3.5 whitespace-pre-line">
 						{isReply && replyTo && <span className="text-[#890f0e] mr-1">@{replyTo.nickname}</span>}
 						{content.contents}
-					</div>
+					</div>}
 
-					{/* 하단 영역: 답글 버튼, 답글 토글, 킥 버튼 */}
-					<div className="flex justify-between items-center gap-3.5">
-						<div className="flex flex-col gap-3.5">
-							{isCommentAllowed && !isReply && !isReplyInputOpen && (
-								<button
-									className={clsx(
-										'button5-regular rounded-sm px-2 py-1 mb-0.5 w-fit',
-										isReplyInputOpen ? 'text-black-100 bg-black-500' : 'text-black-700 bg-black-200',
-									)}
-									onClick={toggleReplyInputOpen}
-								>
-									답글
-								</button>
-							)}
-
-							{content.replies?.length > 0 && (
-								<button
-									className="flex items-center gap-[0.625rem] text-black-600 body6-regular"
-									onClick={() => setIsReplyListOpen(!isReplyListOpen)}
-								>
-									<Image
-										src={isReplyListOpen ? '/chevron/score-up.svg' : '/chevron/score-down.svg'}
-										alt="toggle replies"
-										width={18}
-										height={18}
-									/>
-									{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
-								</button>
-							)}
-						</div>
+					<div className="flex justify-between">
+						{/* 답글 입력 버튼 */}
+						{isCommentAllowed && !isEditing && !isReply && !isReplyInputOpen && (
+							<button
+								className={clsx(
+									'button5-regular rounded-sm px-2 py-1 mb-0.5 w-fit',
+									isReplyInputOpen ? 'text-black-100 bg-black-500' : 'text-black-700 bg-black-200',
+								)}
+								onClick={toggleReplyInputOpen}
+							>
+								답글
+							</button>
+						)}
 
 						{/* 킥 버튼 (하단 우측) */}
-						<button onClick={() => toggleCommentLike(content.pk)} className="flex items-center gap-2">
+						{!isEditing && <button onClick={() => toggleCommentLike(content.pk)} className="ml-auto flex items-center gap-2">
 							<Image src={content.kicked ? '/kick/red.svg' : '/kick/gray.svg'} alt="kick" width={16} height={16} />
 							<span className={content.kicked ? 'text-black-900' : 'text-gray-500'}>{content.kickCount}</span>
-						</button>
-					</div> </>}
+						</button>}
+					</div> 
 
-					{/* 댓글 입력창 */}
-					{(isReplyInputOpen) && (
+					{(isReplyInputOpen || isEditing) && 
 						<CommentInput
-							type={'reply'}
-							replyTo={{ pk: content.pk, nickname: content.user.nickname }}
+							type={isEditing ? 'edit' : 'reply'}
+							replyTo={isEditing ? replyTo : { pk: content.pk, nickname: content.user.nickname }}
 							contentType={type}
 							contentsId={contentsId}
 							editingCommentId={editingCommentId}
-							defaultContent={''}
+							defaultContent={isEditing ? content.contents : ''}
 							onCommentSubmit={handleCommentSubmit}
-							onCommentCancel={() => {
-								setIsReplyInputOpen(false);
-							}}
+							onCommentCancel={isEditing 
+									? () => setEditingCommentId(null)
+									: () => setIsReplyInputOpen(false)
+							}
 						/>
+					}
+
+					{/* 답글 토글 */}
+					{content.replies?.length > 0 && (
+						<button
+							className="flex items-center gap-[0.625rem] text-black-600 body6-regular mt-3.5"
+							onClick={() => setIsReplyListOpen(!isReplyListOpen)}
+						>
+							<Image
+								src={isReplyListOpen ? '/chevron/score-up.svg' : '/chevron/score-down.svg'}
+								alt="toggle replies"
+								width={18}
+								height={18}
+							/>
+							{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
+						</button>
 					)}
 
 				</div>
 			</div>
-					{isReplyListOpen &&
-						content.replies?.map((reply) => (
-							<CommentItem
-								key={reply.pk}
-								content={reply}
-								replyTo={{ pk: content.pk, nickname: content.user.nickname }}
-								{...commentItemProps}
-							/>
-						))}
+
+			{isReplyListOpen &&
+				content.replies?.map((reply) => (
+					<CommentItem
+						key={reply.pk}
+						content={reply}
+						replyTo={{ pk: content.pk, nickname: content.user.nickname }}
+						{...commentItemProps}
+					/>
+				))
+			}
 
 			{isConfirmModalOpen && (
 				<AlertModal

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -15,10 +15,10 @@ import AlertModal from '../alert-modal';
 import { useIsLoginModalOpenStore } from '@/lib/store/useIsLoginModalOpenStore';
 
 function CommentItem({
-	content,
-	type,
+	postType,
+	postId,
+	comment,
 	isCommentAllowed,
-	contentsId,
 	replyTo,
 	editingCommentId,
 	setEditingCommentId,
@@ -26,14 +26,14 @@ function CommentItem({
 	setTotalReplies,
 }: CommentItemProps) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
-	const { formattedDate, formattedTime } = formatDate(content.createdAt, '2-digit');
+	const { formattedDate, formattedTime } = formatDate(comment.createdAt, '2-digit');
 
 	const isMobile = useIsMobile();
 
-	const isNews = type === 'news';
+	const isNews = postType === 'news';
 	const isReply = Boolean(replyTo);
-	const isEditing = editingCommentId === content.pk;
-	const isMyComment = currentUserInfo?.id === content.user.id;
+	const isEditing = editingCommentId === comment.pk;
+	const isMyComment = currentUserInfo?.id === comment.user.id;
 
 	const [isReplyListOpen, setIsReplyListOpen] = useState(false);
 	const [isReplyInputOpen, setIsReplyInputOpen] = useState(false);
@@ -130,10 +130,10 @@ function CommentItem({
 		}
 	};
 
-	const commentItemProps: Omit<CommentItemProps, 'content'> = {
-		type,
+	const commentItemProps: Omit<CommentItemProps, 'comment'> = {
+		postType,
 		isCommentAllowed,
-		contentsId,
+		postId,
 		editingCommentId,
 		setEditingCommentId,
 		setComments,
@@ -149,7 +149,7 @@ function CommentItem({
 				)}
 			>
 				<Image
-					src={content.user?.profileImageUrl || '/default-profile.svg'}
+					src={comment.user?.profileImageUrl || '/default-profile.svg'}
 					alt="프로필"
 					width={28}
 					height={28}
@@ -161,8 +161,8 @@ function CommentItem({
 					<div className="flex justify-between items-start">
 						<div className="flex items-center gap-4 mb-3">
 							<span className="flex items-center gap-0.5 body5-medium text-black-900">
-								{content.user.nickname}
-								{content.user.isReporter && <Image width={12} height={12} src="/reporter-mark.svg" alt="구단 기자" />}
+								{comment.user.nickname}
+								{comment.user.isReporter && <Image width={12} height={12} src="/reporter-mark.svg" alt="구단 기자" />}
 							</span>
 							<span className="body6-regular text-black-600">
 								{formattedDate}&nbsp;{formattedTime}
@@ -172,15 +172,15 @@ function CommentItem({
 						{/* 더보기 버튼 (내 댓글일 때만)*/}
 						{isMyComment && (
 							<CommentMoreButton
-								onDeleteClick={() => handleDeleteComment(content.pk, replyTo?.pk)}
+								onDeleteClick={() => handleDeleteComment(comment.pk, replyTo?.pk)}
 								onEditClick={() => {
 									if (isReplyInputOpen) {
 										if (window.confirm('작성 중인 내용이 사라집니다. 계속하시겠습니까?')) {
 											setIsReplyInputOpen(false);
-											handleEnterEditMode(content.pk);
+											handleEnterEditMode(comment.pk);
 										}
 									} else {
-										handleEnterEditMode(content.pk);
+										handleEnterEditMode(comment.pk);
 									}
 								}}
 							/>
@@ -191,7 +191,7 @@ function CommentItem({
 					{!isEditing && (
 						<div className="body5-regular text-black-900 mb-3.5 whitespace-pre-line">
 							{isReply && replyTo && <span className="text-[#890f0e] mr-1">@{replyTo.nickname}</span>}
-							{content.contents}
+							{comment.contents}
 						</div>
 					)}
 
@@ -211,28 +211,28 @@ function CommentItem({
 
 						{/* 킥 버튼 (하단 우측) */}
 						{!isEditing && (
-							<button onClick={() => toggleCommentLike(content.pk)} className="ml-auto flex items-center gap-2">
-								<Image src={content.kicked ? '/kick/red.svg' : '/kick/gray.svg'} alt="kick" width={16} height={16} />
-								<span className={content.kicked ? 'text-black-900' : 'text-gray-500'}>{content.kickCount}</span>
+							<button onClick={() => toggleCommentLike(comment.pk)} className="ml-auto flex items-center gap-2">
+								<Image src={comment.kicked ? '/kick/red.svg' : '/kick/gray.svg'} alt="kick" width={16} height={16} />
+								<span className={comment.kicked ? 'text-black-900' : 'text-gray-500'}>{comment.kickCount}</span>
 							</button>
 						)}
 					</div>
 
 					{(isReplyInputOpen || isEditing) && (
 						<CommentInput
+							postType={postType}
+							postId={postId}
 							type={isEditing ? 'edit' : 'reply'}
-							replyTo={isEditing ? replyTo : { pk: content.pk, nickname: content.user.nickname }}
-							contentType={type}
-							contentsId={contentsId}
+							replyTo={isEditing ? replyTo : { pk: comment.pk, nickname: comment.user.nickname }}
 							editingCommentId={editingCommentId}
-							defaultContent={isEditing ? content.contents : ''}
+							defaultContent={isEditing ? comment.contents : ''}
 							onCommentSubmit={handleCommentSubmit}
 							onCommentCancel={isEditing ? () => setEditingCommentId(null) : () => setIsReplyInputOpen(false)}
 						/>
 					)}
 
 					{/* 답글 토글 */}
-					{content.replies?.length > 0 && (
+					{comment.replies?.length > 0 && (
 						<button
 							className="flex items-center gap-[0.625rem] text-black-600 body6-regular mt-3.5"
 							onClick={() => setIsReplyListOpen(!isReplyListOpen)}
@@ -243,18 +243,18 @@ function CommentItem({
 								width={18}
 								height={18}
 							/>
-							{isReplyListOpen ? '답글 숨기기' : `답글 ${content.replies?.length}개`}
+							{isReplyListOpen ? '답글 숨기기' : `답글 ${comment.replies?.length}개`}
 						</button>
 					)}
 				</div>
 			</div>
 
 			{isReplyListOpen &&
-				content.replies?.map((reply) => (
+				comment.replies?.map((reply) => (
 					<CommentItem
 						key={reply.pk}
-						content={reply}
-						replyTo={{ pk: content.pk, nickname: content.user.nickname }}
+						comment={reply}
+						replyTo={{ pk: comment.pk, nickname: comment.user.nickname }}
 						{...commentItemProps}
 					/>
 				))}
@@ -267,7 +267,7 @@ function CommentItem({
 						setIsConfirmModalOpen(false);
 					}}
 					onConfirm={() => {
-						setEditingCommentId(content.pk);
+						setEditingCommentId(comment.pk);
 						setIsConfirmModalOpen(false);
 					}}
 				/>

--- a/src/components/features/detail/comment/comment-more-button.tsx
+++ b/src/components/features/detail/comment/comment-more-button.tsx
@@ -51,7 +51,7 @@ export function CommentMoreButton({ onEditClick, onDeleteClick }: CommentMoreBut
 	return (
 		<div className="relative inline-block">
 			<button ref={buttonRef} onClick={() => setIsOpen((prev) => !prev)} className="flex items-center pl-1">
-				<Image src="/more-horizontal.svg" alt="더보기" width={20} height={20} className="@mobile:w-4.5 @mobile:h-4.5" />
+				<Image src="/more-horizontal.svg" alt="더보기" width={18} height={18} className="@mobile:w-4.5 @mobile:h-4.5" />
 			</button>
 			{isOpen && (
 				<div

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -13,16 +13,16 @@ import { getNewsCommentList } from '@/services/apis/news/news-reply.api';
 import { getBoardCommentList } from '@/services/apis/board/board-reply.api';
 
 function CommentSection({
-	type,
+	postType,
+	postId,
 	isCommentAllowed,
-	contentsId,
 	totalreplies = 0,
 	setTotalReplies,
 }: CommentSectionProps) {
 	const searchParams = useSearchParams();
 	const isMobile = useIsMobile();
-	const isNews = type === 'news';
-	const baseUrl = `/${type}/${contentsId}`;
+	const isNews = postType === 'news';
+	const baseUrl = `/${postType}/${postId}`;
 
 	const pageParam = searchParams.get('page');
 	const [currentPage, setCurrentPage] = useState(pageParam ? Number(pageParam) : 1);
@@ -37,10 +37,10 @@ function CommentSection({
 	const commentsPerPage = 10;
 
 	const fetchComments = async () => {
-		if (!contentsId || contentsId < 1) return;
+		if (!postId || postId < 1) return;
 
 		const query = {
-			id: contentsId,
+			id: postId,
 			page: currentPage,
 			size: commentsPerPage,
 			...(isMobile && comments.length > 0 ? { infinite: true, lastReply: comments.at(-1).pk } : {}),
@@ -67,7 +67,7 @@ function CommentSection({
 	// 초기 접속 또는 페이지 변경 시 댓글 불러오기
 	useEffect(() => {
 		fetchComments();
-	}, [currentPage, contentsId]);
+	}, [currentPage, postId]);
 
 	// searchParams가 바뀌었을 때 currentPage를 갱신
 	useEffect(() => {
@@ -88,7 +88,7 @@ function CommentSection({
 	const handleLoadMoreComment = async () => {
 		const nextPage = currentPage + 1;
 		const query = {
-			id: contentsId,
+			id: postId,
 			page: nextPage,
 			size: commentsPerPage,
 			infinite: true,
@@ -106,10 +106,10 @@ function CommentSection({
 		}
 	};
 
-	const commentItemProps: Omit<CommentItemProps, 'content'> = {
-		type,
+	const commentItemProps: Omit<CommentItemProps, 'comment'> = {
+		postType,
+		postId,
 		isCommentAllowed,
-		contentsId,
 		editingCommentId,
 		setEditingCommentId,
 		setComments,
@@ -123,9 +123,7 @@ function CommentSection({
 
 	return (
 		<div>
-			{isCommentAllowed && (
-				<CommentInput contentType={type} contentsId={contentsId} editingCommentId={editingCommentId} />
-			)}
+			{isCommentAllowed && <CommentInput postType={postType} postId={postId} editingCommentId={editingCommentId} />}
 
 			<p className="body5-regular text-black-600 border-t border-b border-black-200 px-4 py-3">
 				댓글 <span className="text-black-900">{totalreplies}</span>개
@@ -136,7 +134,7 @@ function CommentSection({
 			) : (
 				<div className="flex flex-col">
 					{comments.map((comment) => (
-						<CommentItem key={comment.pk} content={comment} {...commentItemProps} />
+						<CommentItem key={comment.pk} comment={comment} {...commentItemProps} />
 					))}
 				</div>
 			)}

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -121,19 +121,19 @@ function CommentSection({
 	}
 
 	return (
-		<div className="px-4">
+		<div>
 			{isCommentAllowed && (
 				<CommentInput contentType={type} contentsId={contentsId} editingCommentId={editingCommentId} />
 			)}
 
-			<p className="body5-regular -mx-4 text-black-600 border-t border-b border-black-200 px-4 py-3">
+			<p className="body5-regular text-black-600 border-t border-b border-black-200 px-4 py-3">
 				댓글 <span className="text-black-900">{totalreplies}</span>개
 			</p>
 
 			{comments.length === 0 ? (
 				<p className="text-center body5-regular text-black-500 py-10">댓글이 없습니다.</p>
 			) : (
-				<div className="flex flex-col pr-2">
+				<div className="flex flex-col">
 					{comments.map((comment) => (
 						<CommentItem key={comment.pk} content={comment} {...commentItemProps} />
 					))}

--- a/src/components/features/detail/comment/comment-section.tsx
+++ b/src/components/features/detail/comment/comment-section.tsx
@@ -43,8 +43,9 @@ function CommentSection({
 			id: contentsId,
 			page: currentPage,
 			size: commentsPerPage,
-			...(isMobile ? { infinite: true, lastReply: comments.at(-1).pk } : {}),
+			...(isMobile && comments.length > 0 ? { infinite: true, lastReply: comments.at(-1).pk } : {}),
 		};
+
 		try {
 			const response = isNews ? await getNewsCommentList(query) : await getBoardCommentList(query);
 

--- a/src/components/features/detail/comment/type.ts
+++ b/src/components/features/detail/comment/type.ts
@@ -3,19 +3,19 @@ import { Dispatch, SetStateAction } from 'react';
 
 // comment section props
 export interface CommentSectionProps {
-	type: 'news' | 'board';
+	postType: 'news' | 'board';
+	postId: number;
 	isCommentAllowed: boolean;
-	contentsId: number;
 	totalreplies?: number;
 	setTotalReplies?: (count: number) => void;
 }
 
 // comment item props
 export interface CommentItemProps {
-	content: CommonCommentDto;
-	type: 'news' | 'board';
+	postType: 'news' | 'board';
+	postId: number;
+	comment: CommonCommentDto;
 	isCommentAllowed: boolean;
-	contentsId: number;
 	replyTo?: { pk: number; nickname: string };
 	editingCommentId?: number;
 	setEditingCommentId?: (id: number | null) => void;
@@ -30,8 +30,8 @@ export interface CommentInputProps {
 		pk: number;
 		nickname: string;
 	};
-	contentType: 'news' | 'board';
-	contentsId: number;
+	postType: 'news' | 'board';
+	postId: number;
 	editingCommentId: number;
 	defaultContent?: string;
 	onCommentSubmit?: () => void;

--- a/src/components/features/detail/content/detail-content.tsx
+++ b/src/components/features/detail/content/detail-content.tsx
@@ -21,6 +21,8 @@ interface DetailContentProps {
 const DetailContent = ({ commonDetailData, type, isCommentAllowed }: DetailContentProps) => {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
+	// TODO: common detail data를 받고 news detail data를 새로 선언하는 방식
+	// -> common detail data(-> postDetail)에서 타입 가드 사용해서 내려받은 props를 상황에 맞게 사용
 	const isNews = type === 'news';
 	const newsDetailData = isNews ? (commonDetailData as NewsDetailDto) : undefined;
 	const titleMargin = isNews ? 'mt-0' : 'mt-7.5 @mobile:mt-4';

--- a/src/lib/hooks/useNotificationSocket.ts
+++ b/src/lib/hooks/useNotificationSocket.ts
@@ -22,16 +22,16 @@ export default function useNotificationSocket(userId: string | null) {
 		const client = new Client({
 			webSocketFactory: () => socket,
 			reconnectDelay: 5000,
-			debug: (str) => console.log('%c[STOMP DEBUG]', 'color: gray', str), // 디버깅 로그
+			// debug: (str) => console.log('%c[STOMP DEBUG]', 'color: gray', str), // 디버깅 로그
 		});
 
 		client.onConnect = (frame) => {
 			console.log('[STOMP] 연결 성공', frame);
 			const subscription = client.subscribe(`/topic/notify/${userId}`, (message) => {
-				console.log('[STOMP] 메시지 수신 RAW:', message);
+				// console.log('[STOMP] 메시지 수신 RAW:', message);
 				try {
 					const newNotification = JSON.parse(message.body);
-					console.log('[STOMP] 파싱된 알림:', newNotification);
+					// console.log('[STOMP] 파싱된 알림:', newNotification);
 					useNotificationStore.getState().addNotification(newNotification);
 				} catch (e) {
 					console.error('[STOMP] 메시지 파싱 실패', e);

--- a/src/services/apis/board/board-reply.api.ts
+++ b/src/services/apis/board/board-reply.api.ts
@@ -19,7 +19,7 @@ export const getBoardCommentList = async ({
 		size: String(size),
 	});
 	if (infinite !== undefined) params.append('infinite', String(infinite));
-	if (lastReply !== undefined) params.append('lastReply', String(infinite));
+	if (lastReply !== undefined) params.append('lastReply', String(lastReply));
 
 	const response = await fetch(`${SERVER_URL}/api/board-reply?${params.toString()}`);
 

--- a/src/services/apis/news/news-reply.api.ts
+++ b/src/services/apis/news/news-reply.api.ts
@@ -19,7 +19,7 @@ export const getNewsCommentList = async ({
 		size: String(size),
 	});
 	if (infinite !== undefined) params.append('infinite', String(infinite));
-	if (lastReply !== undefined) params.append('lastReply', String(infinite));
+	if (lastReply !== undefined) params.append('lastReply', String(lastReply));
 
 	const response = await fetch(`${SERVER_URL}/api/news-reply?${params.toString()}`);
 


### PR DESCRIPTION
## 작업 내용
- 변경된 답글 UI 적용
- 피그마 화면과 다른 댓글 수정/답글 UI 수정
- 댓글 더보기 버튼 팝오버 위치 조정
- 모바일 댓글 fetch infinite 로직 수정
- 댓글 관련 변수명 정리

## 작업 특이 사항
- 내 댓글 a에 답글 작성 중 댓글 a를 수정하고자 하는 경우 동일한 comment input 컴포넌트를 사용하기 때문에 기존 답글 작성 input이 사라지는 문제가 있습니다. 이 경우 수정 버튼을 클릭하면 답글 내용이 사라진다는 confirm을 추가했습니다. 추후에 자체 모달로 변경하고자 합니다!
- 기존에 content 관련 변수명 혼동 이슈가 페이지 컴포넌트에서 게시글 상세를 contents라는 변수명으로 받고 있어서 그런 것으로 확인했습니다! 아래와 같은 흐름으로 변수명 정리했으니, 참고 부탁드립니닷.

> 게시글 상세 -> post
댓글 객체 -> comment
댓글 내용 -> content

## 작업 화면
- 답글 리스트
<img width="541" height="222" alt="image" src="https://github.com/user-attachments/assets/1a1da47a-99be-4b89-96e9-659bfded22f7" />

- 답글 작성
<img width="548" height="315" alt="image" src="https://github.com/user-attachments/assets/f3f9bc3b-9ce2-4f9b-b586-c70e47e0b7d4" />

- 댓글 수정
<img width="537" height="254" alt="image" src="https://github.com/user-attachments/assets/1e3be260-a8af-4c2e-a067-19ea06632afe" />

- 댓글 더보기 팝오버
<img width="535" height="160" alt="image" src="https://github.com/user-attachments/assets/1ed9fb29-c112-442f-befc-e3e0863152a4" />
