### PR TITLE
[KO-558] 승부 예측 캘린더 UI 및 로직 개선

### DIFF
--- a/public/chevron/up-and-down.svg
+++ b/public/chevron/up-and-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
+<path d="M4 6L8 10L12 6" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -9,7 +9,7 @@ import 'react-calendar/dist/Calendar.css';
 import '@/styles/calendar-custom.css';
 import { getMonthlyMatchList, getMyCalendar, getPredictionDates } from '@/services/apis/calendar';
 import useIsMobile from '@/lib/hooks/useIsMobile';
-import { formatFromTo, getTileClassName, stripTime } from '@/lib/utils';
+import { formatFromTo, getEndOfWeek, getStartOfWeek, getTileClassName, stripTime } from '@/lib/utils';
 
 import { renderNavigationLabel } from '../features/calendar/renderers/render-navigation-label';
 import { RenderTileContent } from '../features/calendar/renderers/render-tile-content';
@@ -26,8 +26,6 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	const searchParams = useSearchParams();
 
 	const isMatch = type === 'match';
-
-	const calendarRef = useRef<HTMLDivElement>(null);
 
 	const [isCollapsed, setIsCollapsed] = useState(isMatch ? false : true); // 접혀 있는 상태인가
 	const [markedDatesMap, setMarkedDatesMap] = useState<Record<string, number>>({});
@@ -144,7 +142,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	const todayMonth = today.getMonth();
 	const todayYear = today.getFullYear();
 
-	// const maxDate = new Date(todayYear, todayMonth + 2, 1); // 다음 달의 다음 달 1일
+	// const maxDate = new Date(todayYear, todayMonth + 2, 1); // 다음 달의 1일
 
 	// 화살표 표시 여부
 	const minDate = new Date(todayYear, todayMonth, 1); // 이번 달
@@ -152,9 +150,30 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	const canGoNextMonth =
 		firstDayOfCurrentMonth.getTime() < new Date(todayYear, isMatch ? todayMonth + 1 : todayMonth, 1).getTime();
 
