### PR TITLE
[KO-553] 하프타임 상세 서버 페이징 방식 적용

### DIFF
--- a/src/app/halftime/[id]/page.tsx
+++ b/src/app/halftime/[id]/page.tsx
@@ -2,23 +2,20 @@
 
 import Player from '@/components/features/halftime/player';
 import useIsLeftSideVisible from '@/lib/hooks/useIsLeftSideVisible';
-import { useHalftimeQueryKeyStore, useViewedHalftimesStore } from '@/lib/store/useHalftimeStore';
+import { useViewedHalftimesStore } from '@/lib/store/useHalftimeStore';
 import { createBoardView } from '@/services/apis/board/board-view-history.api';
 import { createNewsView } from '@/services/apis/news/news-view-history.api';
 import { getHalftimeDetail } from '@/services/apis/shorts/shorts.api';
-import { GetHalftimeListResponse } from '@/services/apis/shorts/shorts.type';
 import clsx from 'clsx';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { Keyboard } from 'swiper/modules';
 import { Swiper, SwiperRef, SwiperSlide } from 'swiper/react';
 import { Swiper as SwiperType } from 'swiper';
 import { shouldUpdateView } from '@/lib/utils';
-import { InfiniteData, useQueryClient } from '@tanstack/react-query';
-import { useHalftimeListQuery } from '@/lib/hooks/queries/useHalftimeQuery';
+import { HalftimeSortType } from '@/services/apis/shorts/shorts.type';
 
 export default function Page() {
-	const { _hasHydrated: isQueryKeyLoaded, halftimeListQueryKey, setSort } = useHalftimeQueryKeyStore();
 	const {
 		_hasHydrated: isHalftimesLoaded,
 		viewedHalftimes,
@@ -27,24 +24,26 @@ export default function Page() {
 	} = useViewedHalftimesStore();
 
 	const params = useParams();
+	const searchParams = useSearchParams();
 	const { id: pk } = params;
-
-	console.log(halftimeListQueryKey);
-	const [, sort, size] = halftimeListQueryKey;
-	const { fetchNextPage, hasNextPage, isFetchingNextPage } = useHalftimeListQuery(sort, size);
-
-	const queryClient = useQueryClient();
-	const cachedData = queryClient.getQueryData(halftimeListQueryKey) as InfiniteData<GetHalftimeListResponse, unknown>;
-	const halftimes = cachedData?.pages?.flatMap((page) => page.data) ?? [];
-	const pks = halftimes?.map((h) => h.pk);
+	const sort = searchParams.get('sort') as HalftimeSortType;
 
 	const getHalftime = async (pkToFetch: number) => {
 		// 이미 조회한 하프타임인 경우 return
 		if (viewedHalftimes.find((h) => h.pk === pkToFetch)) return;
 
 		try {
-			const response = await getHalftimeDetail(pkToFetch);
-			appendViewedHalftime(response.data);
+			const response = await getHalftimeDetail(pkToFetch, sort);
+
+			if (viewedHalftimes.length > 0 || !response.data.nextPk) {
+				// 스크롤에 따라 다음 하프타임만 추가하거나,
+				// 다음 하프타임이 없어 현재 하프타임 하나만 추가하는 경우
+				appendViewedHalftime(response.data);
+			} else {
+				// 현재 + 다음 하프타임을 추가하는 경우
+				const nextHalftimeResponse = await getHalftimeDetail(response.data.nextPk, sort);
+				appendViewedHalftime(response.data, nextHalftimeResponse.data);
+			}
 		} catch {
 			alert('동영상을 불러오는 중 문제가 발생했습니다.');
 		}
@@ -66,55 +65,23 @@ export default function Page() {
 		}
 	};
 
-	const shouldFetchNext = (index: number) => {
-		// 마지막 영상인 경우 다음 동영상 fetch하지 않음
-		const isLastVideo = index === pks.length - 1;
-		if (isLastVideo) return false;
-
-		// 마지막 영상이 되기 전에 pk list fetch
-		const shouldFetchPks = index === pks.length - 2;
-		if (shouldFetchPks && hasNextPage && !isFetchingNextPage) {
-			fetchNextPage();
-		}
-
-		return true;
-	};
-
-	const getNextHalftime = (currentPk: number) => {
-		const currentIndex = pks.findIndex((p: number) => p === currentPk);
-		if (!shouldFetchNext(currentIndex)) return;
-
-		const nextPkIndex = currentIndex + 1;
-		const nextPk = pks[nextPkIndex];
-
-		getHalftime(nextPk);
-	};
-
-	const swiperRef = useRef<SwiperRef>(null);
-	const defaultSort = 'CREATE_DESC';
-	const { fetchNextPage: fetchPkList } = useHalftimeListQuery(defaultSort, size);
-
 	// 초기 렌더링 시 halftime fetch
+	const swiperRef = useRef<SwiperRef>(null);
+
 	useEffect(() => {
-		if (!pk || !isQueryKeyLoaded || !isHalftimesLoaded || !swiperRef.current) return;
+		if (!pk || !isHalftimesLoaded || !swiperRef.current) return;
 
 		const pkNum = Number(pk);
 		const currentIndex = viewedHalftimes.findIndex((h) => h.pk === pkNum);
-		window.history.replaceState(null, '', `/halftime/${pkNum}`);
+
+		// 경로, params, active slide 일치시키기
+		window.history.replaceState(null, '', `/halftime/${pkNum}${sort ? `?sort=${sort}` : ''}`);
 		swiperRef.current.swiper.slideTo(currentIndex === -1 ? 0 : currentIndex, 0);
 
-		// pk 배열이 빈 경우 (공유된 링크로 접근 등)
-		if (pks.length === 0) {
-			setSort(defaultSort);
-			fetchPkList();
-		}
-
 		getHalftime(pkNum);
-		getNextHalftime(pkNum);
 		createView(pkNum);
-
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [isQueryKeyLoaded, isHalftimesLoaded]);
+	}, [isHalftimesLoaded]);
 
 	useEffect(() => {
 		return () => {
@@ -128,11 +95,15 @@ export default function Page() {
 		if (!viewedHalftimes[activeIndex]) return;
 
 		// useRouter 사용에 따른 재렌더링 방지
-		window.history.replaceState(null, '', `/halftime/${viewedHalftimes[activeIndex].pk}`);
+		window.history.replaceState(null, '', `/halftime/${viewedHalftimes[activeIndex].pk}${sort ? `?sort=${sort}` : ''}`);
 
 		const currentPk = viewedHalftimes[activeIndex].pk;
 		createView(currentPk);
-		getNextHalftime(currentPk);
+
+		const nextPk = viewedHalftimes[activeIndex].nextPk;
+		if (nextPk) {
+			getHalftime(nextPk);
+		}
 	};
 
 	const [globalMuted, setGlobalMuted] = useState(true);

--- a/src/app/halftime/page.tsx
+++ b/src/app/halftime/page.tsx
@@ -8,15 +8,14 @@ import { useFetchSize } from '@/lib/hooks/useFetchSize';
 import { useObserver } from '@/lib/hooks/useObserver';
 import { useHalftimeListQuery } from '@/lib/hooks/queries/useHalftimeQuery';
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useEffect } from 'react';
-import { useHalftimeQueryKeyStore } from '@/lib/store/useHalftimeStore';
+import { Suspense } from 'react';
+import { HalftimeSortType } from '@/services/apis/shorts/shorts.type';
 
 export default function Page() {
 	const searchParams = useSearchParams();
-	const sort = searchParams.get('sort') ?? halftimeSortOptions[0].value;
+	const sort = (searchParams.get('sort') as HalftimeSortType) ?? halftimeSortOptions[0].value;
 	const size = useFetchSize();
 
-	const { setKey } = useHalftimeQueryKeyStore();
 	const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useHalftimeListQuery(sort, size);
 	const halftimes = data?.pages?.flatMap((page) => page.data) ?? [];
 
@@ -25,10 +24,6 @@ export default function Page() {
 			fetchNextPage();
 		}
 	};
-
-	useEffect(() => {
-		setKey(['halftimeList', sort, size]);
-	}, [sort, size, setKey]);
 
 	// 무한 스크롤 커스텀 훅
 	const ref = useObserver(() => getHalftimes());
@@ -51,7 +46,12 @@ export default function Page() {
 						@mobile:grid-cols-2 @mobile:gap-4"
 				>
 					{halftimes.map((halftime, i) => (
-						<PreviewWithTitle ref={i === halftimes.length - 1 ? ref : null} key={halftime.pk} {...halftime} />
+						<PreviewWithTitle
+							ref={i === halftimes.length - 1 ? ref : null}
+							sort={sort}
+							key={halftime.pk}
+							{...halftime}
+						/>
 					))}
 				</div>
 			</ComponentFrame>

--- a/src/components/features/halftime/preview-with-title.tsx
+++ b/src/components/features/halftime/preview-with-title.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { formatNumberByUnit } from '@/lib/utils';
-import { BaseHalftimeDto } from '@/services/apis/shorts/shorts.type';
+import { BaseHalftimeDto, HalftimeSortType } from '@/services/apis/shorts/shorts.type';
 import Image from 'next/image';
 import Link from 'next/link';
 import Preview from './preview';
@@ -14,12 +14,14 @@ export default function PreviewWithTitle({
 	kickCount,
 	hasKick,
 	ref,
+	sort,
 }: Pick<BaseHalftimeDto, 'pk' | 'videoUrl' | 'title' | 'viewCount' | 'kickCount'> & {
 	hasKick?: boolean;
 	ref?: React.RefObject<any>;
+	sort?: HalftimeSortType;
 }) {
 	return (
-		<Link ref={ref} key={pk} href={`/halftime/${pk}`}>
+		<Link ref={ref} key={pk} href={`/halftime/${pk}${sort ? `?sort=${sort}` : ''}`}>
 			<div className="w-full h-auto aspect-[13/20] rounded-lg overflow-hidden">
 				<Preview src={videoUrl} />
 			</div>

--- a/src/lib/constants/options.ts
+++ b/src/lib/constants/options.ts
@@ -31,4 +31,4 @@ export const halftimeSortOptions = [
 	{ label: '최신순', value: 'CREATED_DESC' },
 	{ label: '인기순', value: 'POPULAR' },
 	{ label: '등록순', value: 'CREATED_ASC' },
-];
+] as const;

--- a/src/lib/store/useHalftimeStore.ts
+++ b/src/lib/store/useHalftimeStore.ts
@@ -1,98 +1,12 @@
-import {
-	GetHalftimeDetailDto,
-	GetHalftimeListRequest,
-	GetHalftimeListResponse,
-} from '@/services/apis/shorts/shorts.type';
+import { GetHalftimeDetailDto } from '@/services/apis/shorts/shorts.type';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-// react query key
-interface HalftimeQueryKeyStore {
-	_hasHydrated: boolean;
-	halftimeListQueryKey: [string, string, number];
-	setKey: (key: [string, string, number]) => void;
-	setSort: (sort: string) => void;
-}
-
-export const useHalftimeQueryKeyStore = create(
-	persist<HalftimeQueryKeyStore>(
-		(set) => ({
-			_hasHydrated: false,
-			halftimeListQueryKey: ['halftimeList', 'CREATED_DESC', 12],
-			setKey: (key) => set({ halftimeListQueryKey: key }),
-			setSort: (sort) =>
-				set((state) => ({ halftimeListQueryKey: ['halftimeList', sort, state.halftimeListQueryKey[2]] })),
-		}),
-		{
-			name: 'KICKON_HALFTIME_QUERY_KEY', // 로컬 스토리지에 저장될 키 이름
-			onRehydrateStorage: () => {
-				// hydration이 시작될 때 호출
-				return (state) => {
-					if (state) {
-						state._hasHydrated = true;
-					}
-				};
-			},
-		},
-	),
-);
-
-// 하프타임 목록에서 저장할 pk 배열
-interface AllHalftimePksStore {
-	_hasHydrated: boolean;
-	queryKey: [string, string, number];
-	hasNext: boolean;
-	nextParams: GetHalftimeListRequest | null;
-	allHalftimePks: number[];
-	setSort: (sort: string) => void;
-	appendAllHalftimePks: (
-		nextParams: GetHalftimeListRequest,
-		halftimes: GetHalftimeListResponse,
-		pkToPrepend?: number,
-	) => void;
-	clearAllHalftimePks: () => void;
-}
-
-export const useAllHalftimePksStore = create(
-	persist<AllHalftimePksStore>(
-		(set) => ({
-			_hasHydrated: false,
-			queryKey: ['halftimeList', 'CREATED_DESC', 12],
-			hasNext: false,
-			nextParams: null,
-			allHalftimePks: [],
-			setSort: (sort) => set((state) => ({ queryKey: ['halftimeList', sort, state.queryKey[2]] })),
-			appendAllHalftimePks: (nextParams, response, pkToPrepend) =>
-				set((state) => ({
-					hasNext: response.meta.hasNext,
-					nextParams,
-					allHalftimePks: [
-						...state.allHalftimePks,
-						...(pkToPrepend ? [pkToPrepend] : []),
-						...response.data.map((h) => h.pk),
-					],
-				})),
-			clearAllHalftimePks: () => set(() => ({ hasNext: false, nextParams: null, allHalftimePks: [] })),
-		}),
-		{
-			name: 'KICKON_ALL_HALFTIMES', // 로컬 스토리지에 저장될 키 이름
-			onRehydrateStorage: () => {
-				// hydration이 시작될 때 호출
-				return (state) => {
-					if (state) {
-						state._hasHydrated = true;
-					}
-				};
-			},
-		},
-	),
-);
-
-// 하프타임 상세에서 사용할 halftime 배열
+// 조회한 하프타임 상세 리스트
 interface ViewedHalftimesStore {
 	_hasHydrated: boolean;
 	viewedHalftimes: GetHalftimeDetailDto[];
-	appendViewedHalftime: (halftime: GetHalftimeDetailDto) => void;
+	appendViewedHalftime: (halftime: GetHalftimeDetailDto, nextHalftime?: GetHalftimeDetailDto) => void;
 	toggleIsKicked: (pk: number) => void;
 	clearViewedHalftimes: () => void;
 }
@@ -102,9 +16,9 @@ export const useViewedHalftimesStore = create(
 		(set) => ({
 			_hasHydrated: false,
 			viewedHalftimes: [],
-			appendViewedHalftime: (halftime) =>
+			appendViewedHalftime: (halftime, nextHalftime) =>
 				set((state) => ({
-					viewedHalftimes: [...(state.viewedHalftimes || []), halftime],
+					viewedHalftimes: [...(state.viewedHalftimes || []), halftime, ...(nextHalftime ? [nextHalftime] : [])],
 				})),
 			toggleIsKicked: (referencePk) =>
 				set((state) => ({

--- a/src/services/apis/shorts/shorts.api.ts
+++ b/src/services/apis/shorts/shorts.api.ts
@@ -4,6 +4,7 @@ import {
 	GetHalftimeListRequest,
 	GetHalftimeListResponse,
 	GetTodaysHalftimeResponse,
+	HalftimeSortType,
 } from './shorts.type';
 
 // 하프타임 리스트 조회
@@ -30,9 +31,12 @@ export const getHalftimeList = async ({ sort, page, size }: GetHalftimeListReque
 };
 
 // 하프타임 상세 조회
-export const getHalftimeDetail = async (pk: number) => {
+export const getHalftimeDetail = async (pk: number, sort?: HalftimeSortType) => {
 	try {
-		const response = await fetcher<GetHalftimeDetailResponse>({ method: 'GET', url: `/api/shorts/${pk}` });
+		const response = await fetcher<GetHalftimeDetailResponse>({
+			method: 'GET',
+			url: `/api/shorts/${pk}?sort=${sort || 'CREATED_DESC'}`,
+		});
 
 		if (!response) {
 			console.error('하프타임 상세 조회 실패 - 응답 없음');

--- a/src/services/apis/shorts/shorts.type.ts
+++ b/src/services/apis/shorts/shorts.type.ts
@@ -29,6 +29,7 @@ export interface GetHalftimeDetailDto extends BaseHalftimeDto {
 	replyCount: number;
 	user: UserDto;
 	isKicked: boolean;
+	nextPk: number | undefined;
 }
 export type GetHalftimeDetailResponse = SuccessResponse<GetHalftimeDetailDto>;
 


### PR DESCRIPTION
## 작업 내용
- 다음 하프타임 조회 로직을 서버에서 nextPk를 보내주는 방식으로 변경했습니다.
- 기존에 zustand로 관리하던 pk 배열을 제거했습니다.
- 기존에 zustand로 관리하던 sort 정보를 searchParams로 관리하도록 수정했습니다. (searchParams 없는 경우 api 함수 차원에서 CREATED_DESC로 설정)