### PR TITLE
[KO-612] 캘린더 기반 매치 조회 플로우 구현

### DIFF
--- a/src/app/(with-side)/page.tsx
+++ b/src/app/(with-side)/page.tsx
@@ -9,15 +9,18 @@ import clsx from 'clsx';
 import GameComment from '@/components/features/home/game-comment';
 import { getGames } from '@/services/apis/game/game.api';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import { useCalendarStore } from '@/lib/store/useCalendarStore';
 import FetchingFailedCard from '@/components/common/fetching-failed-card';
 import FloatingCalendarButton from '@/components/features/calendar/mobile-only/floating-calendar-button';
 import CalendarPopover from '@/components/features/calendar/mobile-only/calendar-popover';
+import { formatFromTo } from '@/lib/utils';
 
 export default function Home() {
 	const isMobile = useIsMobile();
 	const [games, setGames] = useState<GameTaggedLeagueDto[]>([]);
 	const [isError, setIsError] = useState(false);
 	const { currentUserInfo } = useCurrentUserInfoStore();
+	const { selectedDate } = useCalendarStore();
 	const [isCalendarModalOpen, setIsCalendarModalOpen] = useState(false);
 
 	useEffect(() => {
@@ -31,9 +34,27 @@ export default function Home() {
 	useEffect(() => {
 		const fetchGames = async () => {
 			try {
+				const fromDate = new Date(selectedDate);
+				fromDate.setDate(selectedDate.getDate() - 7);
+
+				const toDate = new Date(selectedDate);
+				toDate.setDate(selectedDate.getDate() + 7);
+
 				const [proceedingRes, finishedRes] = await Promise.all([
-					getGames({ league: 1, status: 'proceeding', team: undefined }),
-					getGames({ league: 1, status: 'finished', team: undefined }),
+					getGames({
+						league: 1,
+						status: 'proceeding',
+						team: undefined,
+						from: formatFromTo(fromDate),
+						to: formatFromTo(toDate),
+					}),
+					getGames({
+						league: 1,
+						status: 'finished',
+						team: undefined,
+						from: formatFromTo(fromDate),
+						to: formatFromTo(toDate),
+					}),
 				]);
 
 				const proceedingGames = proceedingRes?.data ?? [];
@@ -46,7 +67,7 @@ export default function Home() {
 		};
 
 		fetchGames();
-	}, [currentUserInfo]);
+	}, [currentUserInfo, selectedDate]);
 
 	if (isError) {
 		return (

--- a/src/components/common/match-prediction-calendar.tsx
+++ b/src/components/common/match-prediction-calendar.tsx
@@ -15,23 +15,20 @@ import { RenderTileContent } from '../features/calendar/renderers/render-tile-co
 import useIsDesktop from '@/lib/hooks/useIsDesktop';
 import clsx from 'clsx';
 
+import { useCalendarStore } from '@/lib/store/useCalendarStore';
+
 interface MatchPredictionCalendarProps {
 	type: 'match' | 'predict';
 	isPopover?: boolean;
-	selectedDate?: Date;
-	setSelectedDate?: (date: Date) => void; // 선택한 날짜 상위로 올림
 }
 
-export default function MatchPredictionCalendar({
-	type,
-	isPopover,
-	selectedDate,
-	setSelectedDate,
-}: MatchPredictionCalendarProps) {
+export default function MatchPredictionCalendar({ type, isPopover }: MatchPredictionCalendarProps) {
 	const isDesktop = useIsDesktop();
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const isMatch = type === 'match';
+
+	const { selectedDate, setSelectedDate } = useCalendarStore();
 
 	const [isWeekCalendar, setIsWeekCalendar] = useState(isMatch ? false : true); // 주 단위 캘린더인가 (접힌 상태인가)
 	const [markedDatesMap, setMarkedDatesMap] = useState<Record<string, number>>({}); // 경기가 있는 날짜들

--- a/src/components/common/match-prediction-calendar.tsx
+++ b/src/components/common/match-prediction-calendar.tsx
@@ -52,14 +52,14 @@ export default function MatchPredictionCalendar({ type, isPopover }: MatchPredic
 			const year = parseInt(yearParam);
 			const month = parseInt(monthParam);
 
-			// 현재 selectedDate와 URL의 연/월이 다를 때만 업데이트 (루프 방지)
+			// 현재 selectedDate와 URL의 연/월이 다를 때만 업데이트
 			if (selectedDate.getFullYear() !== year || selectedDate.getMonth() + 1 !== month) {
 				const isCurrentMonth = year === today.getFullYear() && month === today.getMonth() + 1;
 				const newDate = isCurrentMonth ? today : new Date(year, month - 1, 1);
 				setSelectedDate(newDate);
 			}
 		}
-	}, [searchParams]);
+	}, [searchParams, selectedDate, setSelectedDate]);
 
 	useEffect(() => {
 		// 점찍기 페치 (type에 따라 분기)

--- a/src/components/common/match-prediction-calendar.tsx
+++ b/src/components/common/match-prediction-calendar.tsx
@@ -33,21 +33,6 @@ export default function MatchPredictionCalendar({ type, isPopover }: MatchPredic
 	const [isWeekCalendar, setIsWeekCalendar] = useState(isMatch ? false : true); // 주 단위 캘린더인가 (접힌 상태인가)
 	const [markedDatesMap, setMarkedDatesMap] = useState<Record<string, number>>({}); // 경기가 있는 날짜들
 
-	const getYearMonthFromUrl = () => {
-		const year = searchParams.get('year');
-		const month = searchParams.get('month');
-
-		if (year && month) {
-			return new Date(parseInt(year), parseInt(month) - 1, 1);
-		}
-
-		// 파라미터가 없으면 현재 월
-		const today = new Date();
-		return new Date(today.getFullYear(), today.getMonth(), 1);
-	};
-
-	const firstDayOfCurrentMonth = getYearMonthFromUrl(); // 현재 월의 첫째 날
-
 	const updateUrlWithDate = (date: Date) => {
 		const year = date.getFullYear();
 		const month = date.getMonth() + 1;
@@ -57,11 +42,30 @@ export default function MatchPredictionCalendar({ type, isPopover }: MatchPredic
 		router.replace(`?${params.toString()}`, { scroll: false });
 	};
 
+	// URL 파라미터와 전역 selectedDate 동기화
+	useEffect(() => {
+		const yearParam = searchParams.get('year');
+		const monthParam = searchParams.get('month');
+		const today = stripTime(new Date());
+
+		if (yearParam && monthParam) {
+			const year = parseInt(yearParam);
+			const month = parseInt(monthParam);
+
+			// 현재 selectedDate와 URL의 연/월이 다를 때만 업데이트 (루프 방지)
+			if (selectedDate.getFullYear() !== year || selectedDate.getMonth() + 1 !== month) {
+				const isCurrentMonth = year === today.getFullYear() && month === today.getMonth() + 1;
+				const newDate = isCurrentMonth ? today : new Date(year, month - 1, 1);
+				setSelectedDate(newDate);
+			}
+		}
+	}, [searchParams]);
+
 	useEffect(() => {
 		// 점찍기 페치 (type에 따라 분기)
 		async function fetchMarkedDates() {
 			try {
-				const formattedDate = formatFromTo(firstDayOfCurrentMonth);
+				const formattedDate = formatFromTo(new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1));
 				const response = type === 'match' ? await getMonthlyMatchList(formattedDate) : await getMyPredictionDates();
 
 				if (response?.data?.dates) {
@@ -77,10 +81,9 @@ export default function MatchPredictionCalendar({ type, isPopover }: MatchPredic
 		}
 
 		fetchMarkedDates();
-	}, [searchParams, type]);
+	}, [selectedDate.getFullYear(), selectedDate.getMonth(), type]);
 
 	const calendarData = {
-		firstDayOfCurrentMonth,
 		selectedDate,
 		setSelectedDate,
 		isWeekCalendar,
@@ -93,10 +96,10 @@ export default function MatchPredictionCalendar({ type, isPopover }: MatchPredic
 		<div className="w-full">
 			<div className="relative">
 				<Calendar
-					key={`${firstDayOfCurrentMonth.toISOString()}`}
+					key={`${selectedDate.getFullYear()}-${selectedDate.getMonth()}`}
 					view="month"
 					formatDay={(locale, date) => `${date.getDate()}`}
-					activeStartDate={firstDayOfCurrentMonth}
+					activeStartDate={new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1)}
 					calendarType="gregory"
 					locale="ko-KR"
 					className={clsx(
@@ -108,8 +111,8 @@ export default function MatchPredictionCalendar({ type, isPopover }: MatchPredic
 						const clickedDate = stripTime(value);
 						setSelectedDate(clickedDate);
 
-						// 만약 선택된 날짜의 달이 현재 파라미터의 달과 다르다면 -> 파라미터 변경 -> 자동으로 firstDayOfCurrentMonth도 변경
-						if (clickedDate.getMonth() !== firstDayOfCurrentMonth.getMonth()) {
+						// 만약 선택된 날짜의 달이 현재 파라미터의 달과 다르다면 -> 파라미터 변경
+						if (clickedDate.getMonth() !== selectedDate.getMonth()) {
 							updateUrlWithDate(clickedDate);
 						}
 					}}

--- a/src/components/features/calendar/mobile-only/calendar-popover.tsx
+++ b/src/components/features/calendar/mobile-only/calendar-popover.tsx
@@ -1,23 +1,11 @@
 import MatchPredictionCalendar from '@/components/common/match-prediction-calendar';
-import { useNextMatchDateQuery } from '@/lib/hooks/queries/useNextMatchDateQuery';
 import { useEffect, useRef } from 'react';
-import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 interface CalendarPopoverProps {
 	isCalendarOpen: boolean;
 	onClose: () => void;
 }
 export default function CalendarPopover({ isCalendarOpen, onClose }: CalendarPopoverProps) {
-	const { setSelectedDate } = useCalendarStore();
-	const { data: nextDate } = useNextMatchDateQuery();
-
-	useEffect(() => {
-		if (!nextDate) return;
-
-		const [year, month, date] = nextDate.split('-').map(Number);
-		setSelectedDate(new Date(year, month - 1, date));
-	}, [nextDate, setSelectedDate]);
-
 	const popoverRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {

--- a/src/components/features/calendar/mobile-only/calendar-popover.tsx
+++ b/src/components/features/calendar/mobile-only/calendar-popover.tsx
@@ -1,13 +1,14 @@
 import MatchPredictionCalendar from '@/components/common/match-prediction-calendar';
 import { useNextMatchDateQuery } from '@/lib/hooks/queries/useNextMatchDateQuery';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 interface CalendarPopoverProps {
 	isCalendarOpen: boolean;
 	onClose: () => void;
 }
 export default function CalendarPopover({ isCalendarOpen, onClose }: CalendarPopoverProps) {
-	const [selectedDate, setSelectedDate] = useState(new Date());
+	const { setSelectedDate } = useCalendarStore();
 	const { data: nextDate } = useNextMatchDateQuery();
 
 	useEffect(() => {
@@ -15,7 +16,7 @@ export default function CalendarPopover({ isCalendarOpen, onClose }: CalendarPop
 
 		const [year, month, date] = nextDate.split('-').map(Number);
 		setSelectedDate(new Date(year, month - 1, date));
-	}, [nextDate]);
+	}, [nextDate, setSelectedDate]);
 
 	const popoverRef = useRef<HTMLDivElement | null>(null);
 
@@ -49,12 +50,7 @@ export default function CalendarPopover({ isCalendarOpen, onClose }: CalendarPop
                 ${isCalendarOpen ? 'opacity-100 translate-y-0 scale-100' : 'opacity-0 translate-y-3 scale-95'}
             `}
 		>
-			<MatchPredictionCalendar
-				type="match"
-				isPopover={true}
-				selectedDate={selectedDate}
-				setSelectedDate={(date) => setSelectedDate(date)}
-			/>
+			<MatchPredictionCalendar type="match" isPopover={true} />
 			<div className="absolute -bottom-2 right-6 w-4 h-4 bg-white rotate-45 border-r border-b border-black-200" />
 		</div>
 	);

--- a/src/components/features/calendar/navigation-label.tsx
+++ b/src/components/features/calendar/navigation-label.tsx
@@ -5,11 +5,10 @@ import Image from 'next/image';
 import clsx from 'clsx';
 import { getEndOfWeek, getStartOfWeek, stripTime } from '@/lib/utils';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 interface NavigationLabelProps {
 	isMatch: boolean;
-	selectedDate: Date | null;
-	setSelectedDate: (date: Date) => void;
 	firstDayOfCurrentMonth: Date;
 	isWeekCalendar: boolean;
 	updateUrlWithDate: (date: Date) => void;
@@ -17,13 +16,12 @@ interface NavigationLabelProps {
 
 export function NavigationLabel({
 	isMatch,
-	selectedDate,
-	setSelectedDate,
 	firstDayOfCurrentMonth,
 	isWeekCalendar,
 	updateUrlWithDate,
 }: NavigationLabelProps) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
+	const { selectedDate, setSelectedDate } = useCalendarStore();
 	const calendarMode = isWeekCalendar ? 'week' : 'month';
 
 	const year = firstDayOfCurrentMonth.getFullYear();

--- a/src/components/features/calendar/navigation-label.tsx
+++ b/src/components/features/calendar/navigation-label.tsx
@@ -9,23 +9,17 @@ import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 interface NavigationLabelProps {
 	isMatch: boolean;
-	firstDayOfCurrentMonth: Date;
 	isWeekCalendar: boolean;
 	updateUrlWithDate: (date: Date) => void;
 }
 
-export function NavigationLabel({
-	isMatch,
-	firstDayOfCurrentMonth,
-	isWeekCalendar,
-	updateUrlWithDate,
-}: NavigationLabelProps) {
+export function NavigationLabel({ isMatch, isWeekCalendar, updateUrlWithDate }: NavigationLabelProps) {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 	const { selectedDate, setSelectedDate } = useCalendarStore();
 	const calendarMode = isWeekCalendar ? 'week' : 'month';
 
-	const year = firstDayOfCurrentMonth.getFullYear();
-	const month = firstDayOfCurrentMonth.toLocaleString('ko-KR', { month: 'long' });
+	const year = selectedDate.getFullYear();
+	const month = selectedDate.toLocaleString('ko-KR', { month: 'long' });
 	const today = stripTime(new Date());
 
 	const [isVisibleDropdown, setIsVisibleDropdown] = useState(false);
@@ -42,15 +36,15 @@ export function NavigationLabel({
 	}).reverse();
 
 	const handleYearChange = (newYear: number) => {
-		const newDate = new Date(newYear, firstDayOfCurrentMonth.getMonth(), 1);
+		const newDate = new Date(newYear, selectedDate.getMonth(), 1);
 		updateUrlWithDate(newDate);
 	};
 
-	const currentWeekStart = selectedDate ? getStartOfWeek(selectedDate) : getStartOfWeek(today);
+	const currentWeekStart = getStartOfWeek(selectedDate);
 	const currentWeekEnd = getEndOfWeek(currentWeekStart);
 
 	const handleNavigation = (mode: 'month' | 'week', direction: 'prev' | 'next') => {
-		const baseDate = mode === 'month' ? firstDayOfCurrentMonth : currentWeekStart;
+		const baseDate = mode === 'month' ? new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1) : currentWeekStart;
 		const offset = mode === 'month' ? (direction === 'next' ? 1 : -1) : direction === 'next' ? 7 : -1;
 
 		const newDate =
@@ -61,7 +55,7 @@ export function NavigationLabel({
 		setSelectedDate(stripTime(newDate));
 
 		// 월 이동 시에는 항상, 주 이동 시에는 선택한 날짜의 월과 현재 월의 비교 결과에 따라
-		const shouldUpdateUrl = mode === 'month' || newDate.getMonth() !== firstDayOfCurrentMonth.getMonth();
+		const shouldUpdateUrl = mode === 'month' || newDate.getMonth() !== selectedDate.getMonth();
 
 		if (shouldUpdateUrl) updateUrlWithDate(newDate);
 	};
@@ -76,6 +70,7 @@ export function NavigationLabel({
 			return currentWeekStart.getTime() > firstDayOfMinYear.getTime();
 		}
 
+		const firstDayOfCurrentMonth = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1);
 		return firstDayOfCurrentMonth.getTime() > firstDayOfMinYear.getTime();
 	};
 
@@ -89,6 +84,7 @@ export function NavigationLabel({
 			return currentWeekEnd.getTime() < lastDayOfMaxYear.getTime();
 		}
 
+		const firstDayOfCurrentMonth = new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1);
 		const firstDayOfMaxYear = new Date(maxYear, 11, 1);
 		return firstDayOfCurrentMonth.getTime() < firstDayOfMaxYear.getTime();
 	};

--- a/src/components/features/gamble/match-on.tsx
+++ b/src/components/features/gamble/match-on.tsx
@@ -8,9 +8,10 @@ import { formatFromTo } from '@/lib/utils';
 import NoGameCard from './no-game-card';
 import MatchPredictionCalendar from '@/components/common/match-prediction-calendar';
 import { getNextMatchDate } from '@/services/apis/calendar';
+import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 export default function MatchOn() {
-	const [selectedDate, setSelectedDate] = useState(new Date());
+	const { selectedDate, setSelectedDate } = useCalendarStore();
 	const [games, setGames] = useState<GameDto[]>([]);
 	const [trigger, setTrigger] = useState(0);
 
@@ -33,7 +34,7 @@ export default function MatchOn() {
 			}
 		}
 		fetchNextMatchDate();
-	}, [trigger]);
+	}, [trigger, setSelectedDate]);
 
 	// 날짜별 경기 리스트 조회
 	useEffect(() => {
@@ -59,7 +60,7 @@ export default function MatchOn() {
 	return (
 		<div className="pt-6 space-y-9">
 			<div className="px-4">
-				<MatchPredictionCalendar type="match" selectedDate={selectedDate} setSelectedDate={setSelectedDate} />
+				<MatchPredictionCalendar type="match" />
 			</div>
 
 			<div>

--- a/src/components/features/gamble/predict-result.tsx
+++ b/src/components/features/gamble/predict-result.tsx
@@ -10,11 +10,12 @@ import Stat from './stat';
 import MatchPredictionCalendar from '@/components/common/match-prediction-calendar';
 import { useRouter } from 'next/navigation';
 import { useCurrentUserInfoStore } from '@/lib/store/useCurrentUserInfoStore';
+import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 export default function PredictResult() {
 	const { currentUserInfo } = useCurrentUserInfoStore();
 
-	const [selectedDate, setSelectedDate] = useState(new Date());
+	const { selectedDate } = useCalendarStore();
 	const [games, setGames] = useState<GameDto[]>([]);
 	const router = useRouter();
 
@@ -50,7 +51,7 @@ export default function PredictResult() {
 			</div>
 
 			<div className="px-4">
-				<MatchPredictionCalendar type="predict" selectedDate={selectedDate} setSelectedDate={setSelectedDate} />
+				<MatchPredictionCalendar type="predict" />
 			</div>
 
 			{games.length === 0 ? (

--- a/src/components/layouts/with-side/left-side.tsx
+++ b/src/components/layouts/with-side/left-side.tsx
@@ -6,12 +6,13 @@ import useIsLeftSideVisible from '@/lib/hooks/useIsLeftSideVisible';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import ComponentFrame from '@/components/common/component-frame';
 import { useNextMatchDateQuery } from '@/lib/hooks/queries/useNextMatchDateQuery';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 export default function LeftSide() {
 	const isMobile = useIsMobile();
 	const isLeftSideVisible = useIsLeftSideVisible();
-	const [selectedDate, setSelectedDate] = useState(new Date());
+	const { selectedDate, setSelectedDate } = useCalendarStore();
 
 	const { data: nextDate } = useNextMatchDateQuery();
 
@@ -20,14 +21,14 @@ export default function LeftSide() {
 
 		const [year, month, date] = nextDate.split('-').map(Number);
 		setSelectedDate(new Date(year, month - 1, date));
-	}, [nextDate]);
+	}, [nextDate, setSelectedDate]);
 
 	if (isMobile === null || isMobile || !isLeftSideVisible) return null;
 
 	return (
 		<aside className="flex flex-col gap-4">
 			<ComponentFrame>
-				<MatchPredictionCalendar type="match" selectedDate={selectedDate} setSelectedDate={setSelectedDate} />
+				<MatchPredictionCalendar type="match" />
 			</ComponentFrame>
 			<RankingList mode="season" />
 			{/*<RankingList mode="predict" />*/}

--- a/src/components/layouts/with-side/left-side.tsx
+++ b/src/components/layouts/with-side/left-side.tsx
@@ -5,23 +5,10 @@ import RankingList from './ranking-list/ranking-list';
 import useIsLeftSideVisible from '@/lib/hooks/useIsLeftSideVisible';
 import useIsMobile from '@/lib/hooks/useIsMobile';
 import ComponentFrame from '@/components/common/component-frame';
-import { useNextMatchDateQuery } from '@/lib/hooks/queries/useNextMatchDateQuery';
-import { useEffect } from 'react';
-import { useCalendarStore } from '@/lib/store/useCalendarStore';
 
 export default function LeftSide() {
 	const isMobile = useIsMobile();
 	const isLeftSideVisible = useIsLeftSideVisible();
-	const { selectedDate, setSelectedDate } = useCalendarStore();
-
-	const { data: nextDate } = useNextMatchDateQuery();
-
-	useEffect(() => {
-		if (!nextDate) return;
-
-		const [year, month, date] = nextDate.split('-').map(Number);
-		setSelectedDate(new Date(year, month - 1, date));
-	}, [nextDate, setSelectedDate]);
 
 	if (isMobile === null || isMobile || !isLeftSideVisible) return null;
 

--- a/src/lib/store/useCalendarStore.ts
+++ b/src/lib/store/useCalendarStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+import { stripTime } from '../utils';
+
+interface CalendarStore {
+	selectedDate: Date;
+	setSelectedDate: (date: Date) => void;
+}
+
+export const useCalendarStore = create<CalendarStore>((set) => ({
+	selectedDate: stripTime(new Date()),
+	setSelectedDate: (date: Date) => set({ selectedDate: date }),
+}));
+
+export default useCalendarStore;

--- a/src/lib/utils/date/calendar.ts
+++ b/src/lib/utils/date/calendar.ts
@@ -17,15 +17,13 @@ export const getEndOfWeek = (startDate: Date): Date => {
 
 interface TileClassNameProps {
 	dateOfTile: Date; //캘린더 기준 현재 날짜
-	firstDayOfCurrentMonth: Date;
-	selectedDate: Date | null; // 사용자가 선택한 날짜
+	selectedDate: Date; // 사용자가 선택한 날짜
 	isWeekCalendar: boolean;
 	isMatch: boolean;
 	markedDatesMap: Record<string, number>;
 }
 export const getTileClassName = ({
 	dateOfTile,
-	firstDayOfCurrentMonth,
 	selectedDate,
 	isWeekCalendar,
 	isMatch,
@@ -33,7 +31,7 @@ export const getTileClassName = ({
 }: TileClassNameProps) => {
 	const tileDate = stripTime(dateOfTile);
 
-	if (!isWeekCalendar && firstDayOfCurrentMonth && dateOfTile.getMonth() !== firstDayOfCurrentMonth.getMonth()) {
+	if (!isWeekCalendar && selectedDate && dateOfTile.getMonth() !== selectedDate.getMonth()) {
 		return 'hidden-other-month-tile';
 	}
 


### PR DESCRIPTION
## 작업 내용
selectedDate 상태를 전역으로 관리하고, 해당 값을 기반으로 game을 조회하도록 일부 로직 수정했습니다.
- 기존에 사용하던 `firstDayOfCurrentMonth` 변수를 별도로 관리하기보다는, `selectedDate`의 초기값으로 할당하는 게 더 자연스럽다는 생각이 들어 해당 부분 수정했습니다.
-  기존에 달력 내 월 이동 시 오늘이 포함된 달로 돌아와도 searchParams에 year/month 값이 있어 1일이 포커싱되고 있었는데요, 오늘이 포함된 달은 기본적으로 오늘이 포커싱되는 게 자연스러울 것 같아 수정했습니다.
- 그런데 화면 새로고침 시에 오늘이 아니라 가장 가까운 경기 일이 잡히는 것 같더라고요. ㅜㅜ 이 로직이 어디서 트리거되는지 찾지를 못해서 이 부분 확인 부탁드립니다.