+	// 오늘 기준 주 시작/끝
+	const todayWeekStart = getStartOfWeek(today);
+
+	// 현재 주 시작/끝 (selectedDate 기준)
+	const currentWeekStart = selectedDate ? getStartOfWeek(selectedDate) : todayWeekStart;
+	const currentWeekEnd = getEndOfWeek(currentWeekStart);
+
+	const handleWeekChange = (direction: 'prev' | 'next') => {
+		const newDate = new Date(currentWeekStart);
+		newDate.setDate(currentWeekStart.getDate() + (direction === 'next' ? 7 : -7));
+		setSelectedDate(stripTime(newDate));
+		const newMonthStart = new Date(newDate.getFullYear(), newDate.getMonth(), 1); // 달이 바뀌어서 갱신
+		setFirstDayOfCurrentMonth(newMonthStart);
+	};
+
+	// 화살표 활성화 조건
+	const canGoPrevWeek = currentWeekStart.getTime() > todayWeekStart.getTime();
+	const canGoNextWeek = predictionRange
+		? currentWeekEnd.getTime() < stripTime(new Date(predictionRange.end)).getTime()
+		: true;
+
 	return (
 		<div className="w-full">
-			<div className="relative ">
+			<div className="relative">
 				<div>
 					<Calendar
 						key={firstDayOfCurrentMonth.toISOString()}
@@ -163,17 +182,24 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 						activeStartDate={firstDayOfCurrentMonth}
 						calendarType="gregory"
 						locale="ko-KR"
-						className={`custom-calendar ${isMobile && 'custom-calendar-mobile'} relative transition-all duration-[2000ms] ease-linear opacity-100 ${
-							isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'
-						}`}
+						className={`custom-calendar 
+							${isMobile ? 'custom-calendar-mobile' : ''} 
+							${isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'}
+							relative transition-all duration-[2000ms] ease-linear opacity-100`}
 						onClickDay={(value) => setSelectedDate(stripTime(value))}
 						navigationLabel={({ date }) =>
 							renderNavigationLabel({
 								year: date.getFullYear(),
 								month: date.toLocaleString('ko-KR', { month: 'long' }),
-								canGoPrev: canGoPrevMonth,
-								canGoNext: canGoNextMonth,
-								onMonthChange: handleMonthChange,
+								canGoPrev: isCollapsed ? canGoPrevWeek : canGoPrevMonth,
+								canGoNext: isCollapsed ? canGoNextWeek : canGoNextMonth,
+								onMonthChange: (direction) => {
+									if (isCollapsed) {
+										handleWeekChange(direction);
+									} else {
+										handleMonthChange(direction);
+									}
+								},
 							})
 						}
 						prevLabel={null}
@@ -184,7 +210,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 						tileClassName={({ date }) =>
 							getTileClassName({
 								dateOfTile: date,
-								firstDayOfCurrentMonth,
+								firstDayOfCurrentMonth: firstDayOfCurrentMonth,
 								isCollapsed,
 								today,
 								selectedDate,

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -182,7 +182,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 		<div className="w-full">
 			<div className="relative">
 				<Calendar
-					key={firstDayOfCurrentMonth.toISOString()}
+					key={`${firstDayOfCurrentMonth.toISOString()}-${isWeekCalendar ? 'week' : 'month'}`}
 					view="month"
 					formatDay={(locale, date) => `${date.getDate()}`}
 					activeStartDate={firstDayOfCurrentMonth}
@@ -190,7 +190,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 					locale="ko-KR"
 					className={`custom-calendar
 							${isMobile && 'custom-calendar-mobile'} 
-							${isWeekCalendar ? 'h-[250px]' : ' h-full @mobile:max-h-[500px]'}
+							${isWeekCalendar ? 'h-fit' : ' h-full'}
 							relative transition-all duration-[500ms] ease-linear opacity-100`}
 					onClickDay={(value) => setSelectedDate(stripTime(value))}
 					navigationLabel={({ date }) => (

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 
 import 'react-calendar/dist/Calendar.css';
 import '@/styles/calendar-custom.css';
-import { getMonthlyMatchList, getMyPredictionDates, getPredictionDates } from '@/services/apis/calendar';
+import { getMonthlyMatchList, getMyPredictionDates, getPredictionOpenPeriod } from '@/services/apis/calendar';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import { formatFromTo, getEndOfWeek, getStartOfWeek, getTileClassName, stripTime } from '@/lib/utils';
 
@@ -69,7 +69,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	useEffect(() => {
 		async function fetchPredictionDates() {
 			try {
-				const response = await getPredictionDates();
+				const response = await getPredictionOpenPeriod();
 				console.log(response);
 				if (response?.data) {
 					const { startDate, endDate } = response.data;

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -182,7 +182,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 		<div className="w-full">
 			<div className="relative">
 				<Calendar
-					key={`${firstDayOfCurrentMonth.toISOString()}-${isWeekCalendar ? 'week' : 'month'}`}
+					key={`${firstDayOfCurrentMonth.toISOString()}`}
 					view="month"
 					formatDay={(locale, date) => `${date.getDate()}`}
 					activeStartDate={firstDayOfCurrentMonth}
@@ -190,7 +190,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 					locale="ko-KR"
 					className={`custom-calendar
 							${isMobile && 'custom-calendar-mobile'} 
-							${isWeekCalendar ? 'h-fit' : ' h-full'}
+							${isWeekCalendar ? 'max-h-[250px]' : 'max-h-[1000px]'}
 							relative transition-all duration-[500ms] ease-linear opacity-100`}
 					onClickDay={(value) => setSelectedDate(stripTime(value))}
 					navigationLabel={({ date }) => (

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -154,13 +154,8 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 
 	return (
 		<div className="w-full">
-			<div className={`relative opacity-100 ${isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'}`}>
-				<div
-					ref={calendarRef}
-					className={`relative transition-all duration-[400ms] ease opacity-100 ${
-						isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'
-					}`}
-				>
+			<div className="relative ">
+				<div>
 					<Calendar
 						key={firstDayOfCurrentMonth.toISOString()}
 						view="month"
@@ -168,7 +163,9 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 						activeStartDate={firstDayOfCurrentMonth}
 						calendarType="gregory"
 						locale="ko-KR"
-						className={`custom-calendar ${isMobile && 'custom-calendar-mobile'}`}
+						className={`custom-calendar ${isMobile && 'custom-calendar-mobile'} relative transition-all duration-[2000ms] ease-linear opacity-100 ${
+							isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'
+						}`}
 						onClickDay={(value) => setSelectedDate(stripTime(value))}
 						navigationLabel={({ date }) =>
 							renderNavigationLabel({

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -138,6 +138,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 
 	const today = stripTime(new Date());
 
+	//TODO: 여기 다시 보셈 ㄱㄱ
 	// 오늘 날짜 기준으로 고정
 	const todayMonth = today.getMonth();
 	const todayYear = today.getFullYear();
@@ -174,61 +175,60 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 	return (
 		<div className="w-full">
 			<div className="relative">
-				<div>
-					<Calendar
-						key={firstDayOfCurrentMonth.toISOString()}
-						view="month"
-						formatDay={(locale, date) => `${date.getDate()}`}
-						activeStartDate={firstDayOfCurrentMonth}
-						calendarType="gregory"
-						locale="ko-KR"
-						className={`custom-calendar 
-							${isMobile ? 'custom-calendar-mobile' : ''} 
-							${isCollapsed ? 'max-h-[250px]' : 'max-h-[1000px]'}
-							relative transition-all duration-[2000ms] ease-linear opacity-100`}
-						onClickDay={(value) => setSelectedDate(stripTime(value))}
-						navigationLabel={({ date }) =>
-							renderNavigationLabel({
-								year: date.getFullYear(),
-								month: date.toLocaleString('ko-KR', { month: 'long' }),
-								canGoPrev: isCollapsed ? canGoPrevWeek : canGoPrevMonth,
-								canGoNext: isCollapsed ? canGoNextWeek : canGoNextMonth,
-								onMonthChange: (direction) => {
-									if (isCollapsed) {
-										handleWeekChange(direction);
-									} else {
-										handleMonthChange(direction);
-									}
-								},
-							})
-						}
-						prevLabel={null}
-						nextLabel={null}
-						prev2Label={null}
-						next2Label={null}
-						formatShortWeekday={(locale, date) => ['일', '월', '화', '수', '목', '금', '토'][date.getDay()]}
-						tileClassName={({ date }) =>
-							getTileClassName({
-								dateOfTile: date,
-								firstDayOfCurrentMonth: firstDayOfCurrentMonth,
-								isCollapsed,
-								today,
-								selectedDate,
-								isMatch,
-								predictionRange,
-								markedDatesMap,
-							})
-						}
-						tileContent={({ date }) => (
-							<RenderTileContent
-								date={date}
-								today={today}
-								predictionRange={predictionRange}
-								markedDatesMap={markedDatesMap}
-							/>
-						)}
-					/>
-				</div>
+				<Calendar
+					key={firstDayOfCurrentMonth.toISOString()}
+					view="month"
+					formatDay={(locale, date) => `${date.getDate()}`}
+					activeStartDate={firstDayOfCurrentMonth}
+					calendarType="gregory"
+					locale="ko-KR"
+					className={`custom-calendar
+							${isMobile && 'custom-calendar-mobile'} 
+							${isCollapsed ? 'h-[250px]' : ' h-[470px] @mobile:max-h-[500px]'}
+							relative transition-all duration-[500ms] ease-linear opacity-100`}
+					onClickDay={(value) => setSelectedDate(stripTime(value))}
+					navigationLabel={({ date }) =>
+						renderNavigationLabel({
+							year: date.getFullYear(),
+							month: date.toLocaleString('ko-KR', { month: 'long' }),
+							canGoPrev: isCollapsed ? canGoPrevWeek : canGoPrevMonth,
+							canGoNext: isCollapsed ? canGoNextWeek : canGoNextMonth,
+							onMonthChange: (direction) => {
+								if (isCollapsed) {
+									handleWeekChange(direction);
+								} else {
+									handleMonthChange(direction);
+								}
+							},
+						})
+					}
+					prevLabel={null}
+					nextLabel={null}
+					prev2Label={null}
+					next2Label={null}
+					formatShortWeekday={(locale, date) => ['일', '월', '화', '수', '목', '금', '토'][date.getDay()]}
+					tileClassName={({ date }) =>
+						getTileClassName({
+							dateOfTile: date,
+							firstDayOfCurrentMonth: firstDayOfCurrentMonth,
+							isCollapsed,
+							today,
+							selectedDate,
+							isMatch,
+							predictionRange,
+							markedDatesMap,
+						})
+					}
+					tileContent={({ date }) => (
+						<RenderTileContent
+							date={date}
+							today={today}
+							predictionRange={predictionRange}
+							markedDatesMap={markedDatesMap}
+						/>
+					)}
+				/>
+
 				<button
 					onClick={() => setIsCollapsed((prev) => !prev)}
 					className="flex w-full justify-center absolute bottom-2 left-1/2 -translate-x-1/2 z-10 bg-transparent border-none cursor-pointer"

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -11,7 +11,7 @@ import { getMonthlyMatchList, getMyPredictionDates, getPredictionOpenPeriod } fr
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import { formatFromTo, getEndOfWeek, getStartOfWeek, getTileClassName, stripTime } from '@/lib/utils';
 
-import { renderNavigationLabel } from '../features/calendar/renderers/render-navigation-label';
+import { NavigationLabel } from '../features/calendar/renderers/render-navigation-label';
 import { RenderTileContent } from '../features/calendar/renderers/render-tile-content';
 
 interface MatchPredictionCalendarProps {
@@ -136,6 +136,11 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 		updateUrlParams(newDate);
 	};
 
+	const handleYearChange = (newYear: number) => {
+		const newDate = new Date(newYear, firstDayOfCurrentMonth.getMonth(), 1);
+		updateUrlParams(newDate);
+	};
+
 	// predictionRange가 있으면 start 기준으로 이전 달 이동 막기
 	const canGoPrevMonth = predictionRange
 		? firstDayOfCurrentMonth.getTime() >
@@ -185,24 +190,26 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 					locale="ko-KR"
 					className={`custom-calendar
 							${isMobile && 'custom-calendar-mobile'} 
-							${isWeekCalendar ? 'h-[250px]' : ' h-[470px] @mobile:max-h-[500px]'}
+							${isWeekCalendar ? 'h-[250px]' : ' h-full @mobile:max-h-[500px]'}
 							relative transition-all duration-[500ms] ease-linear opacity-100`}
 					onClickDay={(value) => setSelectedDate(stripTime(value))}
-					navigationLabel={({ date }) =>
-						renderNavigationLabel({
-							year: date.getFullYear(),
-							month: date.toLocaleString('ko-KR', { month: 'long' }),
-							canGoPrev: isWeekCalendar ? canGoPrevWeek : canGoPrevMonth,
-							canGoNext: isWeekCalendar ? canGoNextWeek : canGoNextMonth,
-							onMonthChange: (direction) => {
+					navigationLabel={({ date }) => (
+						<NavigationLabel
+							year={date.getFullYear()}
+							month={date.toLocaleString('ko-KR', { month: 'long' })}
+							canGoPrev={isWeekCalendar ? canGoPrevWeek : canGoPrevMonth}
+							canGoNext={isWeekCalendar ? canGoNextWeek : canGoNextMonth}
+							isMatch={isMatch}
+							onMonthChange={(direction) => {
 								if (isWeekCalendar) {
 									handleWeekChange(direction);
 								} else {
 									handleMonthChange(direction);
 								}
-							},
-						})
-					}
+							}}
+							onYearChange={handleYearChange}
+						/>
+					)}
 					prevLabel={null}
 					nextLabel={null}
 					prev2Label={null}

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -192,7 +192,16 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 							${isMobile && 'custom-calendar-mobile'} 
 							${isWeekCalendar ? 'max-h-[250px]' : 'max-h-[1000px]'}
 							relative transition-all duration-[500ms] ease-linear opacity-100`}
-					onClickDay={(value) => setSelectedDate(stripTime(value))}
+					onClickDay={(value) => {
+						const newDate = stripTime(value);
+						setSelectedDate(newDate);
+
+						// 만약 선택된 날짜의 달이 현재 달과 다르면 activeStartDate 업데이트
+						if (newDate.getMonth() !== firstDayOfCurrentMonth.getMonth()) {
+							const newMonthStart = new Date(newDate.getFullYear(), newDate.getMonth(), 1);
+							setFirstDayOfCurrentMonth(newMonthStart);
+						}
+					}}
 					navigationLabel={({ date }) => (
 						<NavigationLabel
 							year={date.getFullYear()}

--- a/src/components/common/calendar.tsx
+++ b/src/components/common/calendar.tsx
@@ -7,7 +7,7 @@ import Image from 'next/image';
 
 import 'react-calendar/dist/Calendar.css';
 import '@/styles/calendar-custom.css';
-import { getMonthlyMatchList, getMyCalendar, getPredictionDates } from '@/services/apis/calendar';
+import { getMonthlyMatchList, getMyPredictionDates, getPredictionDates } from '@/services/apis/calendar';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import { formatFromTo, getEndOfWeek, getStartOfWeek, getTileClassName, stripTime } from '@/lib/utils';
 
@@ -27,15 +27,13 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 
 	const isMatch = type === 'match';
 
-	const [isCollapsed, setIsCollapsed] = useState(isMatch ? false : true); // 접혀 있는 상태인가
-	const [markedDatesMap, setMarkedDatesMap] = useState<Record<string, number>>({});
-
+	const [isWeekCalendar, setIsWeekCalendar] = useState(isMatch ? false : true); // 주 단위 캘린더인가 (접힌 상태인가)
+	const [markedDatesMap, setMarkedDatesMap] = useState<Record<string, number>>({}); // 경기가 있는 날짜들
 	const [predictionRange, setPredictionRange] = useState<{
 		start: Date;
 		end: Date;
 	} | null>(null);
 
-	// URL 파라미터에서 년월 정보 가져오기
 	const getYearMonthFromUrl = () => {
 		const year = searchParams.get('year');
 		const month = searchParams.get('month');
@@ -49,7 +47,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 		return new Date(today.getFullYear(), today.getMonth(), 1);
 	};
 
-	const [firstDayOfCurrentMonth, setFirstDayOfCurrentMonth] = useState(getYearMonthFromUrl);
+	const [firstDayOfCurrentMonth, setFirstDayOfCurrentMonth] = useState(getYearMonthFromUrl); // 현재 월의 첫째 날
 
 	// URL 파라미터 업데이트
 	const updateUrlParams = (date: Date) => {
@@ -59,25 +57,6 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 		params.set('year', year.toString());
 		params.set('month', month.toString());
 		router.replace(`?${params.toString()}`, { scroll: false });
-	};
-
-	const handleMonthChange = (direction: 'prev' | 'next') => {
-		const currentYear = firstDayOfCurrentMonth.getFullYear();
-		const currentMonth = firstDayOfCurrentMonth.getMonth();
-
-		let newYear = currentYear;
-		let newMonth = currentMonth + (direction === 'next' ? 1 : -1);
-
-		if (newMonth > 11) {
-			newMonth = 0;
-			newYear += 1;
-		} else if (newMonth < 0) {
-			newMonth = 11;
-			newYear -= 1;
-		}
-
-		const newDate = new Date(newYear, newMonth, 1);
-		updateUrlParams(newDate);
 	};
 
 	// URL 파라미터가 변경될 때 새로운 월의 첫째 날 업데이트
@@ -107,13 +86,12 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 		fetchPredictionDates();
 	}, []);
 
-	// 월이 변경될 때마다 호출
+	// 월이 변경되면 해당 월의 경기 날짜 조회 + 상위로 변경된 월의 1일 전달 (가장 가까운 경기 날 조회)
 	useEffect(() => {
 		async function fetchMarkedDates() {
 			try {
 				const formattedDate = formatFromTo(firstDayOfCurrentMonth);
-				console.log(formattedDate);
-				const response = isMatch ? await getMonthlyMatchList(formattedDate) : await getMyCalendar();
+				const response = isMatch ? await getMonthlyMatchList(formattedDate) : await getMyPredictionDates();
 				console.log(response);
 				if (response?.data?.dates) {
 					const parsedDates = response.data.dates.map((d) => {
@@ -132,42 +110,65 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 				console.error('캘린더 점찍기용 날짜 조회 실패:', e);
 			}
 		}
+		//setSelectedDate(firstDayOfCurrentMonth); -> 서버 복구되면 재시도
 
 		fetchMarkedDates();
 	}, [firstDayOfCurrentMonth, isMatch]);
 
 	const today = stripTime(new Date());
 
-	//TODO: 여기 다시 보셈 ㄱㄱ
-	// 오늘 날짜 기준으로 고정
-	const todayMonth = today.getMonth();
-	const todayYear = today.getFullYear();
+	const handleMonthChange = (direction: 'prev' | 'next') => {
+		const currentYear = firstDayOfCurrentMonth.getFullYear();
+		const currentMonth = firstDayOfCurrentMonth.getMonth();
 
-	// const maxDate = new Date(todayYear, todayMonth + 2, 1); // 다음 달의 1일
+		let newYear = currentYear;
+		let newMonth = currentMonth + (direction === 'next' ? 1 : -1);
 
-	// 화살표 표시 여부
-	const minDate = new Date(todayYear, todayMonth, 1); // 이번 달
-	const canGoPrevMonth = isMatch ? firstDayOfCurrentMonth.getTime() > minDate.getTime() : true;
-	const canGoNextMonth =
-		firstDayOfCurrentMonth.getTime() < new Date(todayYear, isMatch ? todayMonth + 1 : todayMonth, 1).getTime();
+		if (newMonth > 11) {
+			newMonth = 0;
+			newYear += 1;
+		} else if (newMonth < 0) {
+			newMonth = 11;
+			newYear -= 1;
+		}
 
-	// 오늘 기준 주 시작/끝
-	const todayWeekStart = getStartOfWeek(today);
+		const newDate = new Date(newYear, newMonth, 1);
+		updateUrlParams(newDate);
+	};
 
-	// 현재 주 시작/끝 (selectedDate 기준)
-	const currentWeekStart = selectedDate ? getStartOfWeek(selectedDate) : todayWeekStart;
+	// predictionRange가 있으면 start 기준으로 이전 달 이동 막기
+	const canGoPrevMonth = predictionRange
+		? firstDayOfCurrentMonth.getTime() >
+			new Date(predictionRange.start.getFullYear(), predictionRange.start.getMonth(), 1).getTime()
+		: true;
+
+	// predictionRange가 있으면 end 기준으로 다음 달 이동 막기
+	const canGoNextMonth = predictionRange
+		? firstDayOfCurrentMonth.getTime() <
+			new Date(predictionRange.end.getFullYear(), predictionRange.end.getMonth(), 1).getTime()
+		: true;
+
+	const currentWeekStart = selectedDate ? getStartOfWeek(selectedDate) : getStartOfWeek(today);
 	const currentWeekEnd = getEndOfWeek(currentWeekStart);
 
 	const handleWeekChange = (direction: 'prev' | 'next') => {
 		const newDate = new Date(currentWeekStart);
 		newDate.setDate(currentWeekStart.getDate() + (direction === 'next' ? 7 : -7));
 		setSelectedDate(stripTime(newDate));
-		const newMonthStart = new Date(newDate.getFullYear(), newDate.getMonth(), 1); // 달이 바뀌어서 갱신
-		setFirstDayOfCurrentMonth(newMonthStart);
+
+		// 새로운 주가 속한 달 계산
+		const newMonth = newDate.getMonth();
+		const currentMonth = firstDayOfCurrentMonth.getMonth();
+
+		// 주 이동으로 달이 바뀌었을 때만 갱신
+		if (newMonth !== currentMonth) {
+			const newMonthStart = new Date(newDate.getFullYear(), newMonth, 1);
+			setFirstDayOfCurrentMonth(newMonthStart);
+		}
 	};
 
-	// 화살표 활성화 조건
-	const canGoPrevWeek = currentWeekStart.getTime() > todayWeekStart.getTime();
+	const canGoPrevWeek = currentWeekStart.getTime() > getStartOfWeek(today).getTime();
+
 	const canGoNextWeek = predictionRange
 		? currentWeekEnd.getTime() < stripTime(new Date(predictionRange.end)).getTime()
 		: true;
@@ -184,17 +185,17 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 					locale="ko-KR"
 					className={`custom-calendar
 							${isMobile && 'custom-calendar-mobile'} 
-							${isCollapsed ? 'h-[250px]' : ' h-[470px] @mobile:max-h-[500px]'}
+							${isWeekCalendar ? 'h-[250px]' : ' h-[470px] @mobile:max-h-[500px]'}
 							relative transition-all duration-[500ms] ease-linear opacity-100`}
 					onClickDay={(value) => setSelectedDate(stripTime(value))}
 					navigationLabel={({ date }) =>
 						renderNavigationLabel({
 							year: date.getFullYear(),
 							month: date.toLocaleString('ko-KR', { month: 'long' }),
-							canGoPrev: isCollapsed ? canGoPrevWeek : canGoPrevMonth,
-							canGoNext: isCollapsed ? canGoNextWeek : canGoNextMonth,
+							canGoPrev: isWeekCalendar ? canGoPrevWeek : canGoPrevMonth,
+							canGoNext: isWeekCalendar ? canGoNextWeek : canGoNextMonth,
 							onMonthChange: (direction) => {
-								if (isCollapsed) {
+								if (isWeekCalendar) {
 									handleWeekChange(direction);
 								} else {
 									handleMonthChange(direction);
@@ -211,7 +212,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 						getTileClassName({
 							dateOfTile: date,
 							firstDayOfCurrentMonth: firstDayOfCurrentMonth,
-							isCollapsed,
+							isWeekCalendar,
 							today,
 							selectedDate,
 							isMatch,
@@ -230,7 +231,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 				/>
 
 				<button
-					onClick={() => setIsCollapsed((prev) => !prev)}
+					onClick={() => setIsWeekCalendar((prev) => !prev)}
 					className="flex w-full justify-center absolute bottom-2 left-1/2 -translate-x-1/2 z-10 bg-transparent border-none cursor-pointer"
 				>
 					<Image
@@ -239,7 +240,7 @@ export default function MatchPredictionCalendar({ selectedDate, setSelectedDate,
 						width={36}
 						height={36}
 						style={{
-							transform: isCollapsed ? 'rotate(180deg)' : 'rotate(0deg)',
+							transform: isWeekCalendar ? 'rotate(180deg)' : 'rotate(0deg)',
 							transition: 'transform 0.3s ease',
 						}}
 					/>

--- a/src/components/features/calendar/renderers/render-navigation-label.tsx
+++ b/src/components/features/calendar/renderers/render-navigation-label.tsx
@@ -1,37 +1,89 @@
+'use client';
+import { useState } from 'react';
 import { ArrowButton } from '../arrow-button';
+import Image from 'next/image';
+import clsx from 'clsx';
 
-interface RenderNavigationLabelParams {
-	year: number;
-	month: string;
-	canGoPrev: boolean;
-	canGoNext: boolean;
-	onMonthChange: (direction: 'prev' | 'next') => void;
-}
-
-export const renderNavigationLabel = ({
+export function NavigationLabel({
 	year,
 	month,
 	canGoPrev,
 	canGoNext,
 	onMonthChange,
-}: RenderNavigationLabelParams) => (
-	<div className="flex w-full flex-1 items-center justify-center">
-		<div className="absolute left-0 @mobile:ml-5 ml-9 year">{year}년</div>
+	isMatch,
+	onYearChange,
+}: {
+	year: number;
+	month: string;
+	canGoPrev: boolean;
+	canGoNext: boolean;
+	onMonthChange: (direction: 'prev' | 'next') => void;
+	isMatch: boolean;
+	onYearChange?: (year: number) => void;
+}) {
+	const [isVisibleDropdown, setIsVisibleDropdown] = useState(false);
+	const [selectedYear, setSelectedYear] = useState(year);
 
-		<div className="relative w-full flex-1 flex items-center justify-center">
-			{/* 왼쪽 화살표 */}
-			<ArrowButton direction="prev" onClick={onMonthChange} show={canGoPrev} />
+	const options = [
+		{ label: '2025년', value: 2025 },
+		{ label: '2026년', value: 2026 },
+	]; // 흠...
 
-			{/* 월 중앙 */}
-			{month && (
-				<span className="flex justify-center items-center">
-					<span className="month-number">{month.slice(0, -1)}</span>
-					<span className="month-text">{month.slice(-1)}</span>
-				</span>
-			)}
+	return (
+		<div className="flex w-full flex-1 items-center justify-center">
+			<div className="absolute left-0 @mobile:ml-5 ml-9 year z-50">
+				{isMatch ? (
+					<span>{year}년</span>
+				) : (
+					<div className="relative w-fit">
+						<div
+							role="button"
+							tabIndex={0}
+							onClick={() => setIsVisibleDropdown((prev) => !prev)}
+							className="flex gap-[4px] items-center justify-between cursor-pointer"
+						>
+							<div className="body1-medium @mobile:text-13">{selectedYear}년</div>
+							<Image width={16} height={16} src="/chevron/up-and-down.svg" alt="옵션 선택" />
+						</div>
+						{isVisibleDropdown && (
+							<div className="px-[30px] py-[10px] z-50 absolute top-8 bg-black-000 border border-gray-200 rounded-[10px] shadow-[0_4px_16px_0_rgba(0,0,0,0.20)]">
+								<div className="flex flex-col space-y-[20px]">
+									{options.map((option, index) => (
+										<div
+											key={option.value}
+											className={clsx(
+												'w-12 flex items-center justify-center @mobile:text-13 cursor-pointer transition-colors',
+												{
+													'text-primary-900 body5-medium': selectedYear === option.value,
+													'body5-regular': selectedYear !== option.value,
+												},
+											)}
+											onClick={() => {
+												setSelectedYear(option.value);
+												setIsVisibleDropdown(false);
+												onYearChange?.(option.value);
+											}}
+										>
+											{option.label}
+										</div>
+									))}
+								</div>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
 
-			{/* 오른쪽 화살표 */}
-			<ArrowButton direction="next" onClick={onMonthChange} show={canGoNext} />
+			<div className="relative w-full flex-1 flex items-center justify-center">
+				<ArrowButton direction="prev" onClick={onMonthChange} show={canGoPrev} />
+				{month && (
+					<span className="flex justify-center items-center">
+						<span className="month-number">{month.slice(0, -1)}</span>
+						<span className="month-text">{month.slice(-1)}</span>
+					</span>
+				)}
+				<ArrowButton direction="next" onClick={onMonthChange} show={canGoNext} />
+			</div>
 		</div>
-	</div>
-);
+	);
+}

--- a/src/components/features/calendar/renderers/render-navigation-label.tsx
+++ b/src/components/features/calendar/renderers/render-navigation-label.tsx
@@ -27,13 +27,13 @@ export function NavigationLabel({
 	const options = [
 		{ label: '2025년', value: 2025 },
 		{ label: '2026년', value: 2026 },
-	]; // 흠...
+	];
 
 	return (
 		<div className="flex w-full flex-1 items-center justify-center">
-			<div className="absolute left-0 @mobile:ml-5 ml-9 year z-50">
+			<div className="absolute left-0 @mobile:ml-5 ml-9 z-50">
 				{isMatch ? (
-					<span>{year}년</span>
+					<span className="button1-medium @mobile:text-12">{year}년</span>
 				) : (
 					<div className="relative w-fit">
 						<div
@@ -42,22 +42,19 @@ export function NavigationLabel({
 							onClick={() => setIsVisibleDropdown((prev) => !prev)}
 							className="flex gap-[4px] items-center justify-between cursor-pointer"
 						>
-							<div className="body1-medium @mobile:text-13">{selectedYear}년</div>
+							<div className="button1-medium @mobile:text-12">{selectedYear}년</div>
 							<Image width={16} height={16} src="/chevron/up-and-down.svg" alt="옵션 선택" />
 						</div>
 						{isVisibleDropdown && (
-							<div className="px-[30px] py-[10px] z-50 absolute top-8 bg-black-000 border border-gray-200 rounded-[10px] shadow-[0_4px_16px_0_rgba(0,0,0,0.20)]">
-								<div className="flex flex-col space-y-[20px]">
+							<div className="px-[30px] py-[10px] @mobile:py-4 z-50 absolute top-8 bg-black-000 border border-gray-200 rounded-[10px] shadow-[0_4px_16px_0_rgba(0,0,0,0.20)]">
+								<div className="flex flex-col space-y-[20px] @mobile:space-y-[30px]">
 									{options.map((option, index) => (
 										<div
 											key={option.value}
-											className={clsx(
-												'w-12 flex items-center justify-center @mobile:text-13 cursor-pointer transition-colors',
-												{
-													'text-primary-900 body5-medium': selectedYear === option.value,
-													'body5-regular': selectedYear !== option.value,
-												},
-											)}
+											className={clsx('w-12 flex items-center justify-center cursor-pointer transition-colors', {
+												'text-primary-900 body5-medium': selectedYear === option.value,
+												'body5-regular': selectedYear !== option.value,
+											})}
 											onClick={() => {
 												setSelectedYear(option.value);
 												setIsVisibleDropdown(false);

--- a/src/components/features/calendar/renderers/render-tile-content.tsx
+++ b/src/components/features/calendar/renderers/render-tile-content.tsx
@@ -21,7 +21,7 @@ export const RenderTileContent: React.FC<TileContentProps> = ({ date, today, pre
 
 	return (
 		<div className="flex flex-col items-center gap-1 mt-1">
-			{isToday && <span>오늘</span>}
+			{isToday && <span className="font-semibold">오늘</span>}
 			{count > 0 && (
 				<div className="flex flex-row items-center gap-2">
 					<div className="calendar-dot" />

--- a/src/components/features/calendar/renderers/render-tile-content.tsx
+++ b/src/components/features/calendar/renderers/render-tile-content.tsx
@@ -21,7 +21,7 @@ export const RenderTileContent: React.FC<TileContentProps> = ({ date, today, pre
 
 	return (
 		<div className="flex flex-col items-center gap-1 mt-1">
-			{isToday && <span className="font-semibold">오늘</span>}
+			{isToday && <span className="w-10 font-semibold">오늘</span>}
 			{count > 0 && (
 				<div className="flex flex-row items-center gap-2">
 					<div className="calendar-dot" />

--- a/src/lib/utils/date/calendar.ts
+++ b/src/lib/utils/date/calendar.ts
@@ -35,9 +35,12 @@ export const getTileClassName = ({
 	predictionRange,
 	markedDatesMap,
 }: TileClassNameProps) => {
-	const d = stripTime(dateOfTile);
-	const isCurrentMonth = dateOfTile.getMonth() === firstDayOfCurrentMonth.getMonth();
-	if (!isCurrentMonth) return 'hidden-other-month-tile';
+	const tileDate = stripTime(dateOfTile);
+	if (!isCollapsed && firstDayOfCurrentMonth && dateOfTile.getMonth() !== firstDayOfCurrentMonth.getMonth()) {
+		return 'hidden-other-month-tile';
+	}
+	// collapsed 모드일 때는 !isCollapsed 조건이 false -> month 체크 안 함 -> 모든 타일 보임
+	// collapsed가 false일 때만 month 체크 -> 이번 달 아닌 타일 숨김
 
 	// selectedDate로 이번 주 범위 계산
 	let startOfWeek: Date | null = null;
@@ -47,13 +50,13 @@ export const getTileClassName = ({
 		endOfWeek = getEndOfWeek(startOfWeek);
 	}
 
-	if (isCollapsed && selectedDate && (d < startOfWeek! || d > endOfWeek!)) {
+	if (isCollapsed && selectedDate && (tileDate < startOfWeek! || tileDate > endOfWeek!)) {
 		return 'hidden-tile'; // 히든 타일로 바뀌면서 트랜지션 발생
 	}
-	const dStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+	const dStr = `${tileDate.getFullYear()}-${String(tileDate.getMonth() + 1).padStart(2, '0')}-${String(tileDate.getDate()).padStart(2, '0')}`;
 	const hasMatch = markedDatesMap[dStr] > 0;
 
-	if (predictionRange && d > predictionRange.end) {
+	if (predictionRange && tileDate > predictionRange.end) {
 		const classes = ['disabled-after'];
 		const dayOfWeek = dateOfTile.getDay();
 
@@ -71,14 +74,14 @@ export const getTileClassName = ({
 		return classes.join(' ');
 	}
 
-	const isFocused = selectedDate && isSameDate(d, selectedDate);
-	const isToday = isSameDate(d, today);
+	const isFocused = selectedDate && isSameDate(tileDate, selectedDate);
+	const isToday = isSameDate(tileDate, today);
 
 	let baseClass = '';
 	if (isFocused && isToday) baseClass = 'focused-today-tile';
 	else if (isFocused) baseClass = 'focused-tile';
 	else if (isToday) baseClass = 'not-focused-today-tile';
-	else if (d < today) baseClass = isMatch ? 'past-tile pointer-events-none' : 'future-tile';
+	else if (tileDate < today) baseClass = isMatch ? 'past-tile pointer-events-none' : 'future-tile';
 	else baseClass = isMatch ? 'future-tile' : 'past-tile pointer-events-none';
 
 	return `${baseClass} ${hasMatch ? 'has-match' : ''}`.trim();

--- a/src/lib/utils/date/calendar.ts
+++ b/src/lib/utils/date/calendar.ts
@@ -36,9 +36,11 @@ export const getTileClassName = ({
 	markedDatesMap,
 }: TileClassNameProps) => {
 	const tileDate = stripTime(dateOfTile);
+
 	if (!isWeekCalendar && firstDayOfCurrentMonth && dateOfTile.getMonth() !== firstDayOfCurrentMonth.getMonth()) {
 		return 'hidden-other-month-tile';
 	}
+
 	// collapsed 모드일 때는 !isCollapsed 조건이 false -> month 체크 안 함 -> 모든 타일 보임
 	// collapsed가 false일 때만 month 체크 -> 이번 달 아닌 타일 숨김
 
@@ -51,11 +53,14 @@ export const getTileClassName = ({
 	}
 
 	if (isWeekCalendar && selectedDate && (tileDate < startOfWeek! || tileDate > endOfWeek!)) {
-		return 'hidden-tile'; // 히든 타일로 바뀌면서 트랜지션 발생
+		return 'hidden-tile';
 	}
+
+	// marked date 여부
 	const dStr = `${tileDate.getFullYear()}-${String(tileDate.getMonth() + 1).padStart(2, '0')}-${String(tileDate.getDate()).padStart(2, '0')}`;
 	const hasMatch = markedDatesMap[dStr] > 0;
 
+	// predictionRange 처리
 	if (predictionRange && tileDate > predictionRange.end) {
 		const classes = ['disabled-after'];
 		const dayOfWeek = dateOfTile.getDay();
@@ -74,15 +79,25 @@ export const getTileClassName = ({
 		return classes.join(' ');
 	}
 
+	// 오늘 / 선택 상태
 	const isFocused = selectedDate && isSameDate(tileDate, selectedDate);
 	const isToday = isSameDate(tileDate, today);
 
-	let baseClass = '';
-	if (isFocused && isToday) baseClass = 'focused-today-tile';
-	else if (isFocused) baseClass = 'focused-tile';
-	else if (isToday) baseClass = 'not-focused-today-tile';
-	else if (tileDate < today) baseClass = isMatch ? 'past-tile pointer-events-none' : 'future-tile';
-	else baseClass = isMatch ? 'future-tile' : 'past-tile pointer-events-none';
+	if (isToday) {
+		if (isFocused) return 'focused-today-tile';
+		return 'not-focused-today-tile';
+	}
 
-	return `${baseClass} ${hasMatch ? 'has-match' : ''}`.trim();
+	// 활성화 / 비활성화 구분
+	if (isMatch) {
+		// 오늘 기준 과거 -> disabled
+		if (tileDate < today) return 'disabled-tile pointer-events-none';
+		// 오늘 포함 미래 -> active
+		return isFocused ? 'focused-tile' : 'active-tile';
+	} else {
+		// hasMatch 없으면 disabled
+		if (!hasMatch) return 'disabled-tile pointer-events-none';
+		// hasMatch 있으면 active
+		return isFocused ? 'focused-tile' : 'active-tile';
+	}
 };

--- a/src/lib/utils/date/calendar.ts
+++ b/src/lib/utils/date/calendar.ts
@@ -48,7 +48,7 @@ export const getTileClassName = ({
 	}
 
 	if (isCollapsed && selectedDate && (d < startOfWeek! || d > endOfWeek!)) {
-		return 'hidden-tile';
+		return 'hidden-tile'; // 히든 타일로 바뀌면서 트랜지션 발생
 	}
 	const dStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
 	const hasMatch = markedDatesMap[dStr] > 0;

--- a/src/lib/utils/date/calendar.ts
+++ b/src/lib/utils/date/calendar.ts
@@ -20,7 +20,7 @@ interface TileClassNameProps {
 	firstDayOfCurrentMonth: Date;
 	today: Date; // 오늘 날짜
 	selectedDate: Date | null; // 사용자가 선택한 날짜
-	isCollapsed: boolean;
+	isWeekCalendar: boolean;
 	isMatch: boolean;
 	predictionRange: { start: Date; end: Date } | null;
 	markedDatesMap: Record<string, number>;
@@ -30,13 +30,13 @@ export const getTileClassName = ({
 	firstDayOfCurrentMonth,
 	today,
 	selectedDate,
-	isCollapsed,
+	isWeekCalendar,
 	isMatch,
 	predictionRange,
 	markedDatesMap,
 }: TileClassNameProps) => {
 	const tileDate = stripTime(dateOfTile);
-	if (!isCollapsed && firstDayOfCurrentMonth && dateOfTile.getMonth() !== firstDayOfCurrentMonth.getMonth()) {
+	if (!isWeekCalendar && firstDayOfCurrentMonth && dateOfTile.getMonth() !== firstDayOfCurrentMonth.getMonth()) {
 		return 'hidden-other-month-tile';
 	}
 	// collapsed 모드일 때는 !isCollapsed 조건이 false -> month 체크 안 함 -> 모든 타일 보임
@@ -50,7 +50,7 @@ export const getTileClassName = ({
 		endOfWeek = getEndOfWeek(startOfWeek);
 	}
 
-	if (isCollapsed && selectedDate && (tileDate < startOfWeek! || tileDate > endOfWeek!)) {
+	if (isWeekCalendar && selectedDate && (tileDate < startOfWeek! || tileDate > endOfWeek!)) {
 		return 'hidden-tile'; // 히든 타일로 바뀌면서 트랜지션 발생
 	}
 	const dStr = `${tileDate.getFullYear()}-${String(tileDate.getMonth() + 1).padStart(2, '0')}-${String(tileDate.getDate()).padStart(2, '0')}`;

--- a/src/services/apis/calendar/index.ts
+++ b/src/services/apis/calendar/index.ts
@@ -29,7 +29,7 @@ export const getMonthlyMatchList = async (month: string): Promise<GetMonthlyMatc
 };
 
 // 승부 예측 가능 기간 조회 api
-export const getPredictionDates = async (): Promise<GetPredictionOpenPeriodResponse | null> => {
+export const getPredictionOpenPeriod = async (): Promise<GetPredictionOpenPeriodResponse | null> => {
 	try {
 		const response = await fetcher<GetPredictionOpenPeriodResponse>({
 			method: 'GET',

--- a/src/services/apis/calendar/index.ts
+++ b/src/services/apis/calendar/index.ts
@@ -71,7 +71,7 @@ export const getNextMatchDate = async (todayStr: string): Promise<GetNextMatchDa
 // 승부 예측
 
 // 내가 참여한 승부 예측 경기 날짜 조회 api (캘린더 점찍기 용) TODO: 이름 수정 필요
-export const getMyCalendar = async (): Promise<GetPredictionDatesResponse | null> => {
+export const getMyPredictionDates = async (): Promise<GetPredictionDatesResponse | null> => {
 	try {
 		const response = await fetcher<GetPredictionDatesResponse>({ method: 'GET', url: '/api/game/my-calendar' });
 

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -19,8 +19,8 @@
 	position: relative;
 	overflow: hidden;
 	transition:
-		max-height 1.5s ease,
-		opacity 1.5s ease;
+		height 0.5s ease,
+		opacity 0.5s ease;
 	padding: 30px 16px 38px 16px;
 }
 
@@ -29,8 +29,8 @@
 	width: 100%;
 	overflow: hidden;
 	transition:
-		max-height 1.5s ease,
-		opacity 1.5s ease;
+		height 0.5s ease,
+		opacity 0.5s ease;
 	padding: 26px 5px 48px 5px;
 }
 
@@ -221,8 +221,8 @@
 	margin: 0 !important;
 	opacity: 0 !important;
 	transition:
-		height 0.4s ease,
-		opacity 0.4s ease;
+		height 0.5s ease,
+		opacity 0.5s ease;
 }
 
 .hidden-other-month-tile {

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -117,13 +117,13 @@
 	font-weight: 500;
 	margin: 0;
 }
-/* 오늘 이전 날짜 */
-.custom-calendar .past-tile {
+/* 활성화 안 되는 날짜 */
+.custom-calendar .disabled-tile {
 	color: #cccccc;
 }
 
-/* 오늘 이후 날짜 */
-.custom-calendar .future-tile {
+/* 활성화 되는 날짜 */
+.custom-calendar .active-tile {
 	color: #000000;
 }
 

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -19,8 +19,8 @@
 	position: relative;
 	overflow: hidden;
 	transition:
-		height 0.5s ease,
-		opacity 0.5s ease;
+		max-height 0.8s ease,
+		opacity 0.8s ease;
 	padding: 30px 16px 38px 16px;
 }
 
@@ -29,8 +29,8 @@
 	width: 100%;
 	overflow: hidden;
 	transition:
-		height 0.5s ease,
-		opacity 0.5s ease;
+		max-height 0.8s ease,
+		opacity 0.8s ease;
 	padding: 26px 5px 48px 5px;
 }
 
@@ -46,20 +46,6 @@
 .custom-calendar .react-calendar__month-view__days {
 	display: grid !important;
 	grid-template-columns: repeat(7, 1fr);
-}
-
-.custom-calendar .year {
-	display: flex;
-	color: #000;
-	text-align: center;
-	font-size: 18px;
-	font-weight: 500;
-	line-height: 24px;
-}
-
-.custom-calendar-mobile .year {
-	font-size: 12px;
-	line-height: 16px;
 }
 
 .custom-calendar .month-number {
@@ -139,6 +125,7 @@
 	margin: 0;
 	border-radius: 0px;
 }
+
 /*승부 예측 기간이 아닌 날짜 타일의 border-radius*/
 .custom-calendar .react-calendar__month-view__days .disabled-after-week-start {
 	border-radius: 8px 0 0 8px;

--- a/src/styles/calendar-custom.css
+++ b/src/styles/calendar-custom.css
@@ -163,19 +163,6 @@
 	background-color: #fff;
 }
 
-.custom-calendar .today-text {
-	display: flex;
-	text-align: center;
-	font-size: 15px;
-	font-weight: 600;
-	line-height: 16px;
-}
-
-.custom-calendar-mobile .today-text {
-	font-size: 13px;
-	line-height: 18px;
-}
-
 .has-match {
 	padding-bottom: 12px !important;
 }


### PR DESCRIPTION
## 작업 내용
- 예측 결과의 주간 캘린더 UI 구현했습니다. 예측 결과일 때(=isMatch가 아닐 때)는 NavigationLabel에서 년도를 드롭다운으로 변경할 수 있도록 수정했습니다. NavigationLabel이 기존에는 단순히 JSX를 반환하는 render 함수였는데, 드롭다운 동작을 위해 state 관리가 필요해져서 컴포넌트로 수정했습니다!
- 승부 예측에서 달 이동을 단순히 이전 달은 막고 다음 달까지만 이동 가능하게 해놨던 걸 서버로부터 받은 predictionRange 값을 이용하는 로직으로 수정했습니다.
- 주간 캘린더일 때 문제였던 부분이 9월 마지막 주~ 10월 첫 주로 넘어가는 부분이었는데, 현재 날짜 셀 사이 간격을 마진으로 조정하다 보니 한 주가 꽉 채워지지 않은 주는 배치가 이상해져서 빈 div로 강제로 채울까 싶었지만, 마지막 주~ 첫 주가 이어지도록 수정했습니다. 

<img width="300" height="345" alt="스크린샷 2025-09-28 오후 5 13 48" src="https://github.com/user-attachments/assets/f60ff889-deb2-4412-bbab-55f2fad0ccb5" />
<img width="300" height="284" alt="스크린샷 2025-09-28 오후 5 14 01" src="https://github.com/user-attachments/assets/aabbf356-3fec-4f72-8fe1-ad42e8f4d072" />

(1번 사진에서 오른쪽 화살표를 누르면 2번 사진이 됨. 1번 사진에서 1일을 선택하면 10월 1일의 값이 전달 되도록 함.)

<img width="300" height="269" alt="스크린샷 2025-09-28 오후 5 28 40" src="https://github.com/user-attachments/assets/91f1ee81-7921-4845-906e-4bd11c07d5bf" />

- 전에 피드백 주신대로 날짜 셀의 스타일링을 과거, 현재, 미래 시간으로 나누지 않고 활성화 / 비활성화 상태로 나누어 표현했습니다.
- 상태명, 함수명들을 좀 더 명확하게 수정했습니다.

## 남은 작업
- 서버가 복구되면 전체적으로 문제가 없는지 확인해야 합니다.
- 예측 결과 탭에서는 년도를 드롭다운으로 표시하는데, 이에 대한 정보가 서버 응답으로 내려오지 않는 것 같아서 요청 드린 상태이고 일단 고정 값으로 2025, 2026 넣어서 퍼블리싱 해두었습니다.
<img width="200" height="226" alt="스크린샷 2025-09-28 오후 5 42 48" src="https://github.com/user-attachments/assets/1bc73842-17cc-4fab-ba59-941670e68532" />

- predictionRange가 아닐 때 오픈 기간 label 얹는 작업 남았습니다. 