### PR TITLE
[KO-604] 경기 댓글 api 연동

### DIFF
--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -29,8 +29,8 @@ export default function Home() {
 		const fetchGames = async () => {
 			try {
 				const [proceedingRes, finishedRes] = await Promise.all([
-					getGames({ league: 2, status: 'proceeding', team: undefined }),
-					getGames({ league: 2, status: 'finished', team: undefined }),
+					getGames({ league: 1, status: 'proceeding', team: undefined }),
+					getGames({ league: 1, status: 'finished', team: undefined }),
 				]);
 
 				const proceedingGames = proceedingRes?.data ?? [];

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -48,18 +48,31 @@ export default function Home() {
 	return (
 		<div className="grid grid-cols-1 min-[120rem]:grid-cols-2 gap-6 pb-90">
 			{/* 승부 예측 */}
-			{games.map((game) => (
+			{games.length === 0 ? (
 				<div
-					key={game.pk}
-					className={clsx('py-4 space-y-3 max-w-[41.75rem] bg-white rounded-lg border border-black-300', {
-						'w-[41.75rem]': !isMobile,
-					})}
+					className={clsx(
+						'text-center text-subtitle-02 py-10 space-y-3 max-w-[41.75rem] bg-white rounded-lg border border-black-300',
+						{
+							'w-[41.75rem]': !isMobile,
+						},
+					)}
 				>
-					<PredictCard key={game.pk} type={game.homeScore !== null ? 'finished' : 'proceeding'} game={game} />
-					{game.homeScore !== null && <AiAnalytics pk={game.pk} />}
-					<GameComment pk={game.pk} />
+					지금은 진행 중인 경기가 없어요.
 				</div>
-			))}
+			) : (
+				games.map((game) => (
+					<div
+						key={game.pk}
+						className={clsx('py-4 space-y-3 max-w-[41.75rem] bg-white rounded-lg border border-black-300', {
+							'w-[41.75rem]': !isMobile,
+						})}
+					>
+						<PredictCard key={game.pk} type={game.homeScore !== null ? 'finished' : 'proceeding'} game={game} />
+						{game.homeScore !== null && <AiAnalytics pk={game.pk} />}
+						<GameComment pk={game.pk} />
+					</div>
+				))
+			)}
 		</div>
 	);
 }

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import PredictCard from '@/components/features/home/predict-card';
-import { GameDto } from '@/services/apis/game/game.type';
+import { GameTaggedLeagueDto } from '@/services/apis/game/game.type';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import AiAnalytics from '@/components/features/home/ai-analytics';
 import clsx from 'clsx';
@@ -13,7 +13,7 @@ import FetchingFailedCard from '@/components/common/fetching-failed-card';
 
 export default function Home() {
 	const isMobile = useIsMobile();
-	const [games, setGames] = useState<GameDto[]>([]);
+	const [games, setGames] = useState<GameTaggedLeagueDto[]>([]);
 	const [isError, setIsError] = useState(false);
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
@@ -33,8 +33,8 @@ export default function Home() {
 					getGames({ league: 2, status: 'finished', team: undefined }),
 				]);
 
-				const proceedingGames = proceedingRes?.data.games ?? [];
-				const finishedGames = finishedRes?.data.games ?? [];
+				const proceedingGames = proceedingRes?.data ?? [];
+				const finishedGames = finishedRes?.data ?? [];
 
 				setGames([...proceedingGames, ...finishedGames]);
 			} catch (error) {
@@ -75,18 +75,25 @@ export default function Home() {
 					지금은 진행 중인 경기가 없어요.
 				</div>
 			) : (
-				games.map((game) => (
-					<div
-						key={game.pk}
-						className={clsx('py-4 space-y-3 max-w-[41.75rem] bg-white rounded-lg border border-black-300', {
-							'w-[41.75rem]': !isMobile,
-						})}
-					>
-						<PredictCard key={game.pk} type={game.homeScore !== null ? 'finished' : 'proceeding'} game={game} />
-						{game.homeScore !== null && <AiAnalytics pk={game.pk} />}
-						<GameComment pk={game.pk} />
-					</div>
-				))
+				games.flatMap(({ league, games }) =>
+					games.map((game) => (
+						<div
+							key={game.pk}
+							className={clsx('py-4 space-y-3 max-w-[41.75rem] bg-white rounded-lg border border-black-300', {
+								'w-[41.75rem]': !isMobile,
+							})}
+						>
+							<PredictCard
+								key={game.pk}
+								type={game.homeScore !== null ? 'finished' : 'proceeding'}
+								league={league}
+								game={game}
+							/>
+							{game.homeScore !== null && <AiAnalytics pk={game.pk} />}
+							<GameComment pk={game.pk} />
+						</div>
+					)),
+				)
 			)}
 		</div>
 	);

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -84,7 +84,6 @@ export default function Home() {
 							})}
 						>
 							<PredictCard
-								key={game.pk}
 								type={game.homeScore !== null ? 'finished' : 'proceeding'}
 								league={league}
 								game={game}

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import GameComment from '@/components/features/home/game-comment';
 import { getGames } from '@/services/apis/game/game.api';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import FetchingFailedCard from '@/components/common/fetching-failed-card';
 
 export default function Home() {
 	const isMobile = useIsMobile();
@@ -44,7 +45,21 @@ export default function Home() {
 		fetchGames();
 	}, [currentUserInfo]);
 
