### PR TITLE
[KO-528] 대체 UI 추가 및 기타 버그 수정

### DIFF
--- a/src/app/(mobile-only)/notice/page.tsx
+++ b/src/app/(mobile-only)/notice/page.tsx
@@ -8,19 +8,23 @@ export default function Page() {
 	const notifications = useNotificationStore((state) => state.notifications);
 
 	return (
-		<div>
+		<div className="h-dvh flex flex-col">
 			<NoticeHeader />
-			{notifications.map((notice) => (
-				<NoticeItem
-					key={notice.pk}
-					pk={notice.pk}
-					type={notice.type}
-					read={notice.read}
-					redirectUrl={notice.redirectUrl}
-					relativeTime={notice.relativeTime}
-					content={notice.content}
-				/>
-			))}
+			{notifications.length ? (
+				notifications.map((notice) => (
+					<NoticeItem
+						key={notice.pk}
+						pk={notice.pk}
+						type={notice.type}
+						read={notice.read}
+						redirectUrl={notice.redirectUrl}
+						relativeTime={notice.relativeTime}
+						content={notice.content}
+					/>
+				))
+			) : (
+				<div className="m-auto pb-4 text-center text-body-03 text-black-800">킥온에서 다양한 소식을 만나보세요!</div>
+			)}
 		</div>
 	);
 }

--- a/src/app/halftime/page.tsx
+++ b/src/app/halftime/page.tsx
@@ -10,6 +10,8 @@ import { useHalftimeListQuery } from '@/lib/hooks/queries/useHalftimeQuery';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect } from 'react';
 import { useHalftimeQueryKeyStore } from '@/lib/store/useHalftimeStore';
