### PR TITLE
[KO-553] setSelectedSort에 string 값 전달 시 타입 오류 수정

### DIFF
--- a/src/components/features/halftime/sorter.tsx
+++ b/src/components/features/halftime/sorter.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 export default function Sorter() {
-	const [selectedSort, setSelectedSort] = useState(halftimeSortOptions[0].value);
+	const [selectedSort, setSelectedSort] = useState<string>(halftimeSortOptions[0].value);
 	const selectedIndex = halftimeSortOptions.findIndex((option) => option.value === selectedSort);
 	const searchParams = useSearchParams();
 	const router = useRouter();


### PR DESCRIPTION
## 작업 내용
- 제가 머지 하고 발견한 내용이고 작은 수정이라 바로 진행했습니다 
- 기존에는 useState 초기값이 특정 리터럴 타입으로 추론되어 searchParams에서 가져온 sort 값을 setSelectedSort로 넘길 때
타입스크립트 에러가 발생했습니닷. 그래서 state 제네릭에 string/union 타입을 명시하여 해결했습니다!!