-	// TODO: 경기가 없는 경우, 에러난 경우 처리 필요
+	if (isError) {
+		return (
+			<div
+				className={clsx(
+					'text-center text-subtitle-02 py-10 space-y-3 max-w-[41.75rem] bg-white rounded-lg border border-black-300',
+					{
+						'w-[41.75rem]': !isMobile,
+					},
+				)}
+			>
+				<FetchingFailedCard height="" marginTop="" />
+			</div>
+		);
+	}
+
 	return (
 		<div className="grid grid-cols-1 min-[120rem]:grid-cols-2 gap-6 pb-90">
 			{/* 승부 예측 */}

--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import PredictCard from '@/components/features/home/predict-card';
 import { GameDto } from '@/services/apis/game/game.type';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import AiAnalytics from '@/components/features/home/ai-analytics';
 import clsx from 'clsx';
 import GameComment from '@/components/features/home/game-comment';
+import { getGames } from '@/services/apis/game/game.api';
+import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 
 export default function Home() {
 	const isMobile = useIsMobile();
+	const [games, setGames] = useState<GameDto[]>([]);
+	const [isError, setIsError] = useState(false);
+	const { currentUserInfo } = useCurrentUserInfoStore();
 
 	useEffect(() => {
 		document.body.style.backgroundColor = 'var(--color-black-800)';
@@ -19,121 +24,27 @@ export default function Home() {
 		};
 	}, []);
 
-	// 여기서 경기 조회
-	const games: GameDto[] = [
-		{
-			pk: 1,
-			league: {
-				pk: 1,
-				nameKr: '프리미어리그',
-				nameEn: 'Premier League',
-				logoUrl: '/league-logo/premier-league.svg',
-			},
-			homeTeam: {
-				pk: 1,
-				nameKr: '아스널',
-				nameEn: 'Arsenal',
-				logoUrl: '/team-logo/arsenal.svg',
-			},
-			awayTeam: {
-				pk: 2,
-				nameKr: '첼시',
-				nameEn: 'Chelsea',
-				logoUrl: '/team-logo/chelsea.svg',
-			},
-			gambleResult: {
-				home: 45,
-				away: 30,
-				draw: 25,
-				participationNumber: 1250,
-			},
-			myGambleResult: null,
-			homeScore: 2,
-			awayScore: 1,
-			round: '24',
-			homePenaltyScore: null,
-			awayPenaltyScore: null,
-			gameStatus: 'HOME',
-			startAt: '2026-02-04T20:00:00Z',
-		},
-		{
-			pk: 2,
-			league: {
-				pk: 1,
-				nameKr: '프리미어리그',
-				nameEn: 'Premier League',
-				logoUrl: '/league-logo/premier-league.svg',
-			},
-			homeTeam: {
-				pk: 3,
-				nameKr: '리버풀',
-				nameEn: 'Liverpool',
-				logoUrl: '/team-logo/liverpool.svg',
-			},
-			awayTeam: {
-				pk: 4,
-				nameKr: '맨시티',
-				nameEn: 'Manchester City',
-				logoUrl: '/team-logo/man-city.svg',
-			},
-			gambleResult: {
-				home: 35,
-				away: 40,
-				draw: 25,
-				participationNumber: 3420,
-			},
-			myGambleResult: {
-				id: 'g1',
-				homeScore: 1,
-				awayScore: 2,
-				result: 'AWAY',
-				gambleStatus: 'SUCCEED',
-			},
-			homeScore: 1,
-			awayScore: 2,
-			round: '24',
-			homePenaltyScore: null,
-			awayPenaltyScore: null,
-			gameStatus: 'AWAY',
-			startAt: '2026-02-05T22:30:00Z',
-		},
-		{
-			pk: 3,
-			league: {
-				pk: 2,
-				nameKr: '라리가',
-				nameEn: 'La Liga',
-				logoUrl: '/league-logo/la-liga.svg',
-			},
-			homeTeam: {
-				pk: 5,
-				nameKr: '뉴캐슬',
-				nameEn: 'Newcastle',
-				logoUrl: '/team-logo/newcastle.svg',
-			},
-			awayTeam: {
-				pk: 6,
-				nameKr: '본머스',
-				nameEn: 'Bournemouth',
-				logoUrl: '/team-logo/bournemouth.svg',
-			},
-			gambleResult: {
-				home: 60,
-				away: 15,
-				draw: 25,
-				participationNumber: 840,
-			},
-			myGambleResult: null,
-			homeScore: null,
-			awayScore: null,
-			round: '20',
-			homePenaltyScore: null,
-			awayPenaltyScore: null,
-			gameStatus: 'PROCEEDING',
-			startAt: '2026-02-06T19:00:00Z',
-		},
-	];
+	useEffect(() => {
+		const fetchGames = async () => {
+			try {
+				const [proceedingRes, finishedRes] = await Promise.all([
+					getGames({ league: 2, status: 'proceeding', team: undefined }),
+					getGames({ league: 2, status: 'finished', team: undefined }),
+				]);
 
+				const proceedingGames = proceedingRes?.data.games ?? [];
+				const finishedGames = finishedRes?.data.games ?? [];
+
+				setGames([...proceedingGames, ...finishedGames]);
+			} catch (error) {
+				setIsError(true);
+			}
+		};
+
+		fetchGames();
+	}, [currentUserInfo]);
+
+	// TODO: 경기가 없는 경우, 에러난 경우 처리 필요
 	return (
 		<div className="grid grid-cols-1 min-[120rem]:grid-cols-2 gap-6 pb-90">
 			{/* 승부 예측 */}

--- a/src/components/common/category-tab/community-item.tsx
+++ b/src/components/common/category-tab/community-item.tsx
@@ -89,7 +89,7 @@ export default function CommunityItem({
 						aria-hidden={true}
 						width={16}
 						height={16}
-						className="@mobile:inline hidden w-4 h-4 object-contain text-[#8F8F8F]"
+						className="@mobile:inline hidden w-4 h-4 object-contain text-black-600"
 					/>
 					<span aria-hidden={true}>{likes}</span>
 				</div>

--- a/src/components/common/category-tab/news-item.tsx
+++ b/src/components/common/category-tab/news-item.tsx
@@ -80,7 +80,7 @@ export default function NewsItem({
 
 					<div className="flex justify-end items-center gap-3">
 						<span className="flex items-center gap-1.5" aria-label={`킥 ${likes}개`}>
-							<KickIcon aria-hidden={true} width={18} height={18} className="text-[#8F8F8F]" />
+							<KickIcon aria-hidden={true} width={18} height={18} className="text-black-600" />
 							<span aria-hidden={true}>{likes}</span>
 						</span>
 						<span className="flex items-center gap-1.5" aria-label={`댓글 ${replies}개`}>

--- a/src/components/features/detail/comment/comment-item.tsx
+++ b/src/components/features/detail/comment/comment-item.tsx
@@ -176,7 +176,7 @@ function CommentItem({
 						{/* 킥 버튼 (하단 우측) */}
 						{!isEditing && (
 							<button onClick={() => void toggleCommentLike()} className="ml-auto flex items-center gap-2">
-								<KickIcon className={comment.kicked ? 'text-[#C00C0B]' : 'text-[#8F8F8F]'} width={16} height={16} />
+								<KickIcon className={comment.kicked ? 'text-primary-900' : 'text-black-600'} width={16} height={16} />
 								<span className={comment.kicked ? 'text-black-900' : 'text-gray-500'}>{comment.kickCount}</span>
 							</button>
 						)}

--- a/src/components/features/detail/content/detail-content.tsx
+++ b/src/components/features/detail/content/detail-content.tsx
@@ -206,7 +206,7 @@ const DetailContent = ({ detailData, type, isCommentAllowed }: DetailContentProp
 
 					<div className="flex gap-3 items-center text-black-600 body5-regular">
 						<div className="flex items-center gap-1.5 @mobile:hidden" aria-label={`킥 ${likes}개`}>
-							<KickIcon aria-hidden={true} className="text-[#8F8F8F]" width={18} height={18} />
+							<KickIcon aria-hidden={true} className="text-black-600" width={18} height={18} />
 							<span aria-hidden={true}>{likes}</span>
 						</div>
 						<div className="flex items-center gap-1.5 @mobile:hidden" aria-label={`댓글 ${detailData.replies}개`}>

--- a/src/components/features/halftime/player-action/icon.tsx
+++ b/src/components/features/halftime/player-action/icon.tsx
@@ -5,7 +5,7 @@ import Share from '@/assets/halftime/share.svg';
 import Paper from '@/assets/halftime/paper.svg';
 
 export function KickIcon({ isKicked }: { isKicked: boolean }) {
-	return isKicked ? <KickRed className="w-6 h-6 " /> : <Kick className="text-[#8F8F8F]" />;
+	return isKicked ? <KickRed className="w-6 h-6" /> : <Kick className="text-black-600" />;
 }
 
 export function CommentIcon() {

--- a/src/components/features/halftime/preview-with-title.tsx
+++ b/src/components/features/halftime/preview-with-title.tsx
@@ -33,7 +33,7 @@ export default function PreviewWithTitle({
 					<>
 						<div className="h-3 w-px bg-black-600" />
 						<span className="flex gap-1.5 items-center">
-							<KickIcon className="text-[#8F8F8F]" width={16} height={16} />킥 {formatNumberByUnit(kickCount)}
+							<KickIcon className="text-black-600" width={16} height={16} />킥 {formatNumberByUnit(kickCount)}
 						</span>
 					</>
 				)}

--- a/src/components/features/home/ai-analytics.tsx
+++ b/src/components/features/home/ai-analytics.tsx
@@ -1,7 +1,7 @@
 export default function AiAnalytics({ pk }: { pk: number }) {
 	// pk 기반으로 ai 분석 조회
 	const summary =
-		'어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구';
+		'aaaaaaaaasasaaasdfsadhjknlmfhfhfhfhfhhfhfhfhfhfhfhfhfhfhfhdjdjdjdjdjjddjjdjdjdjdjdjdjdjdjdjffhfhhffhhfhfhfhfhfhfhffhhsgf어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구 어쩌구저쩌구';
 	const mvp = {
 		name: '손흥민',
 		oneLineReview:
@@ -17,19 +17,19 @@ export default function AiAnalytics({ pk }: { pk: number }) {
 		<div className="bg-black-200 text-black rounded px-4 pt-3 pb-4 mx-4 space-y-3">
 			<div className="space-y-1">
 				<h3 className="text-subtitle-02 font-semibold">킥온 AI 분석</h3>
-				<ul className="pl-4 text-caption-01 list-disc">
+				<ul className="pl-4 text-caption-01 list-disc break-words">
 					<li>{summary}</li>
 				</ul>
 			</div>
 			<div className="space-y-1">
 				<h3 className="text-subtitle-02 font-semibold">MVP {mvp.name}</h3>
-				<ul className="pl-4 text-caption-01 list-disc">
+				<ul className="pl-4 text-caption-01 list-disc break-words">
 					<li>{mvp.oneLineReview}</li>
 				</ul>
 			</div>
 			<div className="space-y-1">
 				<h3 className="text-subtitle-02 font-semibold">WORST {worst.name}</h3>
-				<ul className="pl-4 text-caption-01 list-disc">
+				<ul className="pl-4 text-caption-01 list-disc break-words">
 					<li>{worst.oneLineReview}</li>
 				</ul>
 			</div>

--- a/src/components/features/home/game-comment-item.tsx
+++ b/src/components/features/home/game-comment-item.tsx
@@ -1,0 +1,34 @@
+import KickIcon from '@/assets/common/kick/fill-none.svg';
+import { GameCommentDto } from '@/services/apis/game/game-reply.type';
+import Image from 'next/image';
+import clsx from 'clsx';
+
+export interface GameCommentItemProps extends GameCommentDto {
+	isBest?: boolean;
+}
+
+export default function GameCommentItem({ user, contents, kickCount, kicked, isBest = false }: GameCommentItemProps) {
+	return (
+		<div className="flex gap-3 justify-between items-center hover:bg-black-100 p-1 rounded-lg">
+			<div className="grid grid-cols-[auto_auto_1fr] gap-1 items-start">
+				<Image src={user.profileImageUrl} alt="" className="w-4 h-4 rounded-full bg-black-200 object-cover shrink-0" />
+				<div className="flex gap-1 shrink-0">
+					<span className="font-medium">{user.nickname}</span>
+					{isBest && (
+						<div className="font-semibold text-caption-02 text-primary-900 border border-primary-900 bg-primary-50 rounded-full px-1.5 py-px">
+							BEST
+						</div>
+					)}
+				</div>
+				<div className={clsx('ml-1 break-words min-w-0', isBest && 'truncate')}>{contents}</div>
+			</div>
+
+			<div className="flex gap-1 items-center text-black-600 shrink-0">
+				{kickCount}
+				<button>
+					<KickIcon className={`w-4 h-4 ${kicked ? 'text-primary-900' : 'text-black-600'}`} />
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/components/features/home/game-comment-item.tsx
+++ b/src/components/features/home/game-comment-item.tsx
@@ -2,16 +2,38 @@ import KickIcon from '@/assets/common/kick/fill-none.svg';
 import { GameCommentDto } from '@/services/apis/game/game-reply.type';
 import Image from 'next/image';
 import clsx from 'clsx';
+import { useToggleGameCommentKickMutation } from '@/lib/hooks/queries/useGameReplyQuery';
 
 export interface GameCommentItemProps extends GameCommentDto {
+	gamePk: number;
 	isBest?: boolean;
 }
 
-export default function GameCommentItem({ user, contents, kickCount, kicked, isBest = false }: GameCommentItemProps) {
+export default function GameCommentItem({
+	pk,
+	user,
+	contents,
+	kickCount,
+	kicked,
+	gamePk,
+	isBest = false,
+}: GameCommentItemProps) {
+	const toggleKickMutation = useToggleGameCommentKickMutation(gamePk);
+
+	const handleKick = () => {
+		toggleKickMutation.mutate(pk);
+	};
+
 	return (
 		<div className="flex gap-3 justify-between items-center hover:bg-black-100 p-1 rounded-lg">
 			<div className="grid grid-cols-[auto_auto_1fr] gap-1 items-start">
-				<Image src={user.profileImageUrl} alt="" className="w-4 h-4 rounded-full bg-black-200 object-cover shrink-0" />
+				<Image
+					src={user.profileImageUrl || '/default-profile.svg'}
+					alt=""
+					width={16}
+					height={16}
+					className="w-4 h-4 rounded-full bg-black-200 object-cover shrink-0"
+				/>
 				<div className="flex gap-1 shrink-0">
 					<span className="font-medium">{user.nickname}</span>
 					{isBest && (
@@ -25,8 +47,8 @@ export default function GameCommentItem({ user, contents, kickCount, kicked, isB
 
 			<div className="flex gap-1 items-center text-black-600 shrink-0">
 				{kickCount}
-				<button>
-					<KickIcon className={`w-4 h-4 ${kicked ? 'text-primary-900' : 'text-black-600'}`} />
+				<button onClick={handleKick} disabled={toggleKickMutation.isPending}>
+					<KickIcon className={clsx('w-4 h-4', kicked ? 'text-primary-900' : 'text-black-600')} />
 				</button>
 			</div>
 		</div>

--- a/src/components/features/home/game-comment.tsx
+++ b/src/components/features/home/game-comment.tsx
@@ -16,7 +16,7 @@ export default function GameComment({ pk }: { pk: number }) {
 							<div className="flex gap-1 items-center text-black-600">
 								{kickCount}
 								<button>
-									<KickIcon className={`w-4 h-4 ${kickCount % 3 === 0 ? 'text-primary-900' : 'text-[#8F8F8F]'}`} />
+									<KickIcon className={`w-4 h-4 ${kickCount % 3 === 0 ? 'text-primary-900' : 'text-black-600'}`} />
 								</button>
 							</div>
 						</div>
@@ -36,7 +36,7 @@ export default function GameComment({ pk }: { pk: number }) {
 					<div className="flex gap-1 items-center text-black-600">
 						33
 						<button>
-							<KickIcon className={`w-4 h-4 text-[#8F8F8F]`} />
+							<KickIcon className={`w-4 h-4 text-black-600`} />
 						</button>
 					</div>
 				</div>

--- a/src/components/features/home/game-comment.tsx
+++ b/src/components/features/home/game-comment.tsx
@@ -1,45 +1,87 @@
-import KickIcon from '@/assets/common/kick/fill-none.svg';
+import { GameCommentDto } from '@/services/apis/game/game-reply.type';
+import GameCommentItem from '@/components/features/home/game-comment-item';
 
 export default function GameComment({ pk }: { pk: number }) {
+	const comments: GameCommentDto[] = [
+		{
+			pk: 1,
+			contents:
+				'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
+			user: {
+				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
+				nickname: '가으님',
+				profileImageUrl: '',
+				isReporter: false,
+			},
+			createdAt: '2026-02-03T17:16:13.490055',
+			kickCount: 1,
+			kicked: true,
+		},
+		{
+			pk: 1,
+			contents: '댓글 입니다~~',
+			user: {
+				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
+				nickname: '가으님',
+				profileImageUrl: '',
+				isReporter: false,
+			},
+			createdAt: '2026-02-03T17:16:13.490055',
+			kickCount: 1,
+			kicked: true,
+		},
+		{
+			pk: 1,
+			contents:
+				'댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~',
+			user: {
+				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
+				nickname: '가으님',
+				profileImageUrl: '',
+				isReporter: false,
+			},
+			createdAt: '2026-02-03T17:16:13.490055',
+			kickCount: 1,
+			kicked: true,
+		},
+		{
+			pk: 1,
+			contents: '댓글 입니다~~',
+			user: {
+				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
+				nickname: '가으님',
+				profileImageUrl: '',
+				isReporter: false,
+			},
+			createdAt: '2026-02-03T17:16:13.490055',
+			kickCount: 1,
+			kicked: true,
+		},
+		{
+			pk: 1,
+			contents: '댓글 입니다~~',
+			user: {
+				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
+				nickname: '가으님',
+				profileImageUrl: '',
+				isReporter: false,
+			},
+			createdAt: '2026-02-03T17:16:13.490055',
+			kickCount: 1,
+			kicked: true,
+		},
+	];
+
 	return (
 		<div className="flex flex-col gap-3 text-caption-01 mx-4">
 			<div className="space-y-2">
-				<div className="flex flex-col gap-1.5 min-h-0 max-h-26 game-comment-scrollbar -mr-3 pr-1">
-					{[1, 2, 3, 4, 5, 6, 7, 8].map((kickCount) => (
-						<div key={kickCount} className="flex justify-between items-center">
-							<div className="flex gap-1 items-center">
-								<div className="w-4 h-4 rounded-full bg-black-200" />
-								<span className="font-medium">닉네임</span>
-								<span className="ml-1">와 손흥민 미쳣음</span>
-							</div>
-
-							<div className="flex gap-1 items-center text-black-600">
-								{kickCount}
-								<button>
-									<KickIcon className={`w-4 h-4 ${kickCount % 3 === 0 ? 'text-primary-900' : 'text-black-600'}`} />
-								</button>
-							</div>
-						</div>
+				<div className="flex flex-col gap-1.5 min-h-0 max-h-32 game-comment-scrollbar -mr-3 pr-1">
+					{comments.map((comment) => (
+						<GameCommentItem key={comment.pk} {...comment} />
 					))}
 				</div>
 
-				<div className="flex justify-between items-center sticky bottom-0">
-					<div className="flex gap-1 items-center">
-						<div className="w-4 h-4 rounded-full bg-black-200" />
-						<span className="font-medium">닉네임</span>
-						<div className="font-semibold text-caption-02 text-primary-900 border border-primary-900 bg-primary-50 rounded-full px-1.5 py-px">
-							BEST
-						</div>
-						<span className="ml-1 ">와 손흥민 미쳣음</span>
-					</div>
-
-					<div className="flex gap-1 items-center text-black-600">
-						33
-						<button>
-							<KickIcon className={`w-4 h-4 text-black-600`} />
-						</button>
-					</div>
-				</div>
+				<GameCommentItem isBest {...comments[0]} />
 			</div>
 
 			<div className="bg-black-200 rounded-full grid grid-cols-[1fr_auto]">

--- a/src/components/features/home/game-comment.tsx
+++ b/src/components/features/home/game-comment.tsx
@@ -7,9 +7,13 @@ import {
 	useGameCommentListInfiniteQuery,
 	useTopGameCommentQuery,
 } from '@/lib/hooks/queries/useGameReplyQuery';
+import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 
 export default function GameComment({ pk }: { pk: number }) {
 	const [content, setContent] = useState('');
+
+	const { currentUserInfo } = useCurrentUserInfoStore();
+	const isLoggedIn = !!currentUserInfo;
 
 	const { data: commentListData } = useGameCommentListInfiniteQuery({
 		game: pk,
@@ -50,7 +54,8 @@ export default function GameComment({ pk }: { pk: number }) {
 				<input
 					type="text"
 					className="px-4 py-1.5 outline-0 bg-transparent"
-					placeholder="댓글을 입력하세요..."
+					disabled={!isLoggedIn}
+					placeholder={isLoggedIn ? '댓글을 입력하세요...' : '로그인하고 대화에 참여하세요.'}
 					value={content}
 					onChange={(e) => setContent(e.target.value)}
 					onKeyDown={(e) => {
@@ -59,13 +64,15 @@ export default function GameComment({ pk }: { pk: number }) {
 						}
 					}}
 				/>
-				<button
-					className="px-3 text-black-700 disabled:opacity-50"
-					onClick={handleCreateComment}
-					disabled={createCommentMutation.isPending}
-				>
-					등록
-				</button>
+				{isLoggedIn && (
+					<button
+						className="px-3 text-black-700 disabled:opacity-50"
+						onClick={handleCreateComment}
+						disabled={createCommentMutation.isPending}
+					>
+						등록
+					</button>
+				)}
 			</div>
 		</div>
 	);

--- a/src/components/features/home/game-comment.tsx
+++ b/src/components/features/home/game-comment.tsx
@@ -36,9 +36,11 @@ export default function GameComment({ pk }: { pk: number }) {
 		<div className="flex flex-col gap-3 text-caption-01 mx-4">
 			<div className="space-y-2">
 				<div className="flex flex-col gap-1.5 min-h-0 max-h-32 game-comment-scrollbar -mr-3 pr-1">
-					{comments.map((comment) => (
-						<GameCommentItem key={comment.pk} {...comment} gamePk={pk} />
-					))}
+					{comments.length === 0 ? (
+						<div className="text-center pt-1 pb-5">지금 경기에 대한 이야기를 시작해 보세요!</div>
+					) : (
+						comments.map((comment) => <GameCommentItem key={comment.pk} {...comment} gamePk={pk} />)
+					)}
 				</div>
 
 				{topComment && <GameCommentItem isBest {...topComment} gamePk={pk} />}

--- a/src/components/features/home/game-comment.tsx
+++ b/src/components/features/home/game-comment.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import GameCommentItem from '@/components/features/home/game-comment-item';
 import {
 	useCreateGameCommentMutation,
@@ -11,6 +11,7 @@ import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 
 export default function GameComment({ pk }: { pk: number }) {
 	const [content, setContent] = useState('');
+	const scrollRef = useRef<HTMLDivElement>(null);
 
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const isLoggedIn = !!currentUserInfo;
@@ -23,8 +24,8 @@ export default function GameComment({ pk }: { pk: number }) {
 	const { data: topCommentData } = useTopGameCommentQuery(pk);
 	const createCommentMutation = useCreateGameCommentMutation(pk);
 
-	const comments = commentListData?.pages.flatMap((page) => page.data) ?? [];
-	const topComment = topCommentData?.data;
+	const comments = useMemo(() => commentListData?.pages.flatMap((page) => page.data) ?? [], [commentListData]);
+	const topComment = useMemo(() => topCommentData?.data, [topCommentData]);
 
 	const handleCreateComment = () => {
 		if (!content.trim()) return;
@@ -36,10 +37,16 @@ export default function GameComment({ pk }: { pk: number }) {
 		);
 	};
 
+	useEffect(() => {
+		if (scrollRef.current) {
+			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+		}
+	}, [comments]);
+
 	return (
 		<div className="flex flex-col gap-3 text-caption-01 mx-4">
 			<div className="space-y-2">
-				<div className="flex flex-col gap-1.5 min-h-0 max-h-32 game-comment-scrollbar -mr-3 pr-1">
+				<div ref={scrollRef} className="flex flex-col gap-1.5 min-h-0 max-h-32 game-comment-scrollbar -mr-3 pr-1">
 					{comments.length === 0 ? (
 						<div className="text-center pt-1 pb-5">지금 경기에 대한 이야기를 시작해 보세요!</div>
 					) : (

--- a/src/components/features/home/game-comment.tsx
+++ b/src/components/features/home/game-comment.tsx
@@ -1,92 +1,69 @@
-import { GameCommentDto } from '@/services/apis/game/game-reply.type';
+'use client';
+
+import { useState } from 'react';
 import GameCommentItem from '@/components/features/home/game-comment-item';
+import {
+	useCreateGameCommentMutation,
+	useGameCommentListInfiniteQuery,
+	useTopGameCommentQuery,
+} from '@/lib/hooks/queries/useGameReplyQuery';
 
 export default function GameComment({ pk }: { pk: number }) {
-	const comments: GameCommentDto[] = [
-		{
-			pk: 1,
-			contents:
-				'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz',
-			user: {
-				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
-				nickname: '가으님',
-				profileImageUrl: '',
-				isReporter: false,
+	const [content, setContent] = useState('');
+
+	const { data: commentListData } = useGameCommentListInfiniteQuery({
+		game: pk,
+		size: 20,
+		page: 1,
+	});
+	const { data: topCommentData } = useTopGameCommentQuery(pk);
+	const createCommentMutation = useCreateGameCommentMutation(pk);
+
+	const comments = commentListData?.pages.flatMap((page) => page.data) ?? [];
+	const topComment = topCommentData?.data;
+
+	const handleCreateComment = () => {
+		if (!content.trim()) return;
+		createCommentMutation.mutate(
+			{ game: pk, contents: content },
+			{
+				onSuccess: () => setContent(''),
 			},
-			createdAt: '2026-02-03T17:16:13.490055',
-			kickCount: 1,
-			kicked: true,
-		},
-		{
-			pk: 1,
-			contents: '댓글 입니다~~',
-			user: {
-				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
-				nickname: '가으님',
-				profileImageUrl: '',
-				isReporter: false,
-			},
-			createdAt: '2026-02-03T17:16:13.490055',
-			kickCount: 1,
-			kicked: true,
-		},
-		{
-			pk: 1,
-			contents:
-				'댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~댓글 입니다~~',
-			user: {
-				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
-				nickname: '가으님',
-				profileImageUrl: '',
-				isReporter: false,
-			},
-			createdAt: '2026-02-03T17:16:13.490055',
-			kickCount: 1,
-			kicked: true,
-		},
-		{
-			pk: 1,
-			contents: '댓글 입니다~~',
-			user: {
-				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
-				nickname: '가으님',
-				profileImageUrl: '',
-				isReporter: false,
-			},
-			createdAt: '2026-02-03T17:16:13.490055',
-			kickCount: 1,
-			kicked: true,
-		},
-		{
-			pk: 1,
-			contents: '댓글 입니다~~',
-			user: {
-				id: '9ba08d10-8d66-4b66-937c-8233ef7e3036',
-				nickname: '가으님',
-				profileImageUrl: '',
-				isReporter: false,
-			},
-			createdAt: '2026-02-03T17:16:13.490055',
-			kickCount: 1,
-			kicked: true,
-		},
-	];
+		);
+	};
 
 	return (
 		<div className="flex flex-col gap-3 text-caption-01 mx-4">
 			<div className="space-y-2">
 				<div className="flex flex-col gap-1.5 min-h-0 max-h-32 game-comment-scrollbar -mr-3 pr-1">
 					{comments.map((comment) => (
-						<GameCommentItem key={comment.pk} {...comment} />
+						<GameCommentItem key={comment.pk} {...comment} gamePk={pk} />
 					))}
 				</div>
 
-				<GameCommentItem isBest {...comments[0]} />
+				{topComment && <GameCommentItem isBest {...topComment} gamePk={pk} />}
 			</div>
 
 			<div className="bg-black-200 rounded-full grid grid-cols-[1fr_auto]">
-				<input type="text" className="px-4 py-1.5 outline-0" placeholder="댓글을 입력하세요..." />
-				<button className="px-3 text-black-700">등록</button>
+				<input
+					type="text"
+					className="px-4 py-1.5 outline-0 bg-transparent"
+					placeholder="댓글을 입력하세요..."
+					value={content}
+					onChange={(e) => setContent(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+							handleCreateComment();
+						}
+					}}
+				/>
+				<button
+					className="px-3 text-black-700 disabled:opacity-50"
+					onClick={handleCreateComment}
+					disabled={createCommentMutation.isPending}
+				>
+					등록
+				</button>
 			</div>
 		</div>
 	);

--- a/src/components/features/home/predict-card/index.tsx
+++ b/src/components/features/home/predict-card/index.tsx
@@ -15,17 +15,20 @@ import {
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
 import { GameDto } from '@/services/apis/game/game.type';
 import { addCommas, formatDate, getRelativeTime, getServerDeviceType } from '@/lib/utils';
+import { LeagueDto } from '@/services/apis/league/league.type';
 
 export default function PredictCard({
 	game,
+	league,
 	type,
 	refetchGames,
 }: {
 	game: GameDto;
+	league: LeagueDto;
 	type: 'proceeding' | 'finished';
 	refetchGames?: () => void;
 }) {
-	const { pk, gambleResult, myGambleResult, homeScore, awayScore, gameStatus, startAt, league } = game;
+	const { pk, gambleResult, myGambleResult, homeScore, awayScore, gameStatus, startAt } = game;
 
 	const { isMobile, isTablet } = getServerDeviceType();
 

--- a/src/components/features/notice/notice-item.tsx
+++ b/src/components/features/notice/notice-item.tsx
@@ -63,7 +63,7 @@ export default function NoticeItem({
 				console.error('알림 읽음 API 실패', e);
 			}
 		}
-		router.push(redirectUrl);
+		// router.push(redirectUrl);
 		if (isModal && onCloseModal) {
 			onCloseModal();
 		}

--- a/src/lib/hooks/queries/useGameReplyQuery.ts
+++ b/src/lib/hooks/queries/useGameReplyQuery.ts
@@ -31,6 +31,7 @@ export const useGameCommentListInfiniteQuery = (params: GetGameCommentListReques
 			return lastPage.data.at(-1)?.pk ?? undefined;
 		},
 		enabled: enabled && Number.isSafeInteger(params.game) && params.game > 0,
+		refetchInterval: 5000,
 	});
 };
 
@@ -40,6 +41,7 @@ export const useTopGameCommentQuery = (gamePk: number, enabled = true) => {
 		queryKey: gameCommentKeys.top(gamePk),
 		queryFn: () => getTopGameComment(gamePk),
 		enabled: enabled && Number.isSafeInteger(gamePk) && gamePk > 0,
+		refetchInterval: 5000,
 	});
 };
 

--- a/src/lib/hooks/queries/useGameReplyQuery.ts
+++ b/src/lib/hooks/queries/useGameReplyQuery.ts
@@ -8,7 +8,6 @@ import {
 	CreateGameCommentRequest,
 	CreateGameCommentResponse,
 	GetGameCommentListRequest,
-	GetGameCommentListResponse,
 	GetTopGameCommentResponse,
 } from '@/services/apis/game/game-reply.type';
 import { SuccessResponse } from '@/services/config/dto';
@@ -16,14 +15,15 @@ import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tansta
 
 export const gameCommentKeys = {
 	all: ['game-comment'] as const,
-	list: (params: GetGameCommentListRequest) => [...gameCommentKeys.all, 'list', params] as const,
+	list: (gamePk: number) => [...gameCommentKeys.all, 'list', gamePk] as const,
 	top: (gamePk: number) => [...gameCommentKeys.all, 'top', gamePk] as const,
 };
 
 // 경기 댓글 무한 스크롤 조회
 export const useGameCommentListInfiniteQuery = (params: GetGameCommentListRequest, enabled = true) => {
-	return useInfiniteQuery<GetGameCommentListResponse, Error, GetGameCommentListResponse, any, number | undefined>({
-		queryKey: gameCommentKeys.list({ ...params, infinite: true }),
+	return useInfiniteQuery({
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps
+		queryKey: gameCommentKeys.list(params.game),
 		queryFn: ({ pageParam }) => getGameCommentList({ ...params, infinite: true, lastReply: pageParam }),
 		initialPageParam: undefined,
 		getNextPageParam: (lastPage) => {
@@ -44,21 +44,26 @@ export const useTopGameCommentQuery = (gamePk: number, enabled = true) => {
 };
 
 // 경기 댓글 생성
-export const useCreateGameCommentMutation = () => {
+export const useCreateGameCommentMutation = (gamePk: number) => {
 	const queryClient = useQueryClient();
 
 	return useMutation<CreateGameCommentResponse, unknown, CreateGameCommentRequest>({
 		mutationFn: createGameComment,
-		onSuccess: async () => await queryClient.invalidateQueries({ queryKey: gameCommentKeys.all }),
+		onSuccess: async () => await queryClient.invalidateQueries({ queryKey: gameCommentKeys.list(gamePk) }),
 	});
 };
 
 // 경기 댓글 킥
-export const useToggleGameCommentKickMutation = () => {
+export const useToggleGameCommentKickMutation = (gamePk: number) => {
 	const queryClient = useQueryClient();
 
 	return useMutation<SuccessResponse<null>, unknown, number>({
 		mutationFn: toggleGameCommentKick,
-		onSuccess: async () => await queryClient.invalidateQueries({ queryKey: gameCommentKeys.all }),
+		onSuccess: async () => {
+			await Promise.all([
+				queryClient.invalidateQueries({ queryKey: gameCommentKeys.list(gamePk) }),
+				queryClient.invalidateQueries({ queryKey: gameCommentKeys.top(gamePk) }),
+			]);
+		},
 	});
 };

--- a/src/lib/hooks/queries/useGameReplyQuery.ts
+++ b/src/lib/hooks/queries/useGameReplyQuery.ts
@@ -1,0 +1,64 @@
+import {
+	createGameComment,
+	getGameCommentList,
+	getTopGameComment,
+	toggleGameCommentKick,
+} from '@/services/apis/game/game-reply.api';
+import {
+	CreateGameCommentRequest,
+	CreateGameCommentResponse,
+	GetGameCommentListRequest,
+	GetGameCommentListResponse,
+	GetTopGameCommentResponse,
+} from '@/services/apis/game/game-reply.type';
+import { SuccessResponse } from '@/services/config/dto';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const gameCommentKeys = {
+	all: ['game-comment'] as const,
+	list: (params: GetGameCommentListRequest) => [...gameCommentKeys.all, 'list', params] as const,
+	top: (gamePk: number) => [...gameCommentKeys.all, 'top', gamePk] as const,
+};
+
+// 경기 댓글 무한 스크롤 조회
+export const useGameCommentListInfiniteQuery = (params: GetGameCommentListRequest, enabled = true) => {
+	return useInfiniteQuery<GetGameCommentListResponse, Error, GetGameCommentListResponse, any, number | undefined>({
+		queryKey: gameCommentKeys.list({ ...params, infinite: true }),
+		queryFn: ({ pageParam }) => getGameCommentList({ ...params, infinite: true, lastReply: pageParam }),
+		initialPageParam: undefined,
+		getNextPageParam: (lastPage) => {
+			if (!lastPage.meta.hasNext) return undefined;
+			return lastPage.data.at(-1)?.pk ?? undefined;
+		},
+		enabled: enabled && Number.isSafeInteger(params.game) && params.game > 0,
+	});
+};
+
+// 경기 인기 댓글 조회
+export const useTopGameCommentQuery = (gamePk: number, enabled = true) => {
+	return useQuery<GetTopGameCommentResponse>({
+		queryKey: gameCommentKeys.top(gamePk),
+		queryFn: () => getTopGameComment(gamePk),
+		enabled: enabled && Number.isSafeInteger(gamePk) && gamePk > 0,
+	});
+};
+
+// 경기 댓글 생성
+export const useCreateGameCommentMutation = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation<CreateGameCommentResponse, unknown, CreateGameCommentRequest>({
+		mutationFn: createGameComment,
+		onSuccess: async () => await queryClient.invalidateQueries({ queryKey: gameCommentKeys.all }),
+	});
+};
+
+// 경기 댓글 킥
+export const useToggleGameCommentKickMutation = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation<SuccessResponse<null>, unknown, number>({
+		mutationFn: toggleGameCommentKick,
+		onSuccess: async () => await queryClient.invalidateQueries({ queryKey: gameCommentKeys.all }),
+	});
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,7 +12,8 @@ export function middleware(request: NextRequest) {
 	}
 
 	const isProd = process.env.NEXT_PUBLIC_NODE_ENV === 'prod';
-	const isAllowed = ALLOWED_ROUTES.some((route) => route.startsWith(pathname));
+	const isAllowed = ALLOWED_ROUTES.some((route) => pathname === route || pathname.startsWith(`${route}/`));
+
 	if (isProd && !isAllowed) {
 		return NextResponse.redirect(new URL('/404', request.url));
 	}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
-const ALLOWED_ROUTES = ['/', '/login', '/signup', '/auth', '/leave', '/profile-setting', '/ranking', '/notice', '/404'];
+const ALLOWED_ROUTES = ['/', '/login', '/signup', '/auth', '/withdrawal', '/profile-setting', '/ranking', '/notice', '/404'];
 
 export function middleware(request: NextRequest) {
 	const { pathname } = request.nextUrl;

--- a/src/services/apis/game/game-reply.api.ts
+++ b/src/services/apis/game/game-reply.api.ts
@@ -1,0 +1,53 @@
+import { appendParams } from '@/lib/server/appendParams';
+import { fetcher } from '@/lib/server/fetcher';
+import {
+	CreateGameCommentRequest,
+	CreateGameCommentResponse,
+	GetGameCommentListRequest,
+	GetGameCommentListResponse,
+	GetTopGameCommentResponse,
+} from '@/services/apis/game/game-reply.type';
+import { SuccessResponse } from '@/services/config/dto';
+import { CommonCommentKickDto } from '@/services/apis/common/types';
+
+// 경기 별 댓글 리스트 조회
+export const getGameCommentList = async (req: GetGameCommentListRequest) => {
+	const params = new URLSearchParams();
+	appendParams(params, req);
+
+	const response = await fetcher<GetGameCommentListResponse>({
+		method: 'GET',
+		url: `/api/game-reply?${params.toString()}`,
+	});
+
+	return response;
+};
+
+// 경기 별 인기 댓글 조회
+export const getTopGameComment = async (gamePk: number) => {
+	const response = await fetcher<GetTopGameCommentResponse>({
+		method: 'GET',
+		url: `/api/game-reply/top?game=${gamePk}`,
+	});
+
+	return response;
+};
+
+// 경기 별 댓글 생성
+export const createGameComment = async (body: CreateGameCommentRequest) => {
+	const response = await fetcher<CreateGameCommentResponse>({
+		method: 'POST',
+		url: '/api/game-reply',
+		body: body,
+	});
+
+	return response;
+};
+
+// 경기 별 댓글 킥
+export const toggleGameCommentKick = async (commentPk: number) => {
+	const body: CommonCommentKickDto = { reply: commentPk };
+	const response = await fetcher<SuccessResponse<null>>({ method: 'POST', url: '/api/game-reply-kick', body });
+
+	return response;
+};

--- a/src/services/apis/game/game-reply.type.ts
+++ b/src/services/apis/game/game-reply.type.ts
@@ -1,0 +1,35 @@
+import { UserDto } from '@/services/apis/user/user.type';
+import { SuccessResponse } from '@/services/config/dto';
+
+// 경기 별 댓글 리스트 조회
+export interface GetGameCommentListRequest {
+	game: number;
+	size: number;
+	page: number;
+	infinite: boolean;
+	lastReply: number;
+}
+
+export type GetGameCommentListResponse = SuccessResponse<GameCommentDto[]>;
+
+// 경기 별 인기 댓글 조회
+// 인기 댓글이 없는 경우 null
+export type GetTopGameCommentResponse = SuccessResponse<GameCommentDto | null>;
+
+// 경기 별 댓글 생성
+export interface CreateGameCommentRequest {
+	game: number;
+	contents: string;
+}
+
+export type CreateGameCommentResponse = SuccessResponse<GameCommentDto>;
+
+// 내부 dto
+export interface GameCommentDto {
+	pk: number;
+	contents: string;
+	user: UserDto;
+	createdAt: string;
+	kickCount: number;
+	kicked: boolean;
+}

--- a/src/services/apis/game/game-reply.type.ts
+++ b/src/services/apis/game/game-reply.type.ts
@@ -6,8 +6,8 @@ export interface GetGameCommentListRequest {
 	game: number;
 	size: number;
 	page: number;
-	infinite: boolean;
-	lastReply: number;
+	infinite?: boolean;
+	lastReply?: number;
 }
 
 export type GetGameCommentListResponse = SuccessResponse<GameCommentDto[]>;

--- a/src/services/apis/game/game.type.ts
+++ b/src/services/apis/game/game.type.ts
@@ -5,7 +5,7 @@ import { TeamDto } from '../team/team.type';
 
 // 매치 리스트 조회
 export interface GetGamesRequest {
-	league: number;
+	league?: number;
 	status: 'proceeding' | 'finished';
 	team?: number;
 	from?: string; // YYYY-MM-DD

--- a/src/services/apis/game/game.type.ts
+++ b/src/services/apis/game/game.type.ts
@@ -5,9 +5,9 @@ import { TeamDto } from '../team/team.type';
 
 // 매치 리스트 조회
 export interface GetGamesRequest {
-	league?: number;
+	league?: number; // 응원팀이 없거나 비회원인 경우에 사용
 	status: 'proceeding' | 'finished';
-	team?: number;
+	team?: number; // 응원팀이 있는 경우에 사용, 그때 undefined이면 전체 팀 경기
 	from?: string; // YYYY-MM-DD
 	to?: string; // YYYY-MM-DD
 }

--- a/src/services/apis/game/game.type.ts
+++ b/src/services/apis/game/game.type.ts
@@ -12,7 +12,7 @@ export interface GetGamesRequest {
 	to?: string; // YYYY-MM-DD
 }
 
-export type GetGamesResponse = SuccessResponse<GameTaggedLeagueDto>;
+export type GetGamesResponse = SuccessResponse<GameTaggedLeagueDto[]>;
 
 // 참여한 예측 리스트 조회
 export interface GetMyPredictionsRequest {
@@ -20,7 +20,7 @@ export interface GetMyPredictionsRequest {
 	to: string; // YYYY-MM-DD
 }
 
-export type GetMyPredictionsResponse = SuccessResponse<GameTaggedLeagueDto>;
+export type GetMyPredictionsResponse = SuccessResponse<GameTaggedLeagueDto[]>;
 
 // 예측 통계 조회
 export type GetMyStatsResponse = SuccessResponse<MyStatsDto>;


### PR DESCRIPTION
## 작업 내용
- 경기 리스트 조회, 경기 댓글 리스트 조회, 경기 인기 댓글 조회, 경기 댓글 킥 api 연동했습니다.
- 경기 댓글은 5초마다 refetch하여 댓글 목록을 최신화하도록 폴링 로직 구현했습니다.
- 그 외 603 피드백 반영했습니다. (색상코드 대신 유틸리티 클래스 사용, 댓글 개행 및 줄임 처리)
- 미들웨어 로직을 startsWith 기반으로 변경하여 하위 경로에서도 정상 동작하도록 수정했었는데, 허용 경로에 루트 경로가 포함되기 때문에 모든 경로가 허용되는 문제가 있었습니다. 후행 슬래시를 포함해 비교하도록 해당 로직 보완했습니다.
- 알림 클릭 시 비활성 페이지로 이동할 우려가 있어 라우팅 로직 제거했습니다.