+import Image from 'next/image';
+import Link from 'next/link';
 
 export default function Page() {
 	const searchParams = useSearchParams();
@@ -40,20 +42,32 @@ export default function Page() {
 					mx-auto @mobile:bg-transparent @mobile:border-0
 					px-[7.125rem] max-[1440px]:px-4 space-y-6 py-6"
 			>
-				<Suspense>
-					<Sorter />
-				</Suspense>
-
-				<div
-					className="grid grid-cols-5 gap-6
+				{halftimes.length ? (
+					<>
+						<Suspense>
+							<Sorter />
+						</Suspense>
+						<div
+							className="grid grid-cols-5 gap-6
 						max-[1440px]:grid-cols-4 max-[1440px]:gap-x-3
 						max-[1094px]:grid-cols-3 max-[1094px]:gap-x-3
 						@mobile:grid-cols-2 @mobile:gap-4"
-				>
-					{halftimes.map((halftime, i) => (
-						<PreviewWithTitle ref={i === halftimes.length - 1 ? ref : null} key={halftime.pk} {...halftime} />
-					))}
-				</div>
+						>
+							{halftimes.map((halftime, i) => (
+								<PreviewWithTitle ref={i === halftimes.length - 1 ? ref : null} key={halftime.pk} {...halftime} />
+							))}
+						</div>
+					</>
+				) : (
+					<div className="flex flex-col mt-[9.9375rem] items-center">
+						<Image width={120} height={74} src={'/goal-post.svg'} alt="" />
+						<span className="mt-[2.375rem] mb-4 body2-semibold">아직 등록된 하프타임이 없어요.</span>
+						<span className="mb-9 body5-regular">하프타임의 첫 영상을 남겨주세요!</span>
+						<Link className="flex gap-1.5 body7-regular text-black-700 mb-[30.625rem]" href={'/post/board'}>
+							동영상 업로드하러 가기 <Image width={16} height={16} src={'/chevron/right-gray.svg'} alt="" />
+						</Link>
+					</div>
+				)}
 			</ComponentFrame>
 		</div>
 	);

--- a/src/components/features/home/predict-card-list.tsx
+++ b/src/components/features/home/predict-card-list.tsx
@@ -4,6 +4,7 @@ import FetchingFailedCard from '@/components/common/fetching-failed-card';
 import NoGameCard from '@/components/features/home/no-game-card';
 import PredictCard from '@/components/features/home/predict-card';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import { isPastDate } from '@/lib/utils/date/isPastDate';
 import { getGames } from '@/services/apis/game';
 import { GameTaggedLeagueDto, GetGamesRequest } from '@/services/apis/game/dto';
 import { useCallback, useEffect, useState } from 'react';
@@ -68,7 +69,11 @@ export default function PredictCardList({ teamPk }: { teamPk: undefined | number
 						<div>
 							{proceedingGames.games.map((game, i) => (
 								<div key={game.pk}>
-									<PredictCard type={'proceeding'} refetchGames={() => getGamesByStatus('proceeding')} game={game} />
+									<PredictCard
+										type={isPastDate(game.startAt) ? 'finished' : 'proceeding'}
+										refetchGames={() => getGamesByStatus('proceeding')}
+										game={game}
+									/>
 									{i !== proceedingGames.games.length - 1 && <hr className="mx-4 my-2 border-black-200" />}
 								</div>
 							))}

--- a/src/components/features/home/todays-halftime.tsx
+++ b/src/components/features/home/todays-halftime.tsx
@@ -42,11 +42,17 @@ export default function TodaysHalftime() {
 				</Link>
 			</header>
 
-			<div className="grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4">
-				{videos.map((video) => (
-					<PreviewWithTitle key={video.pk} {...video} />
-				))}
-			</div>
+			{videos.length ? (
+				<div className="grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4">
+					{videos.map((video) => (
+						<PreviewWithTitle key={video.pk} {...video} />
+					))}
+				</div>
+			) : (
+				<Link href={'/halftime'} className="py-10 text-center text-body-03 text-black-7800">
+					모든 하프타임 둘러보러 가기 &gt;
+				</Link>
+			)}
 		</ComponentFrame>
 	);
 }

--- a/src/components/features/home/todays-halftime.tsx
+++ b/src/components/features/home/todays-halftime.tsx
@@ -42,7 +42,7 @@ export default function TodaysHalftime() {
 				</Link>
 			</header>
 
-			{false ? (
+			{videos.length ? (
 				<div className="grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4">
 					{videos.map((video) => (
 						<PreviewWithTitle key={video.pk} {...video} />

--- a/src/components/features/home/todays-halftime.tsx
+++ b/src/components/features/home/todays-halftime.tsx
@@ -42,14 +42,14 @@ export default function TodaysHalftime() {
 				</Link>
 			</header>
 
-			{videos.length ? (
+			{false ? (
 				<div className="grid grid-cols-2 grid-rows-2 gap-x-3 gap-y-4">
 					{videos.map((video) => (
 						<PreviewWithTitle key={video.pk} {...video} />
 					))}
 				</div>
 			) : (
-				<Link href={'/halftime'} className="py-10 text-center text-body-03 text-black-7800">
+				<Link href={'/halftime'} className="py-10 text-center text-body-03 text-black-700">
 					모든 하프타임 둘러보러 가기 &gt;
 				</Link>
 			)}

--- a/src/components/layouts/root/navbar/index.tsx
+++ b/src/components/layouts/root/navbar/index.tsx
@@ -34,13 +34,9 @@ export default function Navbar() {
 	];
 
 	const filteredNavButtons = navButtons.filter((button) => {
-		// isLeftSideBarVisible이 true일 때 '홈' 버튼은 숨김
-		if (isLeftSideBarVisible && button.href === '/') {
+		// isLeftSideBarVisible이 true일 때 홈/랭킹 버튼 숨김
+		if (isLeftSideBarVisible && (button.href === '/' || button.href === '/ranking')) {
 			return false;
-		}
-		// isLeftSideBarVisible이 false 또는 데스크톱 환경이 아닐 때 '랭킹' 버튼을 제외
-		if (!isLeftSideBarVisible || !isDesktop) {
-			return button.href === '/ranking';
 		}
 		return true;
 	});

--- a/src/components/layouts/root/navbar/notice-modal.tsx
+++ b/src/components/layouts/root/navbar/notice-modal.tsx
@@ -43,22 +43,26 @@ export default function NoticeModal({ onCloseModal }: { onCloseModal: () => void
 				alt="화살표"
 			/>
 			<NoticeHeader isModal={true} onClose={onCloseModal} />
-			<div className="flex-1 rounded-b-[0.625rem] overflow-y-auto no-scrollbar">
-				{notifications.map((notice) => (
-					<NoticeItem
-						key={notice.pk}
-						pk={notice.pk}
-						type={notice.type}
-						read={notice.read}
-						teamLogo={notice.teamLogo}
-						redirectUrl={notice.redirectUrl}
-						relativeTime={notice.relativeTime}
-						content={notice.content}
-						isModal={true}
-						onCloseModal={onCloseModal}
-					/>
-				))}
-			</div>
+			{notifications.length ? (
+				<div className="flex-1 rounded-b-[0.625rem] overflow-y-auto no-scrollbar">
+					{notifications.map((notice) => (
+						<NoticeItem
+							key={notice.pk}
+							pk={notice.pk}
+							type={notice.type}
+							read={notice.read}
+							teamLogo={notice.teamLogo}
+							redirectUrl={notice.redirectUrl}
+							relativeTime={notice.relativeTime}
+							content={notice.content}
+							isModal={true}
+							onCloseModal={onCloseModal}
+						/>
+					))}
+				</div>
+			) : (
+				<div className="m-auto pb-4 text-center text-body-03 text-black-800">킥온에서 다양한 소식을 만나보세요!</div>
+			)}
 		</div>
 	);
 }

--- a/src/components/layouts/with-side/top-news-halftime/top-halftime.tsx
+++ b/src/components/layouts/with-side/top-news-halftime/top-halftime.tsx
@@ -3,6 +3,7 @@
 import PreviewWithoutTitle from '@/components/features/halftime/preview-without-title';
 import { getTodaysHalftime } from '@/services/apis/shorts/shorts.api';
 import { BaseHalftimeDto } from '@/services/apis/shorts/shorts.type';
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 export default function TopHalftime() {
@@ -19,11 +20,18 @@ export default function TopHalftime() {
 		getVideos();
 	}, []);
 
-	return (
+	return videos.length ? (
 		<div className="grid grid-cols-2 grid-rows-2 gap-2.5">
 			{videos.map((video) => (
 				<PreviewWithoutTitle key={video.pk} {...video} />
 			))}
 		</div>
+	) : (
+		<Link
+			href={'/halftime'}
+			className="flex items-center justify-center text-body-03 text-black-800 w-full aspect-[13/20] -mb-1"
+		>
+			모든 하프타임 둘러보러 가기 &gt;
+		</Link>
 	);
 }

--- a/src/components/layouts/with-side/top-news-halftime/top-halftime.tsx
+++ b/src/components/layouts/with-side/top-news-halftime/top-halftime.tsx
@@ -20,7 +20,7 @@ export default function TopHalftime() {
 		getVideos();
 	}, []);
 
-	return false ? (
+	return videos.length ? (
 		<div className="grid grid-cols-2 grid-rows-2 gap-2.5">
 			{videos.map((video) => (
 				<PreviewWithoutTitle key={video.pk} {...video} />

--- a/src/components/layouts/with-side/top-news-halftime/top-halftime.tsx
+++ b/src/components/layouts/with-side/top-news-halftime/top-halftime.tsx
@@ -20,7 +20,7 @@ export default function TopHalftime() {
 		getVideos();
 	}, []);
 
-	return videos.length ? (
+	return false ? (
 		<div className="grid grid-cols-2 grid-rows-2 gap-2.5">
 			{videos.map((video) => (
 				<PreviewWithoutTitle key={video.pk} {...video} />
@@ -29,7 +29,7 @@ export default function TopHalftime() {
 	) : (
 		<Link
 			href={'/halftime'}
-			className="flex items-center justify-center text-body-03 text-black-800 w-full aspect-[13/20] -mb-1"
+			className="flex items-center justify-center text-body-03 text-black-700 w-full aspect-[13/20] -mb-1"
 		>
 			모든 하프타임 둘러보러 가기 &gt;
 		</Link>

--- a/src/lib/utils/date/getRelativeTime.ts
+++ b/src/lib/utils/date/getRelativeTime.ts
@@ -1,11 +1,12 @@
 export const getRelativeTime = (dateString: string) => {
-	const past = new Date(dateString);
+	const date = new Date(dateString);
 
 	// 현재 시간을 UTC로 맞추기
 	const now = new Date();
 	const nowUTC = new Date(now.getTime() + now.getTimezoneOffset() * 60000);
 
-	const diffInSeconds = Math.floor((nowUTC.getTime() - past.getTime()) / 1000);
+	const absTime = Math.abs(nowUTC.getTime() - date.getTime());
+	const diffInSeconds = Math.floor(absTime / 1000);
 
 	const rtf = new Intl.RelativeTimeFormat('ko', { numeric: 'auto' });
 

--- a/src/lib/utils/date/isPastDate.ts
+++ b/src/lib/utils/date/isPastDate.ts
@@ -1,0 +1,6 @@
+export const isPastDate = (dateStr: string) => {
+	const date = new Date(dateStr);
+	const now = new Date();
+
+	return now.getTime() - date.getTime() > 0;
+};


### PR DESCRIPTION
## 작업 내용
- 알림이 없을 때 대체 UI 추가

- 하프타임이 없을 때 대체 UI 추가

- 랭킹 사이드가 있을 때 내브바에 랭킹 버튼이 중복으로 노출되는 버그 수정

- 승부예측 마감 N일 후로 뜨는 버그 수정
게시글의 경우 과거 date를 받아서 N일 전으로 렌더링하는 로직이고,
승부예측의 경우 미래 date를 받아서 **마감 N일 전**으로 렌더링하는 로직입니다.
해당 로직을 `getRelativeTime` 함수로 통합한 후, 미래 date -> **N일 후**로 렌더링되는 문제를 발견했습니다.
abs를 계산해서 모두 N일 전 형태로 반환하도록 수정했습니다.

## 작업 화면
임의로 작업한 대체 UI 화면입니다.
분기 조건을 false로 변경하시면 로컬에서 테스트하실 수 있습니다.

- 알림창 및 알림 페이지
<img width="314" height="564" alt="image" src="https://github.com/user-attachments/assets/5d3ba340-4e78-4335-a47e-1a3f3b3dd760" />
<img width="377" height="668" alt="image" src="https://github.com/user-attachments/assets/834863d6-1b95-47ed-bb1f-d6ff1996031c" />

- 홈 화면 하프타임 컴포넌트
<img width="381" height="238" alt="image" src="https://github.com/user-attachments/assets/38eb4598-2288-4a50-95bf-2fc91407b5f8" />
<img width="304" height="435" alt="image" src="https://github.com/user-attachments/assets/a5d6eeea-4626-4a57-a353-a735073728f6" />

- 하프타임 페이지
뉴스/게시글 empty state 컴포넌트를 참고해서 작업했습니다.
<img width="904" height="565" alt="image" src="https://github.com/user-attachments/assets/3b01d32f-c1a2-424c-9424-b05972a80a11" />


