### PR TITLE
[KO-600] 기존 기능 disabled

### DIFF
--- a/src/app/(with-side)/layout.tsx
+++ b/src/app/(with-side)/layout.tsx
@@ -1,12 +1,11 @@
 import { ReactNode, Suspense } from 'react';
 import LeftSide from '@/components/layouts/with-side/left-side';
-import RightSide from '@/components/layouts/with-side/right-side';
 import FloatingWritingButton from '@/components/layouts/with-side/floating-writing-button';
 
 export default function Layout({ children }: { children: ReactNode }) {
 	return (
 		<div
-			className="pt-4 max-w-[85rem] m-auto grid gap-6 desktop:grid-cols-[1fr_auto_1fr]
+			className="pt-4 m-auto grid gap-6 desktop:grid-cols-[auto_auto]
 				min-[1094px]:grid-cols-[auto_auto] min-[1094px]:justify-center"
 		>
 			<LeftSide />
@@ -18,7 +17,7 @@ export default function Layout({ children }: { children: ReactNode }) {
 					</Suspense>
 				</div>
 			</main>
-			<RightSide />
+			{/*<RightSide />*/}
 		</div>
 	);
 }

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -1,15 +1,11 @@
 'use client';
 
-import RecommendedContent from '@/components/common/recommended-content';
 import PredictLeagueTab from '@/components/features/home/predict-league-tab';
-import TodaysHalftime from '@/components/features/home/todays-halftime';
-import useIsDesktop from '@/lib/hooks/useIsDesktop';
-import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
-import { Suspense, useEffect } from 'react';
+import { useEffect } from 'react';
 
 export default function Home() {
-	const { currentUserInfo } = useCurrentUserInfoStore();
-	const isDesktop = useIsDesktop();
+	// const { currentUserInfo } = useCurrentUserInfoStore();
+	// const isDesktop = useIsDesktop();
 
 	useEffect(() => {
 		document.body.style.backgroundColor = 'var(--color-black-800)';
@@ -20,22 +16,31 @@ export default function Home() {
 	}, []);
 
 	return (
-		<div className="flex flex-col gap-4">
+		<div className="grid grid-cols-1 min-[120rem]:grid-cols-2 gap-6 pb-90">
 			{/* 승부 예측 */}
 			<div className="bg-black-000 rounded-[0.625rem]">
 				<PredictLeagueTab />
 			</div>
+			<div className="bg-black-000 rounded-[0.625rem]">
+				<PredictLeagueTab />
+			</div>
+			<div className="bg-black-000 rounded-[0.625rem]">
+				<PredictLeagueTab />
+			</div>
+			<div className="bg-black-000 rounded-[0.625rem]">
+				<PredictLeagueTab />
+			</div>
 
-			{!isDesktop && <TodaysHalftime />}
+			{/*{!isDesktop && <TodaysHalftime />}*/}
 
 			{/* 추천 뉴스 및 게시글 */}
-			<Suspense>
-				<RecommendedContent
-					mode={'news'}
-					teamName={currentUserInfo?.favoriteTeams[0]?.nameKr || currentUserInfo?.favoriteTeams[0]?.nameEn || undefined}
-				/>
-				<RecommendedContent mode={'board'} />
-			</Suspense>
+			{/*<Suspense>*/}
+			{/*	<RecommendedContent*/}
+			{/*		mode={'news'}*/}
+			{/*		teamName={currentUserInfo?.favoriteTeams[0]?.nameKr || currentUserInfo?.favoriteTeams[0]?.nameEn || undefined}*/}
+			{/*	/>*/}
+			{/*	<RecommendedContent mode={'board'} />*/}
+			{/*</Suspense>*/}
 		</div>
 	);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,10 +5,10 @@ import Footer from '@/components/layouts/root/footer';
 import MinWidth from '@/components/layouts/root/min-width';
 import LoginPortal from '@/components/layouts/root/navbar/login-portal';
 import MarginWrapper from '@/components/layouts/root/margin-wrapper';
-import Navbar from '@/components/layouts/root/navbar';
 import NotificationInitializer from '@/components/layouts/root/navbar/notification-initializer';
 import ReactQueryProvider from '@/lib/provider/react-query-provider';
 import { DOMAIN_URL } from '@/services/config/constants';
+import MobileNavbar from '@/components/layouts/root/mobile-navbar';
 
 export const metadata: Metadata = {
 	metadataBase: new URL(DOMAIN_URL),
@@ -60,7 +60,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 				<NotificationInitializer />
 				<div className="@container relative">
 					<ReactQueryProvider>
-						<Navbar />
+						<MobileNavbar />
 						<LoginPortal />
 						<MarginWrapper>
 							{/*<Banner />*/}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,12 +2,10 @@ import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import '@/styles/globals.css';
 import Footer from '@/components/layouts/root/footer';
-import Banner from '@/components/layouts/root/banner';
 import MinWidth from '@/components/layouts/root/min-width';
 import LoginPortal from '@/components/layouts/root/navbar/login-portal';
 import MarginWrapper from '@/components/layouts/root/margin-wrapper';
 import Navbar from '@/components/layouts/root/navbar';
-import PaddingWrapper from '@/components/layouts/root/padding-wrapper';
 import NotificationInitializer from '@/components/layouts/root/navbar/notification-initializer';
 import ReactQueryProvider from '@/lib/provider/react-query-provider';
 import { DOMAIN_URL } from '@/services/config/constants';
@@ -60,13 +58,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 		<html lang="ko" className={`antialiased ${pretendard.className}`}>
 			<body>
 				<NotificationInitializer />
-				<div className="@container">
+				<div className="@container relative">
 					<ReactQueryProvider>
 						<Navbar />
 						<LoginPortal />
 						<MarginWrapper>
-							<Banner />
-							<PaddingWrapper>{children}</PaddingWrapper>
+							{/*<Banner />*/}
+							{/*<PaddingWrapper>{children}</PaddingWrapper>*/}
+							{children}
 							<Footer />
 							<MinWidth />
 						</MarginWrapper>

--- a/src/components/features/home/predict-league-tab.tsx
+++ b/src/components/features/home/predict-league-tab.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import PredictCardList from './predict-card-list';
+import ComponentFrame from '@/components/common/component-frame';
 
 export default function PredictLeagueTab() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
@@ -48,7 +49,7 @@ export default function PredictLeagueTab() {
 	}, [currentUserInfo, favoriteTeamLength]);
 
 	return (
-		<div>
+		<ComponentFrame isMain={true}>
 			{/* 탭 바 */}
 			<div
 				className="relative w-full flex rounded-t-[0.625rem] bg-black-200 header-medium
@@ -102,6 +103,6 @@ export default function PredictLeagueTab() {
 			<div className="pt-7 bg-black-000 rounded-b-[0.625rem]">
 				<PredictCardList teamPk={selectedTeamPk} />
 			</div>
-		</div>
+		</ComponentFrame>
 	);
 }

--- a/src/components/layouts/root/footer.tsx
+++ b/src/components/layouts/root/footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
 		const src = isHome ? '/logo/without-icon-black.svg' : '/logo/without-icon-white.svg';
 
 		return (
-			<div className={`${bgColor} h-[13.125rem] flex items-center`}>
+			<div className={`${bgColor} h-[13.125rem] flex items-center absolute bottom-0 left-0 right-0`}>
 				<div
 					className={`${textColor} flex items-start max-w-[85rem]
 						gap-[3.625rem] mx-auto @mobile:flex-col @mobile:gap-6 @mobile:pl-6 @mobile:ml-0`}

--- a/src/components/layouts/root/margin-wrapper.tsx
+++ b/src/components/layouts/root/margin-wrapper.tsx
@@ -14,5 +14,6 @@ export default function MarginWrapper({ children }: { children: React.ReactNode 
 		setHasMargin(isMobileNavbar && !isFullScreen(pathname));
 	}, [pathname, isMobileNavbar]);
 
-	return <div className={hasMargin ? 'mt-16' : ''}>{children}</div>;
+	// return <div className={hasMargin ? 'mt-16' : ''}>{children}</div>;
+	return <div className="mt-16">{children}</div>;
 }

--- a/src/components/layouts/root/mobile-navbar/index.tsx
+++ b/src/components/layouts/root/mobile-navbar/index.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import clsx from 'clsx';
 import { useCallback, useState } from 'react';
 import Sidebar from './sidebar';
-import SideNavbar from './sidebar/side-navbar';
 import { default as SideProfile } from '../navbar/profile';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { NavButton } from '../navbar';
@@ -56,9 +55,10 @@ export default function MobileNavbar({ navButtons }: { navButtons: NavButton[] }
 		<>
 			<header className="fixed w-full top-0 z-40 transition-colors ease-out">
 				<div className={clsx('relative h-16 px-4 grid grid-cols-3 justify-between items-center', bgColor)}>
-					<button aria-label={'메뉴'} onClick={handleToggleMenu} className={`w-fit ${isHome ? '' : 'invert'}`}>
-						<Image aria-hidden={true} src={'/hamburger.svg'} alt="" width={24} height={24} />
-					</button>
+					{/*<button aria-label={'메뉴'} onClick={handleToggleMenu} className={`w-fit ${isHome ? '' : 'invert'}`}>*/}
+					{/*	<Image aria-hidden={true} src={'/hamburger.svg'} alt="" width={24} height={24} />*/}
+					{/*</button>*/}
+					<div />
 					<Link href="/" aria-label={'홈으로 이동'} className="w-auto h-full flex justify-center">
 						<Image aria-hidden={true} src={'/logo/icon-red.svg'} alt="" width={45} height={36} />
 					</Link>
@@ -66,9 +66,9 @@ export default function MobileNavbar({ navButtons }: { navButtons: NavButton[] }
 				</div>
 			</header>
 
-			<Sidebar side={'left'} isMenuOpen={isMenuOpen} isBgVisible={isMenuBgVisible} handleToggleMenu={handleToggleMenu}>
-				<SideNavbar onClickButton={handleToggleMenu} navButtons={navButtons} />
-			</Sidebar>
+			{/*<Sidebar side={'left'} isMenuOpen={isMenuOpen} isBgVisible={isMenuBgVisible} handleToggleMenu={handleToggleMenu}>*/}
+			{/*	<SideNavbar onClickButton={handleToggleMenu} navButtons={navButtons} />*/}
+			{/*</Sidebar>*/}
 
 			{currentUserInfo && (
 				<Sidebar

--- a/src/components/layouts/root/mobile-navbar/index.tsx
+++ b/src/components/layouts/root/mobile-navbar/index.tsx
@@ -8,15 +8,13 @@ import { useCallback, useState } from 'react';
 import Sidebar from './sidebar';
 import { default as SideProfile } from '../navbar/profile';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
-import { NavButton } from '../navbar';
 import { isFullScreen } from '@/lib/utils';
 import RightButtons from '../navbar/right-buttons';
 import useIsMobile from '@/lib/hooks/useIsMobile';
+import { NavButton } from '@/components/layouts/root/navbar';
 
-export default function MobileNavbar({ navButtons }: { navButtons: NavButton[] }) {
-	const [isMenuOpen, setIsMenuOpen] = useState(false);
+export default function MobileNavbar({ navButtons }: { navButtons?: NavButton[] }) {
 	const [isProfileOpen, setIsProfileOpen] = useState(false);
-	const [isMenuBgVisible, setIsMenuBgVisible] = useState(false);
 	const [isProfileBgVisible, setIsProfileBgVisible] = useState(false);
 
 	const { currentUserInfo } = useCurrentUserInfoStore();
@@ -24,16 +22,6 @@ export default function MobileNavbar({ navButtons }: { navButtons: NavButton[] }
 	const pathname = usePathname();
 	const isHome = pathname === '/';
 	const bgColor = isHome ? 'bg-black-000' : 'bg-black-800';
-
-	const handleToggleMenu = useCallback(() => {
-		if (isMenuOpen) {
-			setIsMenuOpen(false);
-			setTimeout(() => setIsMenuBgVisible(false), 200);
-		} else {
-			setIsMenuBgVisible(true);
-			setTimeout(() => setIsMenuOpen(true), 10);
-		}
-	}, [isMenuOpen]);
 
 	const handleToggleProfile = useCallback(() => {
 		if (isProfileOpen) {
@@ -55,9 +43,6 @@ export default function MobileNavbar({ navButtons }: { navButtons: NavButton[] }
 		<>
 			<header className="fixed w-full top-0 z-40 transition-colors ease-out">
 				<div className={clsx('relative h-16 px-4 grid grid-cols-3 justify-between items-center', bgColor)}>
-					{/*<button aria-label={'메뉴'} onClick={handleToggleMenu} className={`w-fit ${isHome ? '' : 'invert'}`}>*/}
-					{/*	<Image aria-hidden={true} src={'/hamburger.svg'} alt="" width={24} height={24} />*/}
-					{/*</button>*/}
 					<div />
 					<Link href="/" aria-label={'홈으로 이동'} className="w-auto h-full flex justify-center">
 						<Image aria-hidden={true} src={'/logo/icon-red.svg'} alt="" width={45} height={36} />
@@ -65,10 +50,6 @@ export default function MobileNavbar({ navButtons }: { navButtons: NavButton[] }
 					<RightButtons isMobile={true} onClickProfile={handleToggleProfile} />
 				</div>
 			</header>
-
-			{/*<Sidebar side={'left'} isMenuOpen={isMenuOpen} isBgVisible={isMenuBgVisible} handleToggleMenu={handleToggleMenu}>*/}
-			{/*	<SideNavbar onClickButton={handleToggleMenu} navButtons={navButtons} />*/}
-			{/*</Sidebar>*/}
 
 			{currentUserInfo && (
 				<Sidebar

--- a/src/components/layouts/root/navbar/index.tsx
+++ b/src/components/layouts/root/navbar/index.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import Image from 'next/image';
-import useIsTabletWidth from '@/lib/hooks/useIsTabletWidth';
 import MobileNavbar from '../mobile-navbar';
-import useIsLeftSideVisible from '@/lib/hooks/useIsLeftSideVisible';
-import useIsDesktop from '@/lib/hooks/useIsDesktop';
-import RightButtons from './right-buttons';
-import Link from 'next/link';
 
 export interface NavButton {
 	href: string;
@@ -17,11 +11,11 @@ export interface NavButton {
 
 export default function Navbar() {
 	const pathname = usePathname();
-	const isHome = pathname === '/';
+	// const isHome = pathname === '/';
 
-	const isDesktop = useIsDesktop();
-	const isTabletWidth = useIsTabletWidth();
-	const isLeftSideBarVisible = useIsLeftSideVisible();
+	// const isDesktop = useIsDesktop();
+	// const isTabletWidth = useIsTabletWidth();
+	// const isLeftSideBarVisible = useIsLeftSideVisible();
 
 	const navButtons = [
 		{ href: '/', content: '홈', isActive: pathname === '/' },
@@ -32,43 +26,45 @@ export default function Navbar() {
 		{ href: '/ranking', content: '랭킹', isActive: pathname.includes('/ranking') },
 	];
 
-	const filteredNavButtons = navButtons.filter((button) => {
-		// isLeftSideBarVisible이 true일 때 홈/랭킹 버튼 숨김
-		if (isLeftSideBarVisible && (button.href === '/' || button.href === '/ranking')) {
-			return false;
-		}
-		return true;
-	});
+	// const filteredNavButtons = navButtons.filter((button) => {
+	// 	// isLeftSideBarVisible이 true일 때 홈/랭킹 버튼 숨김
+	// 	if (isLeftSideBarVisible && (button.href === '/' || button.href === '/ranking')) {
+	// 		return false;
+	// 	}
+	// 	return true;
+	// });
 
-	if (!isDesktop === null) return null;
+	// if (isDesktop === null) return null;
+
+	return <MobileNavbar navButtons={navButtons} />;
 
 	// 모바일, 태블릿, 데스크톱에서 width가 충분히 작은 경우 MobileNavbar
-	return !isDesktop || !isLeftSideBarVisible ? (
-		<MobileNavbar navButtons={navButtons} />
-	) : (
-		<header className={`${isHome ? 'bg-black-000' : 'bg-black-800'} sticky z-30 transition-colors ease-out`}>
-			<div className="flex justify-between items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
-				<nav className="flex items-center">
-					<Link
-						className="px-6 py-3 ml-[1rem] mr-[4.125rem] tablet:px-2.5 tablet:mx-0 box-content"
-						href={'/'}
-						aria-label={'홈으로 이동'}
-					>
-						<Image
-							aria-hidden={true}
-							width={216}
-							height={48}
-							src={isHome ? '/logo/kick-on-black.svg' : '/logo/kick-on-white.svg'}
-							alt=""
-						/>
-					</Link>
-
-					{/*{filteredNavButtons.map((props) => (*/}
-					{/*	<NavButton key={props.content} {...props} />*/}
-					{/*))}*/}
-				</nav>
-				<RightButtons isTabletWidth={isTabletWidth} />
-			</div>
-		</header>
-	);
+	// return !isDesktop || !isLeftSideBarVisible ? (
+	// 	<MobileNavbar navButtons={navButtons} />
+	// ) : (
+	// 	<header className={`${isHome ? 'bg-black-000' : 'bg-black-800'} sticky z-30 transition-colors ease-out`}>
+	// 		<div className="flex justify-between items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
+	// 			<nav className="flex items-center">
+	// 				<Link
+	// 					className="px-6 py-3 ml-[1rem] mr-[4.125rem] tablet:px-2.5 tablet:mx-0 box-content"
+	// 					href={'/'}
+	// 					aria-label={'홈으로 이동'}
+	// 				>
+	// 					<Image
+	// 						aria-hidden={true}
+	// 						width={216}
+	// 						height={48}
+	// 						src={isHome ? '/logo/kick-on-black.svg' : '/logo/kick-on-white.svg'}
+	// 						alt=""
+	// 					/>
+	// 				</Link>
+	//
+	// 				{filteredNavButtons.map((props) => (
+	// 					<NavButton key={props.content} {...props} />
+	// 				))}
+	// 			</nav>
+	// 			<RightButtons isTabletWidth={isTabletWidth} />
+	// 		</div>
+	// 	</header>
+	// );
 }

--- a/src/components/layouts/root/navbar/index.tsx
+++ b/src/components/layouts/root/navbar/index.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { usePathname, useRouter } from 'next/navigation';
-import NavButton from './nav-button';
+import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 import useIsTabletWidth from '@/lib/hooks/useIsTabletWidth';
 import MobileNavbar from '../mobile-navbar';
@@ -17,7 +16,6 @@ export interface NavButton {
 }
 
 export default function Navbar() {
-	const router = useRouter();
 	const pathname = usePathname();
 	const isHome = pathname === '/';
 
@@ -65,9 +63,9 @@ export default function Navbar() {
 						/>
 					</Link>
 
-					{filteredNavButtons.map((props) => (
-						<NavButton key={props.content} {...props} />
-					))}
+					{/*{filteredNavButtons.map((props) => (*/}
+					{/*	<NavButton key={props.content} {...props} />*/}
+					{/*))}*/}
 				</nav>
 				<RightButtons isTabletWidth={isTabletWidth} />
 			</div>

--- a/src/components/layouts/root/navbar/index.tsx
+++ b/src/components/layouts/root/navbar/index.tsx
@@ -1,7 +1,14 @@
 'use client';
 
+import Link from 'next/link';
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 import MobileNavbar from '../mobile-navbar';
+import useIsDesktop from '@/lib/hooks/useIsDesktop';
+import useIsLeftSideVisible from '@/lib/hooks/useIsLeftSideVisible';
+import useIsTabletWidth from '@/lib/hooks/useIsTabletWidth';
+import RightButtons from '@/components/layouts/root/navbar/right-buttons';
+import NavButton from '@/components/layouts/root/navbar/nav-button';
 
 export interface NavButton {
 	href: string;
@@ -11,11 +18,11 @@ export interface NavButton {
 
 export default function Navbar() {
 	const pathname = usePathname();
-	// const isHome = pathname === '/';
+	const isHome = pathname === '/';
 
-	// const isDesktop = useIsDesktop();
-	// const isTabletWidth = useIsTabletWidth();
-	// const isLeftSideBarVisible = useIsLeftSideVisible();
+	const isDesktop = useIsDesktop();
+	const isTabletWidth = useIsTabletWidth();
+	const isLeftSideBarVisible = useIsLeftSideVisible();
 
 	const navButtons = [
 		{ href: '/', content: '홈', isActive: pathname === '/' },
@@ -26,45 +33,43 @@ export default function Navbar() {
 		{ href: '/ranking', content: '랭킹', isActive: pathname.includes('/ranking') },
 	];
 
-	// const filteredNavButtons = navButtons.filter((button) => {
-	// 	// isLeftSideBarVisible이 true일 때 홈/랭킹 버튼 숨김
-	// 	if (isLeftSideBarVisible && (button.href === '/' || button.href === '/ranking')) {
-	// 		return false;
-	// 	}
-	// 	return true;
-	// });
+	const filteredNavButtons = navButtons.filter((button) => {
+		// isLeftSideBarVisible이 true일 때 홈/랭킹 버튼 숨김
+		if (isLeftSideBarVisible && (button.href === '/' || button.href === '/ranking')) {
+			return false;
+		}
+		return true;
+	});
 
-	// if (isDesktop === null) return null;
-
-	return <MobileNavbar navButtons={navButtons} />;
+	if (isDesktop === null) return null;
 
 	// 모바일, 태블릿, 데스크톱에서 width가 충분히 작은 경우 MobileNavbar
-	// return !isDesktop || !isLeftSideBarVisible ? (
-	// 	<MobileNavbar navButtons={navButtons} />
-	// ) : (
-	// 	<header className={`${isHome ? 'bg-black-000' : 'bg-black-800'} sticky z-30 transition-colors ease-out`}>
-	// 		<div className="flex justify-between items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
-	// 			<nav className="flex items-center">
-	// 				<Link
-	// 					className="px-6 py-3 ml-[1rem] mr-[4.125rem] tablet:px-2.5 tablet:mx-0 box-content"
-	// 					href={'/'}
-	// 					aria-label={'홈으로 이동'}
-	// 				>
-	// 					<Image
-	// 						aria-hidden={true}
-	// 						width={216}
-	// 						height={48}
-	// 						src={isHome ? '/logo/kick-on-black.svg' : '/logo/kick-on-white.svg'}
-	// 						alt=""
-	// 					/>
-	// 				</Link>
-	//
-	// 				{filteredNavButtons.map((props) => (
-	// 					<NavButton key={props.content} {...props} />
-	// 				))}
-	// 			</nav>
-	// 			<RightButtons isTabletWidth={isTabletWidth} />
-	// 		</div>
-	// 	</header>
-	// );
+	return !isDesktop || !isLeftSideBarVisible ? (
+		<MobileNavbar navButtons={navButtons} />
+	) : (
+		<header className={`${isHome ? 'bg-black-000' : 'bg-black-800'} sticky z-30 transition-colors ease-out`}>
+			<div className="flex justify-between items-center h-[4.5rem] max-w-[85rem] min-w-[48rem] max-[1094px]:w-[48rem] max-[1440px]:w-[62.5rem] m-auto">
+				<nav className="flex items-center">
+					<Link
+						className="px-6 py-3 ml-[1rem] mr-[4.125rem] tablet:px-2.5 tablet:mx-0 box-content"
+						href={'/'}
+						aria-label={'홈으로 이동'}
+					>
+						<Image
+							aria-hidden={true}
+							width={216}
+							height={48}
+							src={isHome ? '/logo/kick-on-black.svg' : '/logo/kick-on-white.svg'}
+							alt=""
+						/>
+					</Link>
+
+					{filteredNavButtons.map((props) => (
+						<NavButton key={props.content} {...props} />
+					))}
+				</nav>
+				<RightButtons isTabletWidth={isTabletWidth} />
+			</div>
+		</header>
+	);
 }

--- a/src/components/layouts/root/navbar/right-buttons.tsx
+++ b/src/components/layouts/root/navbar/right-buttons.tsx
@@ -13,7 +13,7 @@ interface RightButtonsProps {
 	onClickProfile?: () => void;
 }
 
-export default function RightButton({ isMobile = false, isTabletWidth = false, onClickProfile }: RightButtonsProps) {
+export default function RightButtons({ isMobile = false, isTabletWidth = false, onClickProfile }: RightButtonsProps) {
 	const pathname = usePathname();
 	const { currentUserInfo } = useCurrentUserInfoStore();
 

--- a/src/components/layouts/with-side/left-side.tsx
+++ b/src/components/layouts/with-side/left-side.tsx
@@ -13,7 +13,7 @@ export default function LeftSide() {
 	return (
 		<aside className="flex flex-col gap-4">
 			<RankingList mode="season" />
-			<RankingList mode="predict" />
+			{/*<RankingList mode="predict" />*/}
 		</aside>
 	);
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const ALLOWED_ROUTES = ['/', '/login', '/signup', '/auth', '/leave', '/profile-setting', '/ranking', '/notice', '/404'];
+
+export function middleware(request: NextRequest) {
+	const { pathname } = request.nextUrl;
+
+	// matcher가 거르지 못한 나머지 정적 파일(.png, .jpg, .svg 등) 통과
+	if (pathname.includes('.')) {
+		return NextResponse.next();
+	}
+
+	const isProd = process.env.NEXT_PUBLIC_NODE_ENV === 'prod';
+	const isAllowed = ALLOWED_ROUTES.includes(pathname);
+	if (isProd && !isAllowed) {
+		return NextResponse.redirect(new URL('/404', request.url));
+	}
+
+	return NextResponse.next();
+}
+
+export const config = {
+	matcher: [
+		/*
+		 * 아래와 같은 경로를 제외한 모든 요청 경로에서 미들웨어 실행:
+		 * - api (API routes)
+		 * - _next/static (static files)
+		 * - _next/image (image optimization files)
+		 * - favicon.ico (favicon file)
+		 */
+		'/((?!api|_next/static|_next/image|favicon.ico).*)',
+	],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,7 @@ export function middleware(request: NextRequest) {
 	}
 
 	const isProd = process.env.NEXT_PUBLIC_NODE_ENV === 'prod';
-	const isAllowed = ALLOWED_ROUTES.includes(pathname);
+	const isAllowed = ALLOWED_ROUTES.some((route) => route.startsWith(pathname));
 	if (isProd && !isAllowed) {
 		return NextResponse.redirect(new URL('/404', request.url));
 	}


### PR DESCRIPTION
## 작업 내용
### 기존 기능 관련 페이지 disabled(404)
- 미들웨어 파일 확인해 주세요!
- 개발 환경에서는 페이지 접근이 가능하나, 운영 환경에서는 404가 뜨도록 처리했습니다. 테스트하실 때에는 isProd 분기를 true로 설정하고 해보시면 될 것 같습니다. 

### 기존 기능 관련 컴포넌트 등 disabled(주석 처리)
- 아예 주석까지 삭제하는 게 나을 것 같으면 말씀해주세용

### 전체 레이아웃 수정
- 우측 사이드바가 빠짐에 따라서 사이드바 형태를 모바일 사이드바로 통일했습니다.
  (기존 우측 사이드바에 있던 프로필 컴포넌트 렌더링 문제)
- 승부예측 카드는 반응형으로 1-2열 그리딩했습니다.
- 캘린더 작업하실 때에는 LeftSide 컴포넌트에 작업하시면 될 것 같습니다!

## 작업 화면
<img width="1352" height="698" alt="image" src="https://github.com/user-attachments/assets/5a5c7db0-d302-4c8f-9476-361f72bf92f1" />

- 우측 사이드바가 빠짐에 따라서 사이드바 형태를 모바일 사이드바로 통일했습니다. (기존 우측 사이드바에 있던 프로필 컴포넌트 렌더링 문제)
- 승부예측 카드는 반응형으로 1-2열 그리딩했습니다.
- 팀별로 경기를 조회할 수 있는지, 전체 경기를 조회할 수 있는지 그 기능에 따라 홈 화면에 승부예측 카드 레이아웃은 변경될 예정입니다. 우선 캘린더 작업과 충돌 없도록 전체 레이아웃 잡는 작업만 진행했습니다. 캘린더 작업하실 때에는 LeftSide 컴포넌트에 작업하시면 될 것 같습